### PR TITLE
OT-0023 — Revalidación Q-5 post conservación de masa

### DIFF
--- a/00_ADMIN/bitacora/OT-0023/OT-0023A_apertura_revalidacion_Q5_post_conservacion_masa.md
+++ b/00_ADMIN/bitacora/OT-0023/OT-0023A_apertura_revalidacion_Q5_post_conservacion_masa.md
@@ -1,0 +1,42 @@
+# OT-0023A — Apertura revalidación Q-5 post conservación de masa
+
+## Objetivo
+
+Revalidar el bloque Q-5 después de la corrección de conservación de masa aplicada en OT-0022.
+
+## Problema
+
+OT-0022 corrigió la escala de masa de los hidrogramas unitarios, pero todavía debe revisarse cómo quedaron las magnitudes Qp, Tp, Volumen, alertas Tc/Tp, semáforo de escala y observaciones técnicas.
+
+## Tesis
+
+Después de corregir conservación de masa, HidroFlow debe reclasificar la lectura técnica de Q-5. No todos los métodos deben presentarse como equivalentes o adoptivos.
+
+## Marco de lectura
+
+La guía GT-AS-004 prioriza la generación de hidrogramas mediante SCS para almacenamiento/regulación y permite metodologías alternativas solo con justificación. Por tanto, Q-5 debe distinguir entre método principal, variantes y métodos comparativos.
+
+## Alcance inicial
+
+- Revalidar visualmente Qp, Tp y Volumen post-normalización.
+- Verificar que el volumen quede cercano a la referencia Pe × Área × 1000.
+- Revisar alertas Tc/Tp persistentes.
+- Revisar observaciones técnicas por método.
+- Proponer clasificación inicial de métodos Q-5.
+
+## Restricciones
+
+- No usar caudales externos como fundamento de corrección.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0023/OT-0023C_cierre_revalidacion_Q5_post_conservacion_masa.md
+++ b/00_ADMIN/bitacora/OT-0023/OT-0023C_cierre_revalidacion_Q5_post_conservacion_masa.md
@@ -1,0 +1,50 @@
+# OT-0023C — Cierre revalidación Q-5 post conservación de masa
+
+## Objetivo
+
+Cerrar la OT-0023 consolidando la revalidación técnica del bloque Q-5 después de la corrección de conservación de masa aplicada en OT-0022.
+
+## Resultado práctico
+
+Se agregó una lectura metodológica post-conservación de masa en el bloque Q-5.
+
+La clasificación visual indica:
+
+- SCS como método principal de referencia para hidrograma.
+- SCS Mod. como variante ajustable.
+- Snyder, Williams & Hann y Clark IUH como métodos comparativos o referenciales hasta justificación técnica.
+
+## Decisión técnica
+
+No todos los métodos Q-5 deben interpretarse como equivalentes o adoptivos.
+
+La corrección de masa de OT-0022 permitió que los volúmenes queden físicamente consistentes, pero la competencia metodológica de cada hidrograma sigue requiriendo jerarquía técnica.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio visual fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0023 entrega una lectura técnica más defendible del bloque Q-5 post conservación de masa: SCS queda como método principal de referencia y los demás métodos quedan explícitamente como variantes, comparativos o referenciales.
+
+## Estado
+
+OT-0023 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1253,6 +1253,10 @@ const obtenerResultadoQMetodo = (metodo) => {
       })()}
 
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
+        Lectura metodológica post-conservación de masa: SCS se toma como método principal de referencia para hidrograma; SCS Mod. queda como variante ajustable; Snyder, Williams & Hann y Clark IUH se mantienen como métodos comparativos/referenciales hasta justificación técnica.
+      </div>
+
+      <div style={{ ...estilos.muted, marginBottom: "10px" }}>
         ⚠ Control de magnitud pendiente: Qp, Tp y Volumen se muestran como resultados no adoptivos hasta validar unidades, integración y escala hidrológica.
       </div>
 
@@ -1260,6 +1264,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0023 — Revalidación Q-5 post conservación de masa.

El objetivo fue reclasificar técnicamente el bloque Q-5 después de la corrección de conservación de masa aplicada en OT-0022.

## Cambios incluidos

- Apertura documental de la revalidación Q-5 post masa.
- Lectura metodológica post-conservación de masa en Q-5.
- Clasificación visual:
  - SCS como método principal de referencia.
  - SCS Mod. como variante ajustable.
  - Snyder, Williams & Hann y Clark IUH como métodos comparativos/referenciales.
- Cierre técnico de la OT.

## Decisión técnica

No todos los métodos Q-5 deben interpretarse como equivalentes o adoptivos.

La corrección de masa estabiliza la escala de volumen, pero la competencia metodológica requiere jerarquía técnica.

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Cambio visual aplicado en Q-5.
- Working tree limpio.

## Dictamen

OT-0023 entrega una lectura técnica más defendible del bloque Q-5 post conservación de masa.