### PR TITLE
OT-0017 — Escenarios hidrológicos Tc para Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0017/OT-0017A_apertura_escenarios_hidrologicos_Tc_Qt.md
+++ b/00_ADMIN/bitacora/OT-0017/OT-0017A_apertura_escenarios_hidrologicos_Tc_Qt.md
@@ -1,0 +1,51 @@
+# OT-0017A — Apertura escenarios hidrológicos Tc para Q(t)
+
+## Objetivo
+
+Abrir el frente de escenarios hidrológicos Tc para Q(t), separando explícitamente las rutas Tc visibles en HidroFlow sin sobrescribir silenciosamente la física del módulo Hidrogramas.
+
+## Problema
+
+HidroFlow ya muestra rutas Tc diferenciadas:
+
+- Tc global del Índice Hidrológico.
+- Tc operativo de Hidrogramas asociado a la ruta interna Q(t).
+- Tc especializado del Comparador Multi-Método.
+
+Estas rutas no deben confundirse ni forzarse automáticamente entre sí.
+
+## Tesis
+
+La conciliación matemática real debe manejarse mediante escenarios explícitos, no mediante un toggle que reemplace el Tc operativo de Hidrogramas sin trazabilidad.
+
+## Alcance inicial
+
+- Definir escenarios Tc para análisis Q(t).
+- Mantener intacto el cálculo operativo actual.
+- Preparar comparación futura de Qp, Tp, Volumen y forma del hidrograma.
+- Evitar carga espacial adicional hasta cerrar la arquitectura de escenarios.
+
+## Escenarios candidatos
+
+- Escenario operativo Hidrogramas.
+- Escenario Tc global Índice.
+- Escenario Tc especializado Comparador.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No forzar Tc global sobre Hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t) en esta fase.
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Decisión inicial
+
+No se implementará un toggle de sobrescritura directa del Tc operativo.
+
+La estrategia será construir escenarios explícitos y trazables para análisis comparativo.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0017/OT-0017C_cierre_escenarios_hidrologicos_Tc_Qt.md
+++ b/00_ADMIN/bitacora/OT-0017/OT-0017C_cierre_escenarios_hidrologicos_Tc_Qt.md
@@ -1,0 +1,44 @@
+# OT-0017C — Cierre escenarios hidrológicos Tc para Q(t)
+
+## Objetivo
+
+Cerrar la OT-0017 consolidando la exposición explícita de escenarios Tc en el módulo Hidrogramas, sin alterar el cálculo operativo Q(t).
+
+## Resultado práctico
+
+Se agregó en Hidrogramas un bloque visual de escenarios Tc que muestra:
+
+- Tc operativo Q(t).
+- Tc global del Índice Hidrológico.
+- Tc especializado del Comparador como pendiente.
+
+El bloque permite entender que el hidrograma se calcula con una ruta operativa interna y que los demás Tc son referencias o escenarios de comparación.
+
+## Decisión técnica
+
+No se implementa un toggle para forzar el Tc global sobre Hidrogramas.
+
+No se modifica la física del módulo Q(t).
+
+No se recalculan Qp, Tp, Volumen ni la forma del hidrograma.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se forzó Tc global sobre Hidrogramas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0017 entrega un resultado práctico: los escenarios Tc quedan visibles en Hidrogramas sin romper el cálculo operativo.
+
+La comparación matemática entre escenarios queda para una OT posterior, donde se podrá evaluar Qp, Tp, Volumen y forma Q(t) bajo escenarios controlados.
+
+## Estado
+
+OT-0017 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2295,6 +2295,10 @@ const qaStatus = useMemo(() => {
          <span className="text-slate-400"> · ruta interna Q(t)</span>
        </div>
 
+       <div className="text-slate-400">
+         Escenarios Tc: operativo Q(t) = {tc_min.toFixed(1)} min · índice global = {Number.isFinite(params?.tcMedMin) ? params.tcMedMin.toFixed(1) : "—"} min · comparador = pendiente
+       </div>
+
        <div className={qaStatus.amcWarning ? "text-red-400" : "text-blue-400"}>
          AMC: {params?.amcActual ?? "N/A"} ({params?.amcFuente ?? "Sin fuente"})
        </div>
@@ -3647,6 +3651,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0017 — Escenarios hidrológicos Tc para Q(t).

El objetivo fue mostrar explícitamente las rutas Tc relevantes en Hidrogramas sin alterar el cálculo operativo del hidrograma.

## Cambios incluidos

- Apertura documental de escenarios Tc.
- Bloque visual en Hidrogramas con escenarios:
  - Tc operativo Q(t).
  - Tc global del Índice Hidrológico.
  - Tc especializado del Comparador como pendiente.
- Cierre técnico de la OT.

## Decisión técnica

No se implementa toggle para forzar Tc global sobre Hidrogramas.

La comparación matemática real queda para una OT posterior mediante escenarios controlados.

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout.
- No se introdujeron console.log permanentes.

## Dictamen

OT-0017 entrega claridad práctica: los escenarios Tc quedan visibles sin romper la física operativa del módulo Hidrogramas.