### PR TITLE
OT-0020 — Control volumen esperado Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0020/OT-0020A_apertura_control_volumen_esperado_Q5.md
+++ b/00_ADMIN/bitacora/OT-0020/OT-0020A_apertura_control_volumen_esperado_Q5.md
@@ -1,0 +1,36 @@
+# OT-0020A — Apertura control volumen esperado Q-5
+
+## Objetivo
+
+Abrir el control físico preliminar entre el volumen esperado por lluvia efectiva y los volúmenes mostrados en el bloque Q-5.
+
+## Problema
+
+Q-5 muestra volúmenes de hidrogramas que pueden ser difíciles de interpretar sin una referencia física de escala.
+
+## Tesis
+
+Antes de adoptar o interpretar volúmenes de Q-5, HidroFlow debe mostrar una referencia preliminar de volumen esperado basada en lluvia efectiva y área de cuenca.
+
+## Control preliminar
+
+Volumen esperado aproximado:
+
+Pe(mm) × Área(km²) × 1000
+
+Este control no reemplaza la integración formal del hidrograma, pero sirve como referencia de escala.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0020/OT-0020C_cierre_control_volumen_esperado_Q5.md
+++ b/00_ADMIN/bitacora/OT-0020/OT-0020C_cierre_control_volumen_esperado_Q5.md
@@ -1,0 +1,44 @@
+# OT-0020C — Cierre control volumen esperado Q-5
+
+## Objetivo
+
+Cerrar la OT-0020 consolidando el control preliminar de volumen esperado frente a los volúmenes mostrados en el bloque Q-5.
+
+## Resultado práctico
+
+Se agregó una referencia de escala basada en:
+
+Pe(mm) × Área(km²) × 1000
+
+para comparar preliminarmente el volumen esperado de lluvia efectiva contra los volúmenes reportados por los métodos Q-5.
+
+## Corrección aplicada
+
+Se corrigió la escala de Pe para evitar sumar una serie acumulada como si fuera lluvia incremental.
+
+La referencia usa un valor representativo de lluvia efectiva total y evita inflar artificialmente el volumen esperado.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El build fue aprobado.
+
+La referencia de volumen esperado fue validada visualmente en el bloque Q-5.
+
+## Dictamen
+
+OT-0020 entrega un control físico preliminar de escala para interpretar los volúmenes Q-5 como resultados no adoptivos hasta auditoría formal.
+
+## Estado
+
+OT-0020 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2103,17 +2103,33 @@ const leerT = (punto, indice) => {
     : [];
 
     
-  const lluviaEfectivaTotalMm = Array.isArray(lluvEfect)
-    ? lluvEfect.reduce((suma, valor) => {
-        const numero = Number(
-          typeof valor === "object"
-            ? valor?.pe ?? valor?.Pe ?? valor?.pn ?? valor?.Pn ?? valor?.valor ?? valor?.y
-            : valor
-        );
+  const valoresLluviaEfectivaMm = Array.isArray(lluvEfect)
+    ? lluvEfect
+        .map((valor) =>
+          Number(
+            typeof valor === "object"
+              ? valor?.pe ?? valor?.Pe ?? valor?.pn ?? valor?.Pn ?? valor?.valor ?? valor?.y
+              : valor
+          )
+        )
+        .filter((numero) => Number.isFinite(numero) && numero >= 0)
+    : [];
 
-        return Number.isFinite(numero) ? suma + numero : suma;
-      }, 0)
+  const sumaLluviaEfectivaMm = valoresLluviaEfectivaMm.reduce(
+    (suma, numero) => suma + numero,
+    0
+  );
+
+  const maxLluviaEfectivaMm = valoresLluviaEfectivaMm.length
+    ? Math.max(...valoresLluviaEfectivaMm)
     : null;
+
+  const lluviaEfectivaTotalMm =
+    maxLluviaEfectivaMm !== null &&
+    maxLluviaEfectivaMm > 0 &&
+    sumaLluviaEfectivaMm / maxLluviaEfectivaMm > 3
+      ? maxLluviaEfectivaMm
+      : sumaLluviaEfectivaMm || null;
 
   onContextoComparador((previo) => ({
     ...(previo ?? {}),
@@ -3667,6 +3683,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2103,10 +2103,23 @@ const leerT = (punto, indice) => {
     : [];
 
     
+  const lluviaEfectivaTotalMm = Array.isArray(lluvEfect)
+    ? lluvEfect.reduce((suma, valor) => {
+        const numero = Number(
+          typeof valor === "object"
+            ? valor?.pe ?? valor?.Pe ?? valor?.pn ?? valor?.Pn ?? valor?.valor ?? valor?.y
+            : valor
+        );
+
+        return Number.isFinite(numero) ? suma + numero : suma;
+      }, 0)
+    : null;
+
   onContextoComparador((previo) => ({
     ...(previo ?? {}),
     fuente: "motor HidroFlow",
     lluvia_efectiva: Boolean(lluvEfect),
+    lluvia_efectiva_total_mm: lluviaEfectivaTotalMm,
     hidrogramas: hidrogramasResumen,
     hidrograma_principal: h0 ?? null,
   }));
@@ -3654,6 +3667,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1208,6 +1208,22 @@ const obtenerResultadoQMetodo = (metodo) => {
 
       {renderTabla("Bloque Tc-15 · Tiempo de concentración / respuesta", "tc")}
 
+      {(() => {
+        const areaKm2 = Number(contextoBase?.area_km2);
+        const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
+        const volumenEsperadoM3 =
+          Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
+            ? areaKm2 * peTotalMm * 1000
+            : null;
+
+        return volumenEsperadoM3 ? (
+          <div style={{ ...estilos.muted, marginBottom: "10px" }}>
+            Referencia de escala: Volumen esperado ≈ {volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 })} m³
+            {" "}({peTotalMm.toFixed(2)} mm × {areaKm2.toFixed(4)} km² × 1000).
+          </div>
+        ) : null;
+      })()}
+
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
         ⚠ Control de magnitud pendiente: Qp, Tp y Volumen se muestran como resultados no adoptivos hasta validar unidades, integración y escala hidrológica.
       </div>
@@ -1216,6 +1232,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0020 — Control volumen esperado Q-5.

El objetivo fue agregar una referencia física preliminar de volumen esperado para interpretar los volúmenes mostrados en el bloque Q-5 del Comparador Hidrológico Multi-Método.

## Cambios incluidos

- Apertura documental del control de volumen esperado.
- Publicación de lluvia efectiva total hacia el contexto del comparador.
- Visualización de referencia de escala:
  - Volumen esperado ≈ Pe(mm) × Área(km²) × 1000.
- Corrección de escala Pe para evitar sumar una serie acumulada como lluvia incremental.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora muestra una referencia de escala, por ejemplo:

Volumen esperado ≈ 2.654.251 m³  
(56.65 mm × 46.8516 km² × 1000)

Esto permite contrastar preliminarmente los volúmenes calculados por los métodos Q-5.

## Decisión técnica

La referencia de escala es informativa y no modifica resultados.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp.
- No se alteró Tp.
- No se alteró Volumen.
- No se alteró Q(t).
- No se introdujeron setTimeout.
- No se introdujeron console.log permanentes.

## Validación

- Build aprobado.
- Referencia de volumen esperado validada visualmente en Q-5.
- Working tree limpio.

## Dictamen

OT-0020 entrega un control físico preliminar de escala para interpretar los volúmenes Q-5 como resultados no adoptivos hasta auditoría formal.