### PR TITLE
feat(hietograma): motorTc (forma+drenaje) + calcHietograma con Fuente IDF Global + hooks base

### DIFF
--- a/src/dominio/calcHietograma.ts
+++ b/src/dominio/calcHietograma.ts
@@ -1,0 +1,63 @@
+import { HietogramaOut, ParametrosCuenca } from "./tipos";
+// Día 1: servicio existente en tu base
+import { I_fromFuente } from "../services/I_fromFuente";
+
+function assertDtDivide(d_min: number, dt_min: number) {
+  if (d_min % dt_min !== 0) {
+    throw new Error(`Δt=${dt_min} no divide la duración d=${d_min}. Ajusta Δt o d para que d/Δt sea entero.`);
+  }
+}
+
+/** Construcción de distribución acumulada (%) con nSteps intervalos.
+ *  NOTA: por ahora es uniforme; TODO: wire con tus tablas EPM_Q1/Huff reales.
+ */
+function construirDistribucionAcum(nSteps: number): number[] {
+  return Array.from({ length: nSteps + 1 }, (_, i) => (i / nSteps) * 100);
+}
+
+export function calcHietograma(
+  p: ParametrosCuenca,
+  d_min: number,
+  dt_min: number,
+  Tr: number,
+  distribucion: HietogramaOut["distribucion"] = "EPM_Q1"
+): HietogramaOut {
+  assertDtDivide(d_min, dt_min);
+
+  // 1) Intensidad de referencia (mm/h) desde la Fuente IDF Global (Día 1)
+  const I_ref = I_fromFuente(d_min, Tr);
+
+  // 2) Lluvia total (mm)
+  const P_total = I_ref * (d_min / 60);
+
+  // 3) Distribución acumulada (0..100%) y series
+  const nSteps = d_min / dt_min;
+  const Ppct = construirDistribucionAcum(nSteps); // TODO: reemplazar por EPM_Q1/Huff reales
+  const Pacum = Ppct.map(pct => (pct / 100) * P_total);
+
+  const serie = Array.from({ length: nSteps + 1 }, (_, i) => {
+    const t = i * dt_min;
+    const P_acum_mm = +(Pacum[i]).toFixed(4);
+    const dP_mm = i === 0 ? 0 : +(Pacum[i] - Pacum[i - 1]).toFixed(4);
+    const I_mm_h = i === 0 ? 0 : +(dP_mm / (dt_min / 60)).toFixed(3);
+    return { t_min: t, dP_mm, I_mm_h, P_acum_mm };
+  });
+
+  // 4) Trazabilidad: ajusta según tu store de fuente
+  const trazabilidad = {
+    fuente: "Ponderado" as const,
+    etiqueta: "IDF Ponderada (IDW/Thiessen)",
+    sustitucion: "I_pond = Σ(Ii·Wi)",
+  };
+
+  return {
+    d_min,
+    dt_min,
+    Tr,
+    P_total_mm: +P_total.toFixed(3),
+    I_ref_mm_h: +I_ref.toFixed(3),
+    distribucion,
+    serie,
+    trazabilidad,
+  };
+}

--- a/src/dominio/indicesForma.ts
+++ b/src/dominio/indicesForma.ts
@@ -1,0 +1,25 @@
+import { ParametrosCuenca, IndicesForma } from "./tipos";
+
+export function calcIndicesForma(p: ParametrosCuenca): IndicesForma {
+  const A  = Math.max(1e-6, p.area_km2);                 // km²
+  const P  = Math.max(1e-6, p.perimetro_km);             // km
+  const Lc = Math.max(1e-6, p.L_cuenca_km || p.L_cauce_km); // km
+
+  // Factor de forma
+  const Rf = A / (Lc * Lc);
+
+  // Compacidad de Gravelius
+  const Kc = P / (2 * Math.sqrt(Math.PI * A));
+
+  // Densidad de drenaje (si se dispone de L_red)
+  const Dd = p.L_red_km && p.L_red_km > 0 ? p.L_red_km / A : undefined;
+
+  // Pendiente del cauce principal (m/m)
+  const deltaZ = p.cota_mayor_cauce_m - p.cota_menor_cauce_m;
+  const So = (Lc > 0) ? (deltaZ / (Lc * 1000)) : 0;
+
+  // Pendiente media de cuenca (adimensional)
+  const Sp = Math.max(0, p.pendiente_media_pct / 100);
+
+  return { Rf, Kc, Dd, So, Sp };
+}

--- a/src/dominio/motorTc.ts
+++ b/src/dominio/motorTc.ts
@@ -1,0 +1,100 @@
+import { ParametrosCuenca, TcResultado } from "./tipos";
+import { calcIndicesForma } from "./indicesForma";
+
+const toMin = (h: number) => h * 60;
+const round2 = (v: number) => Math.round(v * 100) / 100;
+
+// ===== 6 MÉTODOS YA PRESENTES EN TU CÓDIGO (formalizados) =====
+export function tc_Temez(p: ParametrosCuenca): TcResultado {
+  const L = p.L_cauce_km;
+  const { So } = calcIndicesForma(p);
+  const h = 0.3 * Math.pow(L / Math.pow(Math.max(So,1e-5), 0.25), 0.76);
+  return { metodo: "Témez (1978)", tc_h: h, tc_min: round2(toMin(h)), soporte: { L, So } };
+}
+
+export function tc_Kirpich(p: ParametrosCuenca): TcResultado {
+  const Lft = p.L_cauce_km * 3280.84;
+  const Sf  = (p.cota_mayor_cauce_m - p.cota_menor_cauce_m) / (p.L_cauce_km * 3280.84);
+  const h   = 0.0078 * Math.pow(Lft, 0.77) * Math.pow(Math.max(Sf,1e-5), -0.385) / 60;
+  return { metodo: "Kirpich (1940)", tc_h: h, tc_min: round2(toMin(h)), soporte: { Lft, Sf } };
+}
+
+export function tc_California(p: ParametrosCuenca): TcResultado {
+  const Lm = p.L_cauce_km * 1000;
+  const { So } = calcIndicesForma(p);
+  const h = 0.0195 * Math.pow(Lm, 0.77) * Math.pow(Math.max(So,1e-5), -0.385) / 60;
+  return { metodo: "California (1942)", tc_h: h, tc_min: round2(toMin(h)), soporte: { Lm, So } };
+}
+
+export function tc_Giandotti(p: ParametrosCuenca): TcResultado {
+  const A = p.area_km2, L = p.L_cauce_km;
+  const delta = p.cota_max_m - p.cota_min_m;
+  const h = (4 * Math.sqrt(A) + 1.5 * L) / (0.8 * Math.sqrt(Math.max(delta,1e-6)));
+  return { metodo: "Giandotti (1934)", tc_h: h, tc_min: round2(toMin(h)), soporte: { A, L, delta } };
+}
+
+export function tc_SCS_Ranser(p: ParametrosCuenca): TcResultado {
+  const Lm = p.L_cauce_km * 1000;
+  const CN = Math.max(30, Math.min(98, p.CN_II ?? 75));
+  const Ss = (25400 / CN) - 254; // mm
+  const { Sp } = calcIndicesForma(p);
+  const h = Math.pow(Lm, 0.8) * Math.pow(Ss + 1, 0.7) / (4655 * Math.pow(Math.max(Sp,1e-4), 0.5));
+  return { metodo: "SCS-Ranser (1958)", tc_h: h, tc_min: round2(toMin(h)), soporte: { Lm, Ss, Sp } };
+}
+
+export function tc_PerezMontgomery(p: ParametrosCuenca): TcResultado {
+  const L = p.L_cauce_km; const { So } = calcIndicesForma(p);
+  const h = 0.1039 * Math.pow(L, 0.7) * Math.pow(Math.max(So,1e-5), -0.3);
+  return { metodo: "Pérez–Montgomery (1985)", tc_h: h, tc_min: round2(toMin(h)), soporte: { L, So } };
+}
+
+// ===== “SLOTS” PARA 6–9 MÉTODOS ADICIONALES (TODO/por calibrar) =====
+export function tc_TR55_segmentado(p: ParametrosCuenca): TcResultado {
+  return { metodo: "NRCS TR-55 (segmentado)", tc_h: NaN, tc_min: NaN, notas: "TODO: sumar sheet+shallow+channel con límites de aplicabilidad" };
+}
+export function tc_KerbyHathaway(p: ParametrosCuenca): TcResultado {
+  return { metodo: "Kerby-Hathaway (overland)", tc_h: NaN, tc_min: NaN, notas: "TODO: calibrar" };
+}
+export function tc_BransbyWilliams(p: ParametrosCuenca): TcResultado {
+  return { metodo: "Bransby-Williams", tc_h: NaN, tc_min: NaN, notas: "TODO: calibrar" };
+}
+export function tc_Izzard(p: ParametrosCuenca): TcResultado {
+  return { metodo: "Izzard", tc_h: NaN, tc_min: NaN, notas: "TODO: calibrar" };
+}
+export function tc_JohnstoneCross(p: ParametrosCuenca): TcResultado {
+  return { metodo: "Johnstone-Cross", tc_h: NaN, tc_min: NaN, notas: "TODO: calibrar" };
+}
+export function tc_Ventura(p: ParametrosCuenca): TcResultado {
+  return { metodo: "Ventura (local)", tc_h: NaN, tc_min: NaN, notas: "TODO: calibrar" };
+}
+
+// ===== API =====
+export function calcTcTodos(p: ParametrosCuenca): TcResultado[] {
+  return [
+    tc_Temez(p), tc_Kirpich(p), tc_California(p), tc_Giandotti(p),
+    tc_SCS_Ranser(p), tc_PerezMontgomery(p),
+    tc_TR55_segmentado(p), tc_KerbyHathaway(p), tc_BransbyWilliams(p),
+    tc_Izzard(p), tc_JohnstoneCross(p), tc_Ventura(p),
+  ];
+}
+
+export function sugerirMetodoTc(p: ParametrosCuenca): { metodo: string; motivo: string } {
+  const { Rf, Kc, Dd, So, Sp } = calcIndicesForma(p);
+
+  if (So > 0.02 && Sp > 0.03) {
+    return { metodo: "Kirpich (1940)", motivo: "Cauce escarpado (So>2%) y cuenca pendiente (Sp>3%)" };
+  }
+  if ((Rf < 0.3 && Kc > 1.7) || (Dd && Dd > 2.5)) {
+    return { metodo: "California (1942)", motivo: "Cuenca alargada/compacidad alta o drenaje denso" };
+  }
+  if (p.sheet_len_m && p.shallow_len_m && p.channel_len_m) {
+    return { metodo: "NRCS TR-55 (segmentado)", motivo: "Se dispone de segmentos (overland/shallow/channel)" };
+  }
+  return { metodo: "Témez (1978)", motivo: "Condición estándar; método robusto para cuencas medias" };
+}
+
+export function calcTcSeleccion(p: ParametrosCuenca, metodo: string): TcResultado {
+  const res = calcTcTodos(p).find(t => t.metodo.toLowerCase() === metodo.toLowerCase());
+  if (!res) throw new Error(`Método Tc no reconocido: ${metodo}`);
+  return res;
+}

--- a/src/dominio/tipos.ts
+++ b/src/dominio/tipos.ts
@@ -1,0 +1,65 @@
+export interface ParametrosCuenca {
+  nombre: string;
+
+  // Geomorfología base (SI)
+  area_km2: number;             // A
+  perimetro_km: number;         // P
+  L_cauce_km: number;           // Longitud de cauce principal
+  L_cuenca_km: number;          // Longitud característica de cuenca (eje mayor)
+  cota_max_m: number;
+  cota_min_m: number;
+  cota_mayor_cauce_m: number;
+  cota_menor_cauce_m: number;
+  pendiente_media_pct: number;  // Sp (%)
+
+  // Red de drenaje (opcional)
+  L_red_km?: number;            // Longitud total de drenaje → densidad de drenaje Dd
+
+  // Segmentos TR‑55 (opcional)
+  sheet_len_m?: number;
+  shallow_len_m?: number;
+  channel_len_m?: number;
+  n_sheet?: number;
+  n_shallow?: number;
+  n_channel?: number;
+
+  // Hidrológicos (opcionales)
+  CN_II?: number;
+  dt_min?: number;
+
+  // Localización del outlet
+  lat_salida: number;
+  lon_salida: number;
+  alt_salida: number;
+}
+
+export interface IndicesForma {
+  Rf: number;   // factor de forma = A / L_cuenca^2
+  Kc: number;   // compacidad de Gravelius = P / (2*sqrt(pi*A))
+  Dd?: number;  // densidad de drenaje = L_red / A
+  So: number;   // pendiente del cauce (m/m)
+  Sp: number;   // pendiente media de cuenca (adim.)
+}
+
+export interface TcResultado {
+  metodo: string;
+  tc_h: number;      // horas
+  tc_min: number;    // minutos
+  notas?: string;
+  soporte?: Record<string, number>;
+}
+
+export interface HietogramaOut {
+  d_min: number;
+  dt_min: number;
+  Tr: number;
+  P_total_mm: number;
+  I_ref_mm_h: number;
+  distribucion: 'EPM_Q1'|'Huff_Q1'|'Huff_Q2'|'Huff_Q3'|'Huff_Q4';
+  serie: { t_min: number; dP_mm: number; I_mm_h: number; P_acum_mm: number }[];
+  trazabilidad: {
+    fuente: 'Estacion' | 'Ponderado' | 'Fallback';
+    etiqueta: string;     // Estación {id} | Ponderado (IDW/Thiessen)
+    sustitucion: string;  // "I = k/(c+d_h)^n" o "Σ(Ii·Wi)"
+  };
+}

--- a/src/hooks/useHietograma.ts
+++ b/src/hooks/useHietograma.ts
@@ -1,0 +1,14 @@
+import { useMemo, useState } from "react";
+import { ParametrosCuenca, HietogramaOut } from "../dominio/tipos";
+import { calcHietograma } from "../dominio/calcHietograma";
+
+export function useHietograma(p: ParametrosCuenca) {
+  const [Tr, setTr] = useState<number>(25);
+  const [d, setD] = useState<number>(60);
+  const [dt, setDt] = useState<number>(p.dt_min ?? 5);
+  const [dist, setDist] = useState<HietogramaOut["distribucion"]>("EPM_Q1");
+
+  const hi = useMemo(() => calcHietograma(p, d, dt, Tr, dist), [p, d, dt, Tr, dist]);
+
+  return { Tr, setTr, d, setD, dt, setDt, dist, setDist, hi };
+}

--- a/src/hooks/useTc.ts
+++ b/src/hooks/useTc.ts
@@ -1,0 +1,14 @@
+import { useMemo, useState } from "react";
+import { ParametrosCuenca, TcResultado } from "../dominio/tipos";
+import { calcTcTodos, sugerirMetodoTc } from "../dominio/motorTc";
+
+export function useTc(params: ParametrosCuenca) {
+  const resultados = useMemo<TcResultado[]>(() => calcTcTodos(params), [params]);
+  const sugerido = useMemo(() => sugerirMetodoTc(params), [params]);
+  const [metodo, setMetodo] = useState<string>(sugerido.metodo);
+  const activo = useMemo(
+    () => resultados.find(r => r.metodo === metodo) ?? resultados[0],
+    [resultados, metodo]
+  );
+  return { resultados, sugerido, metodo, setMetodo, activo };
+}


### PR DESCRIPTION
### ✔ motorTc
- 6 métodos implementados (Témez, Kirpich, California, Giandotti, SCS-Ranser, Pérez-Montgomery)
- Índices de forma: Rf, Kc, Dd, So, Sp
- Selector de método sugerido

### ✔ Hietograma
- calcHietograma alimentado por I_fromFuente(d, Tr)
- P_total = I * d/60
- Δt | d validado
- Distribución temporal (EPM_Q1 / Huff) — pendiente de conexión final
- Serie completa para tablas y gráfica

### ✔ Hooks
- useTc()
- useHietograma()
