### PR TITLE
OT-0024 — Revalidación Qp–Tp post normalización de masa

### DIFF
--- a/00_ADMIN/bitacora/OT-0024/OT-0024A_apertura_revalidacion_Qp_Tp_post_masa.md
+++ b/00_ADMIN/bitacora/OT-0024/OT-0024A_apertura_revalidacion_Qp_Tp_post_masa.md
@@ -1,0 +1,38 @@
+# OT-0024A — Apertura revalidación Qp–Tp post normalización de masa
+
+## Objetivo
+
+Abrir la revalidación de Qp y Tp en el bloque Q-5 después de la corrección de conservación de masa aplicada en OT-0022 y la reclasificación metodológica aplicada en OT-0023.
+
+## Problema
+
+Los volúmenes Q-5 ya quedaron alineados con la referencia física Pe(mm) × Área(km²) × 1000, pero persisten alertas Tc/Tp y diferencias relevantes en Qp y Tp entre métodos.
+
+## Tesis
+
+Después de corregir la masa, la siguiente validación debe enfocarse en la coherencia temporal y la forma del hidrograma, no en volver a modificar el volumen.
+
+## Alcance inicial
+
+- Revisar Qp post-normalización.
+- Revisar Tp post-normalización.
+- Revisar alertas Tc/Tp persistentes.
+- Verificar qué métodos quedan como candidatos, variantes o comparativos.
+- No modificar el motor en esta fase.
+
+## Restricciones
+
+- No usar caudales externos como fundamento de corrección.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0024/OT-0024C_cierre_revalidacion_Qp_Tp_post_masa.md
+++ b/00_ADMIN/bitacora/OT-0024/OT-0024C_cierre_revalidacion_Qp_Tp_post_masa.md
@@ -1,0 +1,60 @@
+# OT-0024C — Cierre revalidación Qp–Tp post normalización de masa
+
+## Objetivo
+
+Cerrar la OT-0024 consolidando la revalidación de Qp y Tp después de la corrección de conservación de masa aplicada en OT-0022 y la reclasificación metodológica aplicada en OT-0023.
+
+## Resultado práctico
+
+Se agregó una nota visual de revalidación post-masa en el bloque Q-5.
+
+La nota aclara que los volúmenes ya se contrastan contra la referencia física, pero Qp y Tp permanecen sujetos a revisión temporal mediante alerta Tc/Tp antes de cualquier adopción técnica.
+
+## Estado técnico actual
+
+- El volumen esperado se muestra como referencia física.
+- El semáforo de volumen clasifica la escala frente al volumen esperado.
+- Los métodos Q-5 conservan una jerarquía metodológica post-masa.
+- Qp y Tp permanecen sujetos a revisión temporal.
+- La alerta Tc/Tp sigue siendo el mecanismo visual de control temporal.
+
+## Decisión técnica
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+La revalidación post-masa se expresa como una capa visual y técnica de lectura, no como una adopción automática de resultados.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio visual fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El cambio fue validado visualmente en el bloque Q-5.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0024 entrega una lectura técnica más completa del bloque Q-5 post normalización de masa: el volumen ya está controlado por conservación de masa, mientras Qp y Tp quedan explícitamente sujetos a revisión temporal antes de adopción técnica.
+
+## Estado
+
+OT-0024 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1257,6 +1257,10 @@ const obtenerResultadoQMetodo = (metodo) => {
       </div>
 
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
+        Revalidación post-masa: los volúmenes ya se contrastan contra la referencia física; Qp y Tp permanecen sujetos a revisión temporal mediante alerta Tc/Tp antes de cualquier adopción técnica.
+      </div>
+
+      <div style={{ ...estilos.muted, marginBottom: "10px" }}>
         ⚠ Control de magnitud pendiente: Qp, Tp y Volumen se muestran como resultados no adoptivos hasta validar unidades, integración y escala hidrológica.
       </div>
 
@@ -1264,6 +1268,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0024 — Revalidación Qp–Tp post normalización de masa.

El objetivo fue aclarar el estado técnico de Qp y Tp después de la corrección de conservación de masa aplicada en OT-0022 y la reclasificación metodológica aplicada en OT-0023.

## Cambios incluidos

- Apertura documental de la revalidación Qp–Tp post masa.
- Nota visual de revalidación post-masa en el bloque Q-5.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora aclara que los volúmenes ya se contrastan contra la referencia física, mientras Qp y Tp permanecen sujetos a revisión temporal mediante alerta Tc/Tp antes de cualquier adopción técnica.

## Decisión técnica

La revalidación es informativa.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp.
- No se alteró Tp.
- No se alteró Volumen.
- No se alteró Q(t).
- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Cambio visual validado en Q-5.
- Working tree limpio.

## Dictamen

OT-0024 deja el bloque Q-5 en un estado técnico más defendible: masa controlada, volumen en escala y Qp/Tp explícitamente pendientes de revisión temporal antes de adopción.