### PR TITLE
OT-0014 — Despertar Índice Hidrológico global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ HidroFlow - copia.jsx
 01_APP/HIDROFLOW/src/**/*BACKUP*
 01_APP/HIDROFLOW/**/*BACKUP*
 *.docx
+
+# Inventarios locales generados por tooling HidroFlow
+10_LOGS/inventario_hidroflow_*.txt

--- a/00_ADMIN/bitacora/OT-0014/OT-0014A_apertura_auditoria_indice_hidrologico_global.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014A_apertura_auditoria_indice_hidrologico_global.md
@@ -1,0 +1,45 @@
+# OT-0014A — Apertura auditoría Índice Hidrológico global
+
+## Objetivo
+
+Abrir la auditoría para despertar el Índice Hidrológico global fuera del Comparador Multi-Método, especialmente durante la navegación por el módulo Hidrogramas.
+
+## Evidencia visual
+
+En el módulo Hidrogramas se observa Tc: 231.5 min con advertencia, mientras el Índice Hidrológico lateral muestra Tc sugerido, métodos válidos, rango bruto Tc y rango competente Tc sin datos.
+
+En el Comparador Multi-Método, el Índice Hidrológico sí muestra Tc sugerido, métodos válidos, rango bruto Tc y rango competente Tc, lo que indica que la publicación reactiva funciona cuando el Comparador alimenta el agente Tc.
+
+## Auditoría inicial
+
+En HidroFlow.jsx se identificó que el módulo Hidrogramas muestra Tc mediante tc_min.toFixed(1) y qaStatus.tcWarning.
+
+También se identificó que HidroFlow.jsx calcula Tc en varios puntos mediante calcTc(params).
+
+La búsqueda de setTcState, getTcState y subscribeTc muestra que el agente Tc es consumido por IndiceHidrologico.jsx y publicado principalmente desde ComparadorMultiMetodo.jsx.
+
+## Hallazgo
+
+El Índice Hidrológico depende del estado publicado en tcAgent. Si el Comparador no se ha montado o no ha publicado estado, el Índice puede permanecer sin Tc aunque otros módulos de HidroFlow ya calculen o muestren Tc.
+
+## Hipótesis técnica
+
+El estado Tc global no está siendo alimentado desde HidroFlow.jsx como fuente base común. Actualmente el Comparador actúa como publicador principal del estado Tc, lo que limita el despertar del Índice Hidrológico en módulos como Hidrogramas.
+
+## Restricciones
+
+- No modificar hidroEngine.js sin auditoría previa.
+- No modificar fórmulas Tc.
+- No cambiar Tc_final.
+- No cambiar rangos.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+- No duplicar lógica hidrológica.
+
+## Siguiente fase
+
+Auditar el bloque de HidroFlow.jsx donde se calcula Tc para Hidrogramas y el bloque donde se arma el contextoComparador, para decidir si conviene publicar un estado Tc base desde HidroFlow.jsx o crear un adaptador externo mínimo.
+
+## Estado
+
+Apertura y auditoría inicial. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0014/OT-0014B_auditoria_Tc_hidrogramas_vs_tcAgent.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014B_auditoria_Tc_hidrogramas_vs_tcAgent.md
@@ -1,0 +1,65 @@
+# OT-0014B — Auditoría Tc en Hidrogramas vs tcAgent
+
+## Objetivo
+
+Auditar el origen del Tc mostrado en el módulo Hidrogramas y su relación con el estado global tcAgent consumido por el Índice Hidrológico.
+
+## Evidencia auditada
+
+En HidroFlow.jsx se identificó que el módulo Hidrogramas calcula una lista tcList mediante calcTc(params), filtrando métodos con h finito y positivo.
+
+También se identificó que Tc_sugerido_min se calcula como la mediana simple de los valores r.min de tcList.
+
+El Tc efectivo usado por Hidrogramas se define como:
+
+tc_min = usarOverrideTc ? Tc_override_min : +(params?.tcMedMin ?? Tc_sugerido_min)
+
+El panel QA de Hidrogramas muestra visualmente:
+
+Tc: {tc_min.toFixed(1)} min
+
+y agrega advertencia cuando qaStatus.tcWarning es verdadero.
+
+## Criterio QA observado
+
+qaStatus.tcWarning se activa cuando tc_min es menor que 5 min o mayor que 180 min.
+
+Por tanto, el valor visual observado Tc: 231.5 min con advertencia es consistente con la regla tc_min > 180.
+
+## Hallazgo
+
+El Tc mostrado en Hidrogramas no proviene necesariamente del Tc_final publicado por el Comparador Multi-Método.
+
+Hidrogramas usa params.tcMedMin si existe; en caso contrario usa Tc_sugerido_min como mediana simple de calcTc(params).
+
+El Índice Hidrológico lateral consume tcAgent. La auditoría inicial mostró que tcAgent es publicado principalmente desde ComparadorMultiMetodo.jsx.
+
+Esto explica que el Índice pueda mostrar Tc sugerido vacío o métodos válidos 0 mientras Hidrogramas muestra internamente un Tc calculado o persistido.
+
+## Riesgo técnico
+
+Pueden coexistir dos lecturas de Tc en la interfaz: una lectura interna de Hidrogramas basada en params.tcMedMin o mediana simple, y una lectura global del Índice basada en tcAgent publicado por el Comparador.
+
+Esta divergencia puede confundir la interpretación técnica si no se define una fuente global de verdad o un adaptador común de estado Tc.
+
+## Hipótesis siguiente
+
+El valor 231.5 min observado en Hidrogramas puede estar llegando por params.tcMedMin o por persistencia previa de un método dominante. Debe auditarse dónde se asigna params.tcMedMin.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas Tc.
+- No cambiar Tc_final.
+- No cambiar tc_min.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+- No duplicar lógica hidrológica.
+
+## Siguiente fase
+
+Auditar el origen de params.tcMedMin y la persistencia del Tc medio dentro de HidroFlow.jsx, para decidir si el Índice Hidrológico debe alimentarse desde un adaptador global mínimo.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0014/OT-0014C_auditoria_origen_tcMedMin.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014C_auditoria_origen_tcMedMin.md
@@ -1,0 +1,68 @@
+# OT-0014C — Auditoría origen de params.tcMedMin
+
+## Objetivo
+
+Auditar dónde se asigna params.tcMedMin y cómo influye en el Tc mostrado por los módulos Hidrogramas e Hietogramas frente al estado global tcAgent.
+
+## Evidencia auditada
+
+En HidroFlow.jsx se identificó que ModParams persiste un valor tcMedMin dentro de params.
+
+El bloque auditado indica:
+
+tcMedMin = tcMed * 60
+
+y luego actualiza params mediante setParams cuando params.tcMedMin difiere del valor calculado.
+
+El comentario del código indica explícitamente:
+
+Persistir Tc medio (min) en params para otros módulos (Hietogramas, Hidrogramas).
+
+## Hallazgo
+
+params.tcMedMin es una persistencia interna creada desde ModParams para compartir un Tc medio con otros módulos.
+
+ModHidrogramas usa params.tcMedMin como prioridad antes de usar Tc_sugerido_min:
+
+tc_min = usarOverrideTc ? Tc_override_min : +(params?.tcMedMin ?? Tc_sugerido_min)
+
+Por tanto, el Tc visible en Hidrogramas puede provenir de params.tcMedMin y no del Tc_final publicado por el Comparador mediante tcAgent.
+
+## Relación con la evidencia visual
+
+Esto explica que Hidrogramas pueda mostrar Tc = 231.5 min con advertencia, mientras el Índice Hidrológico lateral aparece vacío si tcAgent no ha sido alimentado por el Comparador.
+
+También explica que el Comparador pueda mostrar Tc sugerido = 114.2 min, porque ese valor proviene de seleccionarTc y del flujo tcAgent, no de params.tcMedMin.
+
+## Riesgo técnico
+
+Existen al menos dos rutas activas de Tc:
+
+1. Ruta params.tcMedMin usada por Hidrogramas e Hietogramas.
+2. Ruta Tc_final publicada por ComparadorMultiMetodo hacia tcAgent.
+
+Si ambas rutas no se concilian, el usuario puede observar valores Tc divergentes en distintas vistas.
+
+## Dictamen
+
+No se recomienda modificar todavía el cálculo de Tc ni reemplazar params.tcMedMin.
+
+La acción correcta es diseñar un adaptador mínimo que publique un estado Tc global coherente para el Índice Hidrológico, sin duplicar fórmulas ni alterar el motor.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas Tc.
+- No cambiar Tc_final.
+- No cambiar params.tcMedMin.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+- No duplicar lógica hidrológica.
+
+## Siguiente fase
+
+Auditar la estructura actual de tcAgent y definir si puede recibir un estado base desde HidroFlow.jsx sin romper el flujo del Comparador.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0014/OT-0014D_auditoria_tcAgent_estado_global_Tc.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014D_auditoria_tcAgent_estado_global_Tc.md
@@ -1,0 +1,69 @@
+# OT-0014D — Auditoría tcAgent como estado global Tc
+
+## Objetivo
+
+Auditar la estructura actual de tcAgent.js para determinar si puede actuar como punto de estado global del Tiempo de Concentración para despertar el Índice Hidrológico fuera del Comparador Multi-Método.
+
+## Evidencia auditada
+
+tcAgent.js define un estado inicial mínimo:
+
+Tc_final: null
+metodosTc: null
+contextoTc: null
+
+La función setTcState(data) actualiza el estado mediante merge abierto:
+
+TcState = { ...TcState, ...data }
+
+Luego notifica a los suscriptores mediante listeners.forEach(fn => fn(TcState)).
+
+IndiceHidrologico.jsx consume el estado mediante getTcState y subscribeTc.
+
+ComparadorMultiMetodo.jsx publica estado mediante setTcState.
+
+## Hallazgo
+
+tcAgent es un agente reactivo simple y flexible.
+
+Aunque el estado inicial solo declara Tc_final, metodosTc y contextoTc, el merge abierto permite transportar campos adicionales como rangoCompetenteTc, rangoBrutoTc, fuente o modoPublicacion.
+
+Sin embargo, tcAgent no implementa reglas de prioridad, fuente, versión, timestamp ni protección contra degradación del estado.
+
+## Riesgo técnico
+
+Si HidroFlow.jsx empieza a publicar un estado Tc base sin reglas, podría sobrescribir o degradar el estado más específico publicado por ComparadorMultiMetodo.jsx.
+
+Esto podría producir inconsistencias visuales si un publicador base reemplaza un estado enriquecido que ya contiene Tc_final, metodosTcCompetentes o rangoCompetenteTc.
+
+## Dictamen
+
+tcAgent puede servir como punto global para despertar el Índice Hidrológico, pero la publicación desde HidroFlow.jsx debe ser mínima y controlada.
+
+No se recomienda modificar tcAgent todavía.
+
+La siguiente fase debe diseñar una regla de publicación segura desde HidroFlow.jsx, evitando duplicar lógica hidrológica y evitando pisar el estado especializado del Comparador.
+
+## Criterio preliminar recomendado
+
+HidroFlow.jsx podría publicar un estado base del Tc solo cuando el agente esté vacío o incompleto.
+
+El Comparador Multi-Método debe seguir siendo la fuente especializada para Tc_final, rangos competentes y evaluación comparativa.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas Tc.
+- No cambiar Tc_final.
+- No cambiar params.tcMedMin.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+- No duplicar lógica hidrológica.
+
+## Siguiente fase
+
+Diseñar un adaptador mínimo de publicación base para despertar el Índice Hidrológico sin romper el flujo del Comparador.
+
+## Estado
+
+Auditoría documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0014/OT-0014E_diseno_publicacion_base_Tc_indice_global.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014E_diseno_publicacion_base_Tc_indice_global.md
@@ -1,0 +1,73 @@
+# OT-0014E — Diseño publicación base Tc para Índice Hidrológico global
+
+## Objetivo
+
+Diseñar una regla mínima para que HidroFlow.jsx pueda alimentar el Índice Hidrológico global mediante tcAgent, sin romper el flujo especializado del Comparador Multi-Método.
+
+## Base auditada
+
+OT-0014A identificó que el Índice Hidrológico puede quedar sin Tc cuando el Comparador no ha publicado estado en tcAgent.
+
+OT-0014B identificó que Hidrogramas muestra un Tc interno mediante tc_min, desacoplado del Tc_final del Comparador.
+
+OT-0014C identificó que params.tcMedMin se persiste desde ModParams para ser usado por Hietogramas e Hidrogramas.
+
+OT-0014D identificó que tcAgent permite merge abierto, pero no tiene reglas de prioridad ni protección contra degradación del estado.
+
+## Problema
+
+Si HidroFlow.jsx publica directamente un estado Tc base en tcAgent, podría pisar información más rica publicada por ComparadorMultiMetodo.jsx.
+
+El Comparador publica Tc_final, metodosTc, contextoTc, metodosTcCompetentes y rangoCompetenteTc.
+
+HidroFlow.jsx podría publicar un estado más básico basado en calcTc(params) o params.tcMedMin.
+
+## Criterio de diseño
+
+La publicación base desde HidroFlow.jsx solo debe despertar el Índice cuando el estado Tc esté vacío o incompleto.
+
+No debe reemplazar un estado especializado ya publicado por el Comparador.
+
+## Regla propuesta
+
+Antes de publicar desde HidroFlow.jsx, consultar getTcState().
+
+Publicar estado base solo si:
+
+- Tc_final es null o undefined.
+- metodosTc es null o no tiene métodos.
+- rangoCompetenteTc no existe.
+
+## Contenido mínimo del estado base
+
+El estado base podría incluir:
+
+- Tc_final: valor base documentado, preferiblemente params.tcMedMin si existe.
+- metodosTc: objeto derivado desde calcTc(params), sin cambiar fórmulas.
+- contextoTc: pendiente, área, CN y fuente.
+- fuente: hidroflow_base.
+- modoPublicacion: base_indice_global.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas Tc.
+- No cambiar Tc_final especializado del Comparador.
+- No cambiar params.tcMedMin.
+- No duplicar lógica hidrológica.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Riesgo controlado
+
+El estado base puede despertar el Índice en Hidrogramas, pero debe ceder prioridad al Comparador cuando este publique un estado especializado.
+
+## Dictamen
+
+Se recomienda implementar posteriormente una publicación base mínima desde HidroFlow.jsx, condicionada a que tcAgent esté vacío o incompleto.
+
+La implementación debe ser pequeña, auditable y reversible.
+
+## Estado
+
+Diseño documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0014/OT-0014G_cierre_tecnico_indice_hidrologico_global.md
+++ b/00_ADMIN/bitacora/OT-0014/OT-0014G_cierre_tecnico_indice_hidrologico_global.md
@@ -1,0 +1,73 @@
+# OT-0014G — Cierre técnico Índice Hidrológico global
+
+## Objetivo
+
+Cerrar técnicamente la OT-0014, consolidando la auditoría, diseño, implementación y validación del despertar del Índice Hidrológico global.
+
+## Alcance ejecutado
+
+- OT-0014A: apertura y auditoría inicial del Índice Hidrológico global.
+- OT-0014B: auditoría del Tc mostrado en Hidrogramas frente a tcAgent.
+- OT-0014C: auditoría del origen de params.tcMedMin.
+- OT-0014D: auditoría de tcAgent como estado global Tc.
+- OT-0014E: diseño de publicación base Tc para despertar el Índice.
+- OT-0014F: implementación de publicación base Tc desde HidroFlow.jsx.
+- Tooling operativo: creación de utilidades PowerShell permanentes para reducir dependencia del chat.
+- Git hygiene: .gitignore actualizado para ignorar inventarios locales.
+
+## Resultado técnico
+
+El Índice Hidrológico global ya puede despertar fuera del Comparador Multi-Método mediante una publicación base Tc desde HidroFlow.jsx hacia tcAgent.
+
+La publicación base no reemplaza el estado especializado del Comparador, porque primero revisa el estado actual de tcAgent.
+
+## Validación visual
+
+Se validó visualmente que el Índice Hidrológico muestra Tc, métodos válidos y rango bruto en Parámetros e Hidrogramas.
+
+También se validó que el Comparador conserva el estado especializado con Tc sugerido, rango bruto, rango competente y advertencia técnica.
+
+## Hallazgo pendiente
+
+Persisten rutas distintas de lectura Tc:
+
+- Tc base global publicado desde HidroFlow.jsx.
+- Tc interno de Hidrogramas basado en params.tcMedMin o tc_min.
+- Tc especializado del Comparador basado en seleccionarTc y tcAgent enriquecido.
+
+Esta divergencia queda identificada para una OT posterior de conciliación de Tc, no se corrige dentro de OT-0014.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas Tc.
+- No se cambió params.tcMedMin.
+- No se cambió el Tc_final especializado del Comparador.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+- No se eliminó trazabilidad histórica.
+
+## Tooling incorporado
+
+Se creó:
+
+07_TOOLBOX/powershell/hidroflow-git-tools.ps1
+
+con funciones para:
+
+- Ver-EstadoHidroFlow
+- Confirmar-Bitacora
+- Confirmar-CambioFuncional
+- Nueva-Bitacora
+
+Además, se actualizó .gitignore para excluir inventarios locales:
+
+10_LOGS/inventario_hidroflow_*.txt
+
+## Dictamen
+
+OT-0014 cumple su objetivo: despertar el Índice Hidrológico global y reducir la dependencia operativa del chat mediante herramientas PowerShell versionadas.
+
+## Estado
+
+OT-0014 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -23,12 +23,14 @@ import {
 } from "recharts";
 
 import HidrogramaResultado from "./components/HidrogramaResultado";
+import { getTcState, setTcState } from "./agents/tcAgent";
 
 import {
   calcCNdinamico,
   derivarAMCDesdeSIATA,
   calcLluviaEfectiva,
   calcTc,
+  mapTcResultados,
   cnMixto,
   cnII_to_III
 } from "./services/hidroEngine";
@@ -3472,6 +3474,67 @@ useEffect(() => {
     hidrograma_principal: null,
   });
 }, [onContextoComparador, params]);
+// Publicación base Tc para despertar el Índice Hidrológico global.
+// No reemplaza el estado especializado publicado por ComparadorMultiMetodo.
+useEffect(() => {
+  const estadoTcActual = getTcState();
+
+  const agenteTieneEstado =
+    estadoTcActual?.Tc_final !== null &&
+    estadoTcActual?.Tc_final !== undefined &&
+    estadoTcActual?.metodosTc;
+
+  const agenteTieneEstadoEspecializado =
+    estadoTcActual?.rangoCompetenteTc ||
+    estadoTcActual?.metodosTcCompetentes;
+
+  if (agenteTieneEstado || agenteTieneEstadoEspecializado) return;
+
+  const tcArrayBase = calcTc(params).filter(
+    (r) => Number.isFinite(r.h) && Number.isFinite(r.min) && r.h > 0 && r.min > 0
+  );
+
+  if (!tcArrayBase.length) return;
+
+  const metodosTcBase = mapTcResultados(tcArrayBase);
+  const valoresTcBase = Object.values(metodosTcBase).filter(Number.isFinite);
+
+  if (!valoresTcBase.length) return;
+
+  const valoresOrdenados = [...valoresTcBase].sort((a, b) => a - b);
+  const mitad = Math.floor(valoresOrdenados.length / 2);
+  const tcMedianaBase =
+    valoresOrdenados.length % 2
+      ? valoresOrdenados[mitad]
+      : (valoresOrdenados[mitad - 1] + valoresOrdenados[mitad]) / 2;
+
+  const tcBase =
+    Number.isFinite(params?.tcMedMin) && params.tcMedMin > 0
+      ? params.tcMedMin
+      : tcMedianaBase;
+
+  setTcState({
+    Tc_final: tcBase,
+    metodosTc: metodosTcBase,
+    contextoTc: {
+      pendiente:
+        params?.pendiente_media_pct ??
+        params?.pendienteMediaPct ??
+        params?.pendiente_pct ??
+        params?.S_pct ??
+        params?.pendiente ??
+        8.43,
+      area:
+        params?.area_km2 ??
+        params?.areaKm2 ??
+        params?.area ??
+        params?.A ??
+        null,
+      CN: params?.CN ?? params?.cnBase ?? null,
+      fuente: "hidroflow_base"
+    }
+  });
+}, [params]);
   
   // ────────────────── Defaults AMC / %imperv / CNbase (solo si faltan) ──────────────────
 useEffect(() => {
@@ -3583,6 +3646,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/07_TOOLBOX/powershell/hidroflow-git-tools.ps1
+++ b/07_TOOLBOX/powershell/hidroflow-git-tools.ps1
@@ -1,0 +1,122 @@
+function Ver-EstadoHidroFlow {
+  Write-Host ""
+  Write-Host "Rama actual:" -ForegroundColor Cyan
+  git branch --show-current
+
+  Write-Host ""
+  Write-Host "Estado:" -ForegroundColor Cyan
+  git status --short
+
+  Write-Host ""
+  Write-Host "Log reciente:" -ForegroundColor Cyan
+  git log --oneline -5
+}
+
+function Confirmar-Bitacora {
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$Archivo,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Mensaje
+  )
+
+  Write-Host ""
+  Write-Host "Validando bitacora:" $Archivo -ForegroundColor Cyan
+
+  if (-not (Test-Path -LiteralPath $Archivo)) {
+    Write-Host "ERROR: No existe el archivo." -ForegroundColor Red
+    return
+  }
+
+  Write-Host ""
+  Write-Host "Ultimas lineas:" -ForegroundColor Cyan
+  Get-Content -LiteralPath $Archivo | Select-Object -Last 8
+
+  Write-Host ""
+  Write-Host "Estado antes de add:" -ForegroundColor Cyan
+  git status --short
+
+  git add -- $Archivo
+
+  Write-Host ""
+  Write-Host "Estado staged:" -ForegroundColor Cyan
+  git status --short
+
+  git commit -m $Mensaje
+  git push
+
+  Write-Host ""
+  Write-Host "Estado final:" -ForegroundColor Cyan
+  git status --short
+
+  Write-Host ""
+  Write-Host "Log reciente:" -ForegroundColor Cyan
+  git log --oneline -5
+}
+
+function Confirmar-CambioFuncional {
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$Archivo,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Mensaje
+  )
+
+  Write-Host ""
+  Write-Host "Validando cambio funcional:" $Archivo -ForegroundColor Cyan
+
+  if (-not (Test-Path -LiteralPath $Archivo)) {
+    Write-Host "ERROR: No existe el archivo." -ForegroundColor Red
+    return
+  }
+
+  Write-Host ""
+  Write-Host "Estado antes de add:" -ForegroundColor Cyan
+  git status --short
+
+  Write-Host ""
+  Write-Host "Resumen diff:" -ForegroundColor Cyan
+  git diff --stat -- $Archivo
+
+  git add -- $Archivo
+
+  Write-Host ""
+  Write-Host "Estado staged:" -ForegroundColor Cyan
+  git status --short
+
+  git commit -m $Mensaje
+  git push
+
+  Write-Host ""
+  Write-Host "Estado final:" -ForegroundColor Cyan
+  git status --short
+
+  Write-Host ""
+  Write-Host "Log reciente:" -ForegroundColor Cyan
+  git log --oneline -5
+}
+
+function Nueva-Bitacora {
+  param(
+    [Parameter(Mandatory=$true)]
+    [string]$Archivo,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Contenido,
+
+    [Parameter(Mandatory=$true)]
+    [string]$Mensaje
+  )
+
+  $carpeta = Split-Path -Path $Archivo -Parent
+
+  if (-not (Test-Path -LiteralPath $carpeta)) {
+    New-Item -ItemType Directory -Path $carpeta -Force | Out-Null
+  }
+
+  Set-Content -Path $Archivo -Encoding UTF8 -Value $Contenido
+
+  Confirmar-Bitacora -Archivo $Archivo -Mensaje $Mensaje
+}


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0014 — Despertar Índice Hidrológico global.

El objetivo fue permitir que el Índice Hidrológico lateral despierte fuera del Comparador Multi-Método, especialmente en vistas como Parámetros e Hidrogramas, donde ya existen cálculos Tc internos pero el tcAgent podía permanecer vacío.

## Cambios incluidos

- Auditoría inicial del Índice Hidrológico global.
- Auditoría del Tc mostrado en Hidrogramas frente a tcAgent.
- Auditoría del origen de params.tcMedMin.
- Auditoría de tcAgent como estado global Tc.
- Diseño de publicación base Tc para despertar el Índice.
- Implementación de publicación base Tc desde HidroFlow.jsx.
- Cierre técnico de OT-0014.
- Incorporación de herramientas PowerShell permanentes para reducir dependencia operativa del chat.
- Actualización de .gitignore para ignorar inventarios locales.

## Resultado técnico

El Índice Hidrológico global ya puede mostrar Tc, métodos válidos y rango bruto fuera del Comparador Multi-Método mediante una publicación base desde HidroFlow.jsx hacia tcAgent.

La publicación base no reemplaza el estado especializado del Comparador, porque primero revisa el estado actual de tcAgent.

## Validación visual

Se validó visualmente que el Índice Hidrológico despierta en:

- Parámetros.
- Hidrogramas.

También se validó que el Comparador conserva su estado especializado con:

- Tc sugerido.
- Rango bruto Tc.
- Rango competente Tc.
- Advertencia técnica.

## Hallazgo pendiente

Persisten rutas distintas de lectura Tc:

- Tc base global publicado desde HidroFlow.jsx.
- Tc interno de Hidrogramas basado en params.tcMedMin o tc_min.
- Tc especializado del Comparador basado en seleccionarTc y tcAgent enriquecido.

Esta divergencia queda identificada para una OT posterior de conciliación de Tc.

## Tooling incorporado

Se creó:

```text
07_TOOLBOX/powershell/hidroflow-git-tools.ps1
