### PR TITLE
OT-0011 — Rango bruto y rango competente Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0011/OT-0011B_diseno_rango_competente_Tc.md
+++ b/00_ADMIN/bitacora/OT-0011/OT-0011B_diseno_rango_competente_Tc.md
@@ -1,0 +1,98 @@
+# OT-0011B — Diseño de Rango Competente Tc
+
+## Estado de entrada
+
+- Rama: ot-0011-rango-tc-bruto-competente
+- OT-0011A cerrada con commit 13ae409.
+- Cambio previo: etiqueta visual de Rango Tc a Rango bruto Tc en IndiceHidrologico.jsx.
+- Build Vite aprobado.
+- Working tree limpio antes de iniciar OT-0011B.
+
+## Tesis Senior
+
+El cálculo hidrológico permanece intacto.
+La competencia técnica permanece en la matriz existente.
+El Agente Tc solo transporta estado.
+El Índice Hidrológico solo visualiza y comunica.
+El Rango competente Tc debe ser una derivación trazable de métodos ya calculados y evaluados, no una nueva fórmula ni un umbral inventado.
+
+## Evidencia ya auditada
+
+### Rango bruto Tc
+
+El rango actual mostrado por el Índice Hidrológico se calcula desde tcState.metodosTc tomando todos los valores numéricos positivos.
+
+Por tanto, el rango actual corresponde a rango bruto Tc.
+
+### Competencia técnica
+
+La competencia técnica ya existe en matrizCompetenciaComparador.js mediante evaluarCompetenciaMetodo, evaluarCompetenciaComparador y resumirCompetenciaComparador.
+
+Cada método evaluado puede incluir:
+
+- estadoCompetencia
+- semaforo
+- puntajeCompetencia
+- justificacionCompetencia
+
+### Incompatibilidad de claves detectada
+
+mapTcResultados genera claves:
+
+- Kirpich
+- Temez
+- California
+- Giandotti
+- Perez
+- SCS
+
+El catálogo de competencia usa IDs:
+
+- tc_kirpich
+- tc_temez
+- tc_california
+- tc_giandotti
+- tc_perez_montoya
+- tc_scs_ranser
+
+Por tanto, se requiere un adaptador explícito antes de calcular rango competente Tc.
+
+## Adaptador candidato
+
+tc_kirpich -> Kirpich
+tc_temez -> Temez
+tc_california -> California
+tc_giandotti -> Giandotti
+tc_perez_montoya -> Perez
+tc_scs_ranser -> SCS
+
+## Regla de no intervención
+
+Durante el diseño de OT-0011B queda prohibido:
+
+- Modificar hidroEngine.js
+- Modificar tcSelector.js
+- Modificar tcAgent.js
+- Modificar fórmulas Tc
+- Modificar Tc_final
+- Modificar mapTcResultados
+- Introducir constantes de rango competente
+- Introducir setTimeout
+- Introducir console.log permanentes
+- Usar IndiceHidrologico.corregido.jsx
+
+## Preguntas de diseño pendientes
+
+1. Dónde debe vivir el adaptador id catálogo -> clave metodosTc.
+2. Si ComparadorMultiMetodo.jsx debe publicar evaluacionCompetenciaTc.
+3. Si IndiceHidrologico.jsx debe calcular visualmente el rango competente.
+4. Cómo mostrar ausencia de métodos competentes.
+5. Cómo validar que Tc sugerido, métodos válidos y rango bruto no cambien.
+
+## Criterio preliminar de rango competente
+
+El rango competente Tc debe calcularse únicamente con métodos cuyo estadoCompetencia sea competente y que tengan valor numérico positivo disponible en tcState.metodosTc.
+
+## Estado
+
+Documento de apertura. Sin cambios funcionales aplicados.

--- a/00_ADMIN/bitacora/OT-0011/OT-0011B_diseno_rango_competente_Tc.md
+++ b/00_ADMIN/bitacora/OT-0011/OT-0011B_diseno_rango_competente_Tc.md
@@ -96,3 +96,21 @@ El rango competente Tc debe calcularse únicamente con métodos cuyo estadoCompe
 ## Estado
 
 Documento de apertura. Sin cambios funcionales aplicados.
+
+## Decisión de arquitectura propuesta
+
+La derivación del Rango competente Tc debe vivir inicialmente en ComparadorMultiMetodo.jsx, porque allí coexisten los valores numéricos de metodosTc y la evaluación técnica evaluacionCompetencia.
+
+El Agente Tc no debe modificarse. Su responsabilidad se mantiene como transporte reactivo de estado mediante getTcState, setTcState y subscribeTc.
+
+IndiceHidrologico.jsx no debe conocer reglas de competencia ni detalles del mapeo entre IDs del catálogo y claves internas del motor. Debe limitarse a visualizar rangoCompetenteTc si está disponible.
+
+La arquitectura recomendada queda definida como:
+
+- Motor hidrológico: calcula valores Tc.
+- Matriz de competencia: evalúa competencia técnica.
+- ComparadorMultiMetodo.jsx: integra metodosTc con evaluacionCompetencia y deriva rangoCompetenteTc.
+- tcAgent.js: transporta estado sin cambios.
+- IndiceHidrologico.jsx: visualiza Rango bruto Tc y Rango competente Tc.
+
+Esta decisión no autoriza todavía cambios funcionales. Cualquier implementación posterior deberá ser mínima, auditable y validada con build.

--- a/00_ADMIN/bitacora/OT-0011/OT-0011C_diseno_adaptador_rango_competente_Tc.md
+++ b/00_ADMIN/bitacora/OT-0011/OT-0011C_diseno_adaptador_rango_competente_Tc.md
@@ -1,0 +1,171 @@
+# OT-0011C — Diseño del adaptador mínimo para Rango competente Tc
+
+## Estado de entrada
+
+- Rama: ot-0011-rango-tc-bruto-competente
+- OT-0011A cerrada con commit 13ae409.
+- OT-0011B documentada con commits 6a1652d y 4471a98.
+- Working tree limpio antes de iniciar OT-0011C.
+
+## Objetivo
+
+Diseñar el adaptador mínimo que permita derivar Rango competente Tc a partir de valores Tc ya calculados y de la evaluación técnica ya existente.
+
+El adaptador no debe recalcular Tc, no debe modificar el motor hidrológico y no debe introducir umbrales manuales.
+
+## Tesis Senior
+
+El adaptador debe ser una función pura, localizable, testeable y reversible.
+
+No debe modificar metodosTc.
+No debe modificar evaluacionCompetencia.
+No debe recalcular Tc.
+No debe cambiar Tc_final.
+No debe cambiar mapTcResultados.
+No debe tocar hidroEngine.js.
+No debe tocar tcSelector.js.
+No debe tocar tcAgent.js.
+
+Su única responsabilidad será cruzar valores existentes con criterios existentes.
+
+## Entradas del adaptador
+
+El adaptador deberá recibir:
+
+- metodosTc: objeto con valores numéricos Tc publicados por mapTcResultados.
+- evaluacionCompetenciaTc: arreglo de métodos Tc evaluados por matrizCompetenciaComparador.js.
+
+Ejemplo conceptual de metodosTc:
+
+- Kirpich
+- Temez
+- California
+- Giandotti
+- Perez
+- SCS
+
+Ejemplo conceptual de evaluacionCompetenciaTc:
+
+- tc_kirpich
+- tc_temez
+- tc_california
+- tc_giandotti
+- tc_perez_montoya
+- tc_scs_ranser
+
+## Adaptador de claves candidato
+
+tc_kirpich -> Kirpich
+tc_temez -> Temez
+tc_california -> California
+tc_giandotti -> Giandotti
+tc_perez_montoya -> Perez
+tc_scs_ranser -> SCS
+
+tc_williams_hann no se incluye inicialmente porque mapTcResultados no lo publica dentro de metodosTc.
+
+## Criterio de competencia
+
+El filtro de competencia debe usar estrictamente:
+
+estadoCompetencia == competente
+
+No se usarán:
+
+- umbrales manuales de Tc
+- rangos hipotéticos
+- puntajeCompetencia como sustituto del estado
+- semaforo como sustituto del estado
+- criterios duplicados en componentes visuales
+
+## Salidas esperadas del adaptador
+
+El adaptador deberá producir una estructura conceptual con:
+
+- metodosTcCompetentes
+- rangoCompetenteTc
+
+metodosTcCompetentes deberá contener únicamente métodos con:
+
+- valor numérico positivo disponible en metodosTc
+- estadoCompetencia igual a competente
+- id del catálogo trazable
+- clave interna Tc trazable
+- nombre del método
+- justificacionCompetencia conservada
+
+rangoCompetenteTc deberá contener:
+
+- min
+- max
+- n
+
+Si no existen métodos competentes válidos, rangoCompetenteTc debe ser null.
+
+## Casos borde obligatorios
+
+1. evaluacionCompetenciaTc ausente o vacía.
+2. metodosTc ausente o vacío.
+3. método competente sin clave equivalente en metodosTc.
+4. clave existente con valor no numérico.
+5. clave existente con valor menor o igual a cero.
+6. ningún método competente válido.
+
+En todos los casos, el sistema debe conservar Rango bruto Tc sin cambios.
+
+## Ubicación candidata
+
+Se propone que el adaptador viva inicialmente cerca de la integración en ComparadorMultiMetodo.jsx o como archivo auxiliar pequeño si se decide privilegiar limpieza y prueba aislada.
+
+Opción A:
+
+ComparadorMultiMetodo.jsx
+
+Ventaja: cambio mínimo y localizado.
+Riesgo: aumenta responsabilidad del componente.
+
+Opción B:
+
+Archivo auxiliar externo, por ejemplo:
+
+01_APP/HIDROFLOW/src/services/tc/derivarRangoCompetenteTc.js
+
+Ventaja: función pura, testeable y reusable.
+Riesgo: crea archivo nuevo e import adicional.
+
+## Recomendación preliminar
+
+Para una implementación robusta y mantenible, se recomienda usar un adaptador externo pequeño, sin dependencias del motor, importado por ComparadorMultiMetodo.jsx.
+
+ComparadorMultiMetodo.jsx integraría:
+
+- metodosTc
+- evaluacionCompetencia.tc
+- adaptador de rango competente
+
+y publicaría en setTcState:
+
+- rangoCompetenteTc
+- metodosTcCompetentes
+
+tcAgent.js permanecería sin cambios.
+
+IndiceHidrologico.jsx solo visualizaría rangoCompetenteTc si está disponible.
+
+## Criterios de aceptación futura
+
+Antes de implementar, la solución deberá garantizar:
+
+1. Rango bruto Tc permanece sin cambios.
+2. Tc sugerido permanece sin cambios.
+3. Métodos válidos permanece sin cambios.
+4. Rango competente Tc se deriva solo de métodos competentes.
+5. No se modifica hidroEngine.js.
+6. No se modifica tcSelector.js.
+7. No se modifica tcAgent.js.
+8. Build Vite debe aprobar.
+9. git diff debe mostrar cambios mínimos y auditables.
+
+## Estado
+
+Documento de diseño. Sin cambios funcionales aplicados.

--- a/00_ADMIN/bitacora/OT-0011/OT-0011E_cierre_rango_competente_Tc.md
+++ b/00_ADMIN/bitacora/OT-0011/OT-0011E_cierre_rango_competente_Tc.md
@@ -1,0 +1,40 @@
+# OT-0011E — Cierre técnico Rango bruto vs Rango competente Tc
+
+## Estado final
+
+La OT-0011 queda completamente implementada y validada mediante un enfoque incremental, auditable y sin intervención al motor hidrológico.
+
+## Hitos ejecutados
+
+- OT-0011A: Corrección de etiqueta "Rango bruto Tc".
+- OT-0011B: Diseño arquitectónico del rango competente Tc.
+- OT-0011C: Diseño del adaptador puro.
+- OT-0011D1: Implementación del adaptador.
+- OT-0011D2: Integración en ComparadorMultiMetodo.jsx.
+- OT-0011D3: Visualización en IndiceHidrologico.jsx.
+
+## Resultado funcional
+
+El sistema ahora distingue explícitamente:
+
+- Rango bruto Tc: todos los métodos válidos.
+- Rango competente Tc: subconjunto técnicamente competente.
+
+## Arquitectura final
+
+Motor → Matriz → Adaptador → Comparador → Agente → Índice
+
+## Validaciones
+
+- Build Vite aprobado.
+- Git limpio.
+- Cambios mínimos y auditables.
+- Sin modificación del motor hidrológico.
+- Sin modificación del agente Tc.
+- Sin modificación del selector Tc.
+
+## Conclusión
+
+La implementación cumple criterios de ingeniería hidrológica defendible y mantiene integridad arquitectónica completa.
+
+OT-0011 cerrada técnicamente.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { setTcState } from "../agents/tcAgent";
 import { calcTc, mapTcResultados } from "../services/hidroEngine";
 import { seleccionarTc } from "../services/tcSelector";
+import { derivarRangoCompetenteTc } from "../services/tc/derivarRangoCompetenteTc";
 
 import {
   resumenComparadorCatalogo,
@@ -72,6 +73,11 @@ const conceptoCuenca = useMemo(() => {
 // ✅ Tc FINAL
 
 const Tc_final = seleccionarTc("hidrograma", metodosTc, contextoTc);
+
+const { metodosTcCompetentes, rangoCompetenteTc } = derivarRangoCompetenteTc(
+  metodosTc,
+  evaluacionCompetencia?.tc
+);
 // ✅ Publicar Tc en el agente DESPUÉS del render
 useEffect(() => {
   if (Tc_final !== null && Tc_final !== undefined) {
@@ -79,6 +85,8 @@ useEffect(() => {
       Tc_final,
       metodosTc,
       contextoTc,
+      metodosTcCompetentes,
+      rangoCompetenteTc,
     });
   }
 }, [Tc_final]);
@@ -1188,3 +1196,4 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+

--- a/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
+++ b/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
@@ -653,6 +653,16 @@ const rangoTcAgente =
   </span>
 </div>
 
+        <div style={estilos.dato}>
+          <span style={estilos.label}>Rango competente Tc</span>
+          <span style={estilos.value}>
+            {tcState?.rangoCompetenteTc
+              ? formatNumero(tcState.rangoCompetenteTc.min, 1) + "–" +
+                formatNumero(tcState.rangoCompetenteTc.max, 1) + " min"
+              : "—"}
+          </span>
+        </div>
+
         <p style={estilos.muted}>
           El Tc sugerido corresponde al resumen estadístico del motor. El Tc
           adoptado definitivo queda pendiente de criterio técnico.

--- a/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
+++ b/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
@@ -634,7 +634,7 @@ const rangoTcAgente =
         </div>
 
         <div style={estilos.dato}>
-  <span style={estilos.label}>Rango Tc</span>
+  <span style={estilos.label}>Rango bruto Tc</span>
   <span style={estilos.value}>
     {rangoTcAgente
       ? `${formatNumero(rangoTcAgente.min, 1)}–${formatNumero(

--- a/01_APP/HIDROFLOW/src/services/tc/derivarRangoCompetenteTc.js
+++ b/01_APP/HIDROFLOW/src/services/tc/derivarRangoCompetenteTc.js
@@ -1,0 +1,72 @@
+const MAPA_ID_CATALOGO_A_METODOS_TC = {
+  tc_kirpich: "Kirpich",
+  tc_temez: "Temez",
+  tc_california: "California",
+  tc_giandotti: "Giandotti",
+  tc_perez_montoya: "Perez",
+  tc_scs_ranser: "SCS",
+};
+
+/**
+ * Deriva el rango competente de Tc a partir de:
+ * - metodosTc: valores numéricos ya calculados por el motor.
+ * - evaluacionCompetenciaTc: métodos Tc evaluados por matrizCompetenciaComparador.js.
+ *
+ * Regla Senior:
+ * - No recalcula Tc.
+ * - No modifica metodosTc.
+ * - No modifica evaluacionCompetenciaTc.
+ * - No introduce umbrales manuales.
+ * - Solo cruza valores existentes con criterios existentes.
+ */
+export function derivarRangoCompetenteTc(
+  metodosTc = {},
+  evaluacionCompetenciaTc = []
+) {
+  const metodosEvaluados = Array.isArray(evaluacionCompetenciaTc)
+    ? evaluacionCompetenciaTc
+    : [];
+
+  const metodosTcCompetentes = metodosEvaluados
+    .filter((metodo) => metodo?.estadoCompetencia === "competente")
+    .map((metodo) => {
+      const claveTc = MAPA_ID_CATALOGO_A_METODOS_TC[metodo.id];
+      const valor = Number(claveTc ? metodosTc?.[claveTc] : null);
+
+      if (!claveTc || !Number.isFinite(valor) || valor <= 0) {
+        return null;
+      }
+
+      return {
+        id: metodo.id,
+        claveTc,
+        nombre: metodo.nombre,
+        valor,
+        estadoCompetencia: metodo.estadoCompetencia,
+        semaforo: metodo.semaforo,
+        puntajeCompetencia: metodo.puntajeCompetencia,
+        justificacionCompetencia: metodo.justificacionCompetencia,
+      };
+    })
+    .filter(Boolean);
+
+  if (metodosTcCompetentes.length === 0) {
+    return {
+      metodosTcCompetentes: [],
+      rangoCompetenteTc: null,
+    };
+  }
+
+  const valores = metodosTcCompetentes.map((metodo) => metodo.valor);
+
+  return {
+    metodosTcCompetentes,
+    rangoCompetenteTc: {
+      min: Math.min(...valores),
+      max: Math.max(...valores),
+      n: valores.length,
+    },
+  };
+}
+
+export { MAPA_ID_CATALOGO_A_METODOS_TC };


### PR DESCRIPTION
# OT-0011 — Rango bruto y rango competente Tc

## Resumen

Esta OT separa explícitamente el rango bruto Tc del rango competente Tc en HidroFlow.

El sistema ahora distingue entre:

- **Rango bruto Tc**: rango calculado con todos los métodos Tc numéricamente válidos.
- **Rango competente Tc**: rango derivado únicamente del subconjunto de métodos clasificados como técnicamente competentes.

## Cambios principales

### OT-0011A
- Se corrigió la etiqueta visual del Índice Hidrológico:
  - `Rango Tc` → `Rango bruto Tc`.

### OT-0011B
- Se documentó la arquitectura del rango competente Tc.
- Se definió que:
  - `ComparadorMultiMetodo.jsx` integra.
  - `tcAgent.js` transporta estado sin cambios.
  - `IndiceHidrologico.jsx` visualiza.

### OT-0011C
- Se documentó el diseño del adaptador mínimo.
- Se definieron entradas, salidas, casos borde y criterios de aceptación.

### OT-0011D1
- Se creó el adaptador puro:

`01_APP/HIDROFLOW/src/services/tc/derivarRangoCompetenteTc.js`

### OT-0011D2
- `ComparadorMultiMetodo.jsx` ahora deriva y publica:
  - `metodosTcCompetentes`
  - `rangoCompetenteTc`

### OT-0011D3
- `IndiceHidrologico.jsx` ahora muestra:
  - `Rango bruto Tc`
  - `Rango competente Tc`

### OT-0011E
- Se agregó cierre técnico documentado de la OT.

## Validación

- Build Vite aprobado.
- Validación visual aprobada en `localhost:5173`.
- Working tree limpio.
- Rama sincronizada con GitHub.
- Pull Request sin conflictos con `main`.

## Confirmaciones técnicas

No se modificaron:

- `hidroEngine.js`
- `tcSelector.js`
- `tcAgent.js`
- fórmulas Tc
- `Tc_final`
- `mapTcResultados`

No se introdujeron:

- `setTimeout`
- `console.log` permanentes
- `IndiceHidrologico.corregido.jsx`

## Resultado visual validado

```txt
Tc sugerido              114,2 min
Métodos válidos          6
Rango bruto Tc           11,2–231,5 min
Rango competente Tc      105,1–231,5 min