### PR TITLE
OT-0021 — Semáforo escala Volumen Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0021/OT-0021A_apertura_semaforo_escala_volumen_Q5.md
+++ b/00_ADMIN/bitacora/OT-0021/OT-0021A_apertura_semaforo_escala_volumen_Q5.md
@@ -1,0 +1,45 @@
+# OT-0021A — Apertura semáforo escala Volumen Q-5
+
+## Objetivo
+
+Abrir el frente de clasificación visual de escala para los volúmenes mostrados en el bloque Q-5 del Comparador Hidrológico Multi-Método.
+
+## Problema
+
+OT-0020 incorporó una referencia física preliminar de volumen esperado basada en Pe(mm) × Área(km²) × 1000.
+
+Sin embargo, los volúmenes individuales de cada método Q-5 todavía no muestran una clasificación relativa frente a esa referencia.
+
+## Tesis
+
+Cada volumen Q-5 debe poder leerse frente a una escala física preliminar, sin alterar el cálculo original.
+
+## Criterio inicial
+
+Relación = Volumen método / Volumen esperado
+
+- Relación <= 2: escala razonable.
+- 2 < Relación <= 10: revisar escala.
+- Relación > 10: fuera de escala.
+
+## Alcance
+
+- Mostrar clasificación visual junto al volumen de cada método Q-5.
+- Mantener Qp, Tp, Volumen y Q(t) intactos.
+- No modificar motor hidrológico.
+- No modificar fórmulas.
+
+## Restricciones
+
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0021/OT-0021C_cierre_semaforo_escala_volumen_Q5.md
+++ b/00_ADMIN/bitacora/OT-0021/OT-0021C_cierre_semaforo_escala_volumen_Q5.md
@@ -1,0 +1,54 @@
+# OT-0021C — Cierre semáforo escala Volumen Q-5
+
+## Objetivo
+
+Cerrar la OT-0021 consolidando la clasificación visual de escala para los volúmenes mostrados en el bloque Q-5 del Comparador Hidrológico Multi-Método.
+
+## Resultado práctico
+
+Se agregó un semáforo visual junto al Volumen de cada método Q-5, comparando el volumen calculado contra el volumen esperado incorporado en OT-0020.
+
+La relación usada es:
+
+Volumen método / Volumen esperado
+
+## Criterio aplicado
+
+- Relación <= 2: escala razonable.
+- 2 < Relación <= 10: revisar escala.
+- Relación > 10: fuera de escala.
+
+## Decisión técnica
+
+El semáforo es informativo y no modifica resultados.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio fue validado visualmente en el bloque Q-5.
+
+El build fue aprobado después de sincronizar la rama con main.
+
+## Dictamen
+
+OT-0021 entrega una capa práctica de lectura técnica: cada volumen Q-5 queda clasificado frente a una referencia física preliminar de escala.
+
+La explicación matemática de las desviaciones queda para OT-0022, enfocada en conservación de masa de Q(t).
+
+## Estado
+
+OT-0021 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -808,10 +808,38 @@ const obtenerResultadoQMetodo = (metodo) => {
       return <span style={estilos.chip}>—</span>;
     }
 
+    const areaKm2 = Number(contextoBase?.area_km2);
+    const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
+    const volumenEsperadoM3 =
+      Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
+        ? areaKm2 * peTotalMm * 1000
+        : null;
+
+    const relacionVolumen =
+      volumenEsperadoM3 && volumenEsperadoM3 > 0
+        ? resultadoQ.volumen / volumenEsperadoM3
+        : null;
+
+    const estadoEscalaVolumen =
+      relacionVolumen === null
+        ? null
+        : relacionVolumen <= 2
+        ? "escala razonable"
+        : relacionVolumen <= 10
+        ? "revisar escala"
+        : "fuera de escala";
+
     return (
-      <span style={estilos.chip}>
-        {resultadoQ.volumen.toFixed(2)}
-      </span>
+      <div>
+        <span style={estilos.chip}>
+          {resultadoQ.volumen.toFixed(2)}
+        </span>
+        {estadoEscalaVolumen ? (
+          <div style={{ ...estilos.muted, marginTop: "4px" }}>
+            {estadoEscalaVolumen} · {relacionVolumen.toFixed(1)}x
+          </div>
+        ) : null}
+      </div>
     );
   })()}
 </td>
@@ -1232,6 +1260,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0021 — Semáforo escala Volumen Q-5.

El objetivo fue agregar una clasificación visual para los volúmenes del bloque Q-5, comparando cada volumen calculado contra la referencia física preliminar de volumen esperado incorporada en OT-0020.

## Cambios incluidos

- Apertura documental del semáforo de escala.
- Clasificación visual junto al Volumen de cada método Q-5.
- Cierre técnico de la OT.

## Criterio aplicado

Relación = Volumen método / Volumen esperado

- Relación <= 2: escala razonable.
- 2 < Relación <= 10: revisar escala.
- Relación > 10: fuera de escala.

## Decisión técnica

La clasificación es informativa y no modifica resultados.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp.
- No se alteró Tp.
- No se alteró Volumen.
- No se alteró Q(t).
- No se introdujeron setTimeout.
- No se introdujeron console.log permanentes.

## Validación

- Build aprobado.
- Semáforo validado visualmente en Q-5.
- Rama sincronizada con main posterior a OT-0020.
- Working tree limpio.

## Dictamen

OT-0021 agrega una capa práctica de control visual de escala para los volúmenes Q-5.

La explicación matemática de las desviaciones queda para OT-0022, enfocada en conservación de masa de Q(t).