### PR TITLE
OT-0013 — Auditoría Tc–Tp–Qp–Volumen del comparador hidrológico

### DIFF
--- a/00_ADMIN/bitacora/OT-0013/OT-0013A_apertura_auditoria_Tc_Tp_Qp_Volumen.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013A_apertura_auditoria_Tc_Tp_Qp_Volumen.md
@@ -1,0 +1,32 @@
+# OT-0013A — Apertura auditoría Tc–Tp–Qp–Volumen
+
+## Objetivo
+
+Abrir la auditoría hidrológica de coherencia entre Tc, Tp, Qp y Volumen en el Comparador Hidrológico Multi-Método.
+
+## Tesis
+
+Los resultados de hidrogramas no deben adoptarse solo porque el motor los calcula. Deben auditarse frente a coherencia temporal, unidades, volumen, caudal pico y relación física con el Tc utilizado.
+
+## Alcance inicial
+
+- Auditar cómo se muestran Tc, Tp, Qp y Volumen.
+- Identificar de dónde vienen los valores del motor.
+- Verificar si las unidades son explícitas.
+- Revisar coherencia Tc vs Tp.
+- Revisar coherencia Qp vs Volumen.
+- Mantener el comparador en modo no adoptivo.
+
+## Restricciones
+
+- No modificar hidroEngine.js sin auditoría previa.
+- No modificar fórmulas.
+- No cambiar resultados del motor.
+- No cambiar Tc_final.
+- No introducir constantes manuales.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013B_auditoria_origen_Qp_Tp_Volumen.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013B_auditoria_origen_Qp_Tp_Volumen.md
@@ -1,0 +1,39 @@
+# OT-0013B — Auditoría origen Qp, Tp y Volumen
+
+## Objetivo
+
+Auditar en modo solo lectura cómo el Comparador Hidrológico Multi-Método obtiene Qp, Tp y Volumen para el bloque Q-5.
+
+## Evidencia auditada
+
+En ComparadorMultiMetodo.jsx se identificó que los resultados Q se leen desde contextoBase?.hidrogramas.
+
+El comparador no recalcula hidrogramas. Busca candidatos en bruto, bruto.metodos o bruto.resultados.
+
+Para asociar un resultado al método del catálogo, normaliza el nombre del método y lo compara contra metodo, nombre, label, name o id del objeto de hidrograma.
+
+## Campos extraídos actualmente
+
+Qp se extrae desde: Qp, qp, q_pico, caudalPico, caudal_pico.
+
+Tp se extrae desde: Tp, tp, t_pico, tiempoPico, tiempo_pico.
+
+Volumen se extrae desde: volumen, V, vol, volume.
+
+## Hallazgo técnico
+
+El propio texto del comparador menciona como pendientes de auditoría los campos Qpico, volTotal, dtMin y parámetros internos de cada hidrograma unitario.
+
+Sin embargo, el adaptador de lectura auditado no contempla explícitamente Qpico, tPico ni volTotal dentro de los nombres alternativos usados para extraer Qp, Tp y Volumen.
+
+## Riesgo
+
+Si el motor HidroFlow entrega los resultados con nombres como Qpico, tPico o volTotal, el comparador puede mostrar valores no disponibles o incompletos aunque el motor sí los haya calculado.
+
+## Dictamen
+
+Antes de modificar código, se debe confirmar la estructura real de contextoBase.hidrogramas o del objeto de salida del motor. La siguiente fase debe auditar la fuente real de hidrogramas y sus campos efectivos.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013C_auditoria_estructura_real_hidrogramas.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013C_auditoria_estructura_real_hidrogramas.md
@@ -1,0 +1,50 @@
+# OT-0013C — Auditoría estructura real de hidrogramas
+
+## Objetivo
+
+Auditar la estructura real de los campos de hidrograma producidos o consumidos por módulos vivos de HidroFlow, sin modificar código funcional.
+
+## Archivos auditados
+
+- 01_APP/HIDROFLOW/src/hooks/useHidrograma.ts
+- 01_APP/HIDROFLOW/src/dominio/scsUh.ts
+- 01_APP/HIDROFLOW/src/dominio/SAR.ts
+- 01_APP/HIDROFLOW/src/components/HidrogramaResultado.tsx
+
+## Hallazgos
+
+En hidroEngine.js no se encontraron campos directos Qpico, tPico, volTotal, qSeries, dtMin, hidrograma, hidrogramas, Qp, Tp ni volumen.
+
+En useHidrograma.ts se identificó estructura kpis con Qp_m3s, Tp_idx y Vol_m3, además de meta con Tp_min, Tb_min, qp_m3s_mm, S e Ia.
+
+En scsUh.ts se documenta el Hidrograma Unitario SCS y la convolución Q(t). La función de KPIs retorna Qp_m3s, Tp_idx y Vol_m3.
+
+En HidrogramaResultado.tsx se muestra Qp desde kpis.Qp_m3s y Tp como kpis.Tp_idx multiplicado por dt_min. También se muestra Tp_UH desde meta.Tp_min y qp_UH desde meta.qp_m3s_mm.
+
+En SAR.ts existe una estructura separada con Qp, Q_regulado, Q_entrada y V_excedente, asociada a almacenamiento/regulación.
+
+## Comparación con el adaptador del comparador
+
+ComparadorMultiMetodo.jsx extrae actualmente Qp desde Qp, qp, q_pico, caudalPico y caudal_pico.
+
+También extrae Tp desde Tp, tp, t_pico, tiempoPico y tiempo_pico.
+
+Volumen se extrae desde volumen, V, vol y volume.
+
+Sin embargo, el flujo vivo auditado en useHidrograma.ts y scsUh.ts usa nombres Qp_m3s, Tp_idx y Vol_m3, los cuales no están contemplados explícitamente en el adaptador actual del comparador.
+
+## Riesgo técnico
+
+Si contextoBase.hidrogramas recibe objetos derivados del flujo useHidrograma/scsUh, el comparador puede no leer correctamente Qp, Tp o Volumen aunque existan valores calculados.
+
+Para Tp, el riesgo es mayor porque el valor visible en HidrogramaResultado.tsx se deriva como Tp_idx * dt_min. El comparador no contempla actualmente esa conversión.
+
+## Dictamen
+
+Antes de modificar el adaptador, debe auditarse cómo llega contextoBase.hidrogramas al ComparadorMultiMetodo.jsx y si recibe objetos con campos Qp_m3s, Tp_idx, Vol_m3, dt_min o si recibe otra estructura ya normalizada.
+
+La siguiente fase debe trazar la conexión entre useHidrograma, HidrogramaResultado, el estado/contexto de HidroFlow y ComparadorMultiMetodo.jsx.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013D_trazabilidad_contexto_hidrogramas_comparador.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013D_trazabilidad_contexto_hidrogramas_comparador.md
@@ -1,0 +1,61 @@
+# OT-0013D — Trazabilidad contextoBase.hidrogramas hacia ComparadorMultiMetodo
+
+## Objetivo
+
+Auditar cómo llega contextoBase.hidrogramas al Comparador Hidrológico Multi-Método y verificar si la estructura entregada está alineada con el adaptador de lectura de Qp, Tp y Volumen.
+
+## Cadena trazada
+
+La cadena real auditada es:
+
+HidroFlow.jsx -> onContextoComparador(...) -> contextoComparador -> HidroFlowLayout.jsx -> ComparadorMultiMetodo contexto={contextoComparador} -> contextoBase?.hidrogramas.
+
+## Evidencia en HidroFlowLayout.jsx
+
+HidroFlowLayout.jsx mantiene contextoComparador mediante useState(null) y entrega ese contexto al comparador mediante ComparadorMultiMetodo contexto={contextoComparador}.
+
+HidroFlow recibe onContextoComparador={setContextoComparador}, por lo que HidroFlow.jsx es la fuente real del contexto que consume el comparador.
+
+## Evidencia en HidroFlow.jsx
+
+Se identificaron dos momentos relevantes:
+
+1. Una inicialización de contexto donde se envían datos base, tc_metodos: calcTc(params), lluvia_efectiva: false, hidrogramas: [] e hidrograma_principal: null.
+
+2. Una actualización posterior desde ModHidrogramas, donde se construye hidrogramasResumen y se envía mediante onContextoComparador((previo) => ({ ...previo, fuente: motor HidroFlow, lluvia_efectiva, hidrogramas: hidrogramasResumen, hidrograma_principal })).
+
+## Normalización observada
+
+ModHidrogramas calcula o extrae los campos de cada hidrograma y retorna objetos normalizados con:
+
+- metodo
+- Qp
+- Tp
+- volumen
+- puntos
+
+Para Qp se intenta leer valor directo desde Qpico, Qp, qp, q_pico, caudalPico o caudal_pico. Si no existe, se calcula desde la serie.
+
+Para Tp se intenta leer valor directo desde tPico, Tp, tp, t_pico, tiempoPico o tiempo_pico. Si no existe, se calcula desde la serie.
+
+Para volumen se intenta leer valor directo desde volTotal, volumen, V, vol o volume. Si no existe, se calcula integrando la serie.
+
+## Relación con OT-0013B y OT-0013C
+
+OT-0013B identificó que el comparador extrae Qp, Tp y volumen.
+
+OT-0013C identificó que módulos como useHidrograma.ts y scsUh.ts usan campos internos como Qp_m3s, Tp_idx y Vol_m3.
+
+OT-0013D aclara que HidroFlow.jsx actúa como capa de normalización antes de entregar hidrogramas al comparador.
+
+## Dictamen
+
+El adaptador actual de ComparadorMultiMetodo.jsx está alineado con la estructura normalizada que recibe desde HidroFlow.jsx: Qp, Tp y volumen.
+
+No se recomienda modificar todavía el adaptador del comparador para leer Qp_m3s, Tp_idx o Vol_m3, porque esos campos no llegan necesariamente de forma directa al comparador en el flujo vivo auditado.
+
+La siguiente fase debe auditar la coherencia física de los valores ya normalizados: relación Tc vs Tp, unidades de Qp, integración de volumen y consistencia con la serie Q(t).
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013E_auditoria_coherencia_Tc_vs_Tp.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013E_auditoria_coherencia_Tc_vs_Tp.md
@@ -1,0 +1,35 @@
+# OT-0013E — Auditoría de coherencia Tc vs Tp
+
+## Objetivo
+
+Auditar si el Comparador Hidrológico Multi-Método dispone de una relación explícita entre Tc_final y los Tp de los hidrogramas normalizados.
+
+## Evidencia auditada
+
+En ComparadorMultiMetodo.jsx se identificó que Tc_final se calcula mediante seleccionarTc("hidrograma", metodosTc, contextoTc).
+
+También se identificó que los resultados Q se obtienen mediante obtenerResultadoQMetodo(metodo), que devuelve Qp, Tp, volumen y disponible.
+
+La tabla Q-5 renderiza Qp en m³/s, Tp en minutos y Volumen, usando resultadoQ.Qp, resultadoQ.Tp y resultadoQ.volumen.
+
+## Hallazgo
+
+El comparador muestra Tc_final y muestra Tp de cada hidrograma, pero no se observó una evaluación explícita de coherencia entre Tc_final y resultadoQ.Tp.
+
+Tampoco se observó una advertencia específica cuando un Tp normalizado resulta demasiado bajo o demasiado alto frente al Tc usado como referencia hidrológica.
+
+## Riesgo hidrológico
+
+La ausencia de una revisión Tc vs Tp puede permitir que se visualicen hidrogramas con tiempos al pico físicamente sensibles sin advertencia técnica.
+
+Un caso crítico sería un Tc relativamente alto combinado con un Tp demasiado bajo, porque puede indicar una respuesta temporal no conciliada o una parametrización interna que requiere revisión.
+
+## Dictamen
+
+Antes de adoptar resultados Qp, Tp o Volumen, debe incorporarse una auditoría de coherencia temporal Tc vs Tp.
+
+En esta fase no se recomienda modificar el motor ni recalcular hidrogramas. La siguiente acción debe ser definir un criterio documental de alerta Tc vs Tp y luego evaluar si amerita visualización mínima.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013F_criterio_alerta_Tc_vs_Tp.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013F_criterio_alerta_Tc_vs_Tp.md
@@ -1,0 +1,44 @@
+# OT-0013F — Criterio de alerta Tc vs Tp
+
+## Objetivo
+
+Definir un criterio documental para advertir posibles incoherencias temporales entre el Tc_final usado como referencia hidrológica y los Tp normalizados de los hidrogramas del bloque Q-5.
+
+## Base auditada
+
+- Tc_final se calcula en ComparadorMultiMetodo.jsx mediante seleccionarTc("hidrograma", metodosTc, contextoTc).
+- Los hidrogramas llegan al comparador normalizados desde HidroFlow.jsx con campos metodo, Qp, Tp, volumen y puntos.
+- La tabla Q-5 muestra Tp en minutos, pero no evalúa explícitamente la relación Tp/Tc.
+
+## Criterio propuesto
+
+Para cada hidrograma con Tp válido y Tc_final válido, se recomienda calcular la relación:
+
+Tp_rel = Tp / Tc_final
+
+## Bandas preliminares de lectura
+
+- Tp_rel < 0.25: alerta alta. El tiempo al pico es muy bajo frente al Tc.
+- 0.25 <= Tp_rel < 0.50: advertencia. El hidrograma responde rápido frente al Tc.
+- 0.50 <= Tp_rel <= 1.50: rango inicialmente razonable para revisión ordinaria.
+- Tp_rel > 1.50: revisión. El tiempo al pico es alto frente al Tc y puede requerir explicación metodológica.
+
+## Justificación
+
+El criterio no adopta ni rechaza automáticamente un hidrograma. Solo clasifica la relación temporal para apoyar la auditoría hidrológica.
+
+Un Tp demasiado bajo frente a Tc puede indicar una respuesta temporal demasiado rápida, una parametrización interna sensible, una unidad mal interpretada o una diferencia entre el tiempo al pico del hidrograma y el tiempo de concentración adoptado.
+
+Un Tp demasiado alto frente a Tc puede indicar retardo excesivo o una parametrización que debe ser trazada antes de usar el resultado como soporte de diseño.
+
+## Regla de implementación futura
+
+Cualquier alerta Tc vs Tp debe ser informativa y no debe modificar Tc_final, Tp, Qp, volumen, hidrogramas, motor hidrológico ni fórmulas.
+
+## Dictamen
+
+Se recomienda implementar en una fase posterior una advertencia visual mínima en el bloque Q-5 cuando Tp_rel esté fuera del rango inicialmente razonable.
+
+## Estado
+
+Criterio documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0013/OT-0013H_cierre_tecnico_auditoria_Tc_Tp_Qp_Volumen.md
+++ b/00_ADMIN/bitacora/OT-0013/OT-0013H_cierre_tecnico_auditoria_Tc_Tp_Qp_Volumen.md
@@ -1,0 +1,61 @@
+# OT-0013H — Cierre técnico auditoría Tc–Tp–Qp–Volumen
+
+## Objetivo
+
+Cerrar técnicamente la OT-0013, consolidando la auditoría de coherencia entre Tc, Tp, Qp y Volumen en el Comparador Hidrológico Multi-Método.
+
+## Alcance ejecutado
+
+- OT-0013A: apertura de auditoría Tc–Tp–Qp–Volumen.
+- OT-0013B: auditoría del origen de Qp, Tp y Volumen en ComparadorMultiMetodo.jsx.
+- OT-0013C: auditoría de estructura real de hidrogramas en módulos vivos.
+- OT-0013D: trazabilidad de contextoBase.hidrogramas hacia ComparadorMultiMetodo.
+- OT-0013E: auditoría de coherencia Tc vs Tp.
+- OT-0013F: criterio documental de alerta Tc vs Tp.
+- OT-0013G: visualización mínima de alerta Tc vs Tp en bloque Q.
+
+## Hallazgos consolidados
+
+HidroFlow.jsx normaliza los hidrogramas antes de entregarlos al comparador.
+
+La estructura entregada al comparador contiene metodo, Qp, Tp, volumen y puntos.
+
+ComparadorMultiMetodo.jsx está alineado con esa estructura normalizada y no requiere modificación del adaptador para leer campos internos como Qp_m3s, Tp_idx o Vol_m3.
+
+La relación Tc vs Tp no se evaluaba visualmente antes de esta OT.
+
+Se incorporó una alerta visual mínima en la celda Tp del bloque Q-5 cuando Tp_rel = Tp / Tc_final queda fuera del rango inicialmente razonable.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se recalcularon hidrogramas.
+- No se modificó Tc_final.
+- No se modificó Qp.
+- No se modificó Tp.
+- No se modificó volumen.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Build
+
+Build aprobado con npm run build. La advertencia de chunk size de Rollup/Vite se considera no bloqueante.
+
+## Commits principales
+
+- af307a0 docs(hidrogramas): abre auditoria Tc Tp Qp Volumen
+- a95ccdb docs(hidrogramas): audita origen Qp Tp Volumen
+- 2e9499b docs(hidrogramas): audita estructura real de hidrogramas
+- c5b00b3 docs(hidrogramas): traza contexto de hidrogramas al comparador
+- 7071e23 docs(hidrogramas): audita coherencia Tc vs Tp
+- fc03331 docs(hidrogramas): define criterio alerta Tc vs Tp
+- aae6263 feat(hidrogramas): muestra alerta Tc vs Tp en bloque Q
+
+## Dictamen de cierre
+
+OT-0013 cumple su objetivo: auditar la coherencia Tc–Tp–Qp–Volumen y agregar una alerta visual mínima para la relación Tc vs Tp sin alterar el motor hidrológico.
+
+## Estado
+
+OT-0013 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -772,10 +772,26 @@ const obtenerResultadoQMetodo = (metodo) => {
       return <span style={estilos.chip}>—</span>;
     }
 
+    const tcReferencia = Number(Tc_final);
+    const tpRel =
+      Number.isFinite(tcReferencia) && tcReferencia > 0
+        ? resultadoQ.Tp / tcReferencia
+        : null;
+
+    const alertaTcTp =
+      tpRel !== null && (tpRel < 0.5 || tpRel > 1.5);
+
     return (
-      <span style={estilos.chip}>
-        {resultadoQ.Tp.toFixed(2)} min
-      </span>
+      <div>
+        <span style={estilos.chip}>
+          {resultadoQ.Tp.toFixed(2)} min
+        </span>
+        {alertaTcTp ? (
+          <div style={{ ...estilos.muted, marginTop: "4px" }}>
+            ⚠ Alerta Tc/Tp
+          </div>
+        ) : null}
+      </div>
     );
   })()}
 </td>
@@ -1196,4 +1212,5 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0013 — Auditoría Tc–Tp–Qp–Volumen del comparador hidrológico.

El objetivo fue auditar la coherencia entre Tiempo de Concentración, Tiempo al Pico, Caudal Pico y Volumen en el Comparador Hidrológico Multi-Método, manteniendo el motor hidrológico intacto.

## Cambios incluidos

- Apertura documental de la auditoría Tc–Tp–Qp–Volumen.
- Auditoría del origen de Qp, Tp y Volumen en ComparadorMultiMetodo.jsx.
- Auditoría de estructura real de hidrogramas en módulos vivos.
- Trazabilidad de contextoBase.hidrogramas desde HidroFlow.jsx hacia el comparador.
- Auditoría de coherencia Tc vs Tp.
- Definición documental de criterio de alerta Tc vs Tp.
- Visualización mínima de alerta Tc/Tp en la celda Tp del bloque Q-5.
- Cierre técnico de OT-0013.

## Hallazgos técnicos

- HidroFlow.jsx normaliza hidrogramas antes de entregarlos al comparador.
- La estructura entregada al comparador contiene:
  - metodo
  - Qp
  - Tp
  - volumen
  - puntos
- ComparadorMultiMetodo.jsx está alineado con esa estructura normalizada.
- No se requiere modificar el adaptador para leer campos internos como Qp_m3s, Tp_idx o Vol_m3.
- Antes de esta OT no existía una advertencia visual explícita para relaciones Tc/Tp fuera del rango razonable.

## Cambio funcional

Se agregó una alerta visual informativa en el bloque Q-5 cuando:

Tp_rel = Tp / Tc_final

queda fuera del rango inicialmente razonable definido documentalmente.

La alerta es solo visual y no modifica valores.

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se recalcularon hidrogramas.
- No se modificó Tc_final.
- No se modificó Qp.
- No se modificó Tp.
- No se modificó volumen.
- No se introdujeron setTimeout.
- No se introdujeron console.log permanentes.

## Validación

- Build aprobado con npm run build.
- Advertencia Rollup/Vite de chunk size considerada no bloqueante.
- Working tree limpio.
- Rama local y remota sincronizadas.

## Commits principales

- af307a0 docs(hidrogramas): abre auditoria Tc Tp Qp Volumen
- a95ccdb docs(hidrogramas): audita origen Qp Tp Volumen
- 2e9499b docs(hidrogramas): audita estructura real de hidrogramas
- c5b00b3 docs(hidrogramas): traza contexto de hidrogramas al comparador
- 7071e23 docs(hidrogramas): audita coherencia Tc vs Tp
- fc03331 docs(hidrogramas): define criterio alerta Tc vs Tp
- aae6263 feat(hidrogramas): muestra alerta Tc vs Tp en bloque Q
- 31c0c24 docs(hidrogramas): cierra OT-0013 auditoria Tc Tp Qp Volumen

## Dictamen

OT-0013 cumple su objetivo: auditar la coherencia Tc–Tp–Qp–Volumen y agregar una alerta visual mínima para la relación Tc vs Tp sin alterar el motor hidrológico.