### PR TITLE
OT-0025 — Diagnóstico forma temporal Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0025/OT-0025A_apertura_diagnostico_forma_temporal_Qt.md
+++ b/00_ADMIN/bitacora/OT-0025/OT-0025A_apertura_diagnostico_forma_temporal_Qt.md
@@ -1,0 +1,39 @@
+# OT-0025A — Apertura diagnóstico forma temporal Q(t)
+
+## Objetivo
+
+Abrir el diagnóstico analítico de la forma temporal de los hidrogramas Q(t) después de la corrección de conservación de masa aplicada en OT-0022.
+
+## Problema
+
+La conservación de masa ya fue corregida y los volúmenes Q-5 se encuentran en escala física razonable. Sin embargo, persisten alertas Tc/Tp y diferencias importantes en Qp y Tp entre métodos.
+
+## Tesis
+
+Una vez controlado el volumen, la credibilidad de Q(t) depende de la forma temporal del hidrograma: tiempo al pico, concentración del volumen, ancho efectivo y relación entre Qp, Tp, Volumen y Tc.
+
+## Alcance inicial
+
+- Auditar cómo se obtiene Qp.
+- Auditar cómo se obtiene Tp.
+- Auditar la relación Tp/Tc.
+- Auditar la relación Qp/Volumen.
+- Identificar si los picos son producto de hidrogramas demasiado estrechos.
+- No modificar el motor en esta fase.
+
+## Restricciones
+
+- No usar caudales externos como fundamento de corrección.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0025/OT-0025B_diagnostico_forma_temporal_Qt_post_masa.md
+++ b/00_ADMIN/bitacora/OT-0025/OT-0025B_diagnostico_forma_temporal_Qt_post_masa.md
@@ -1,0 +1,67 @@
+# OT-0025B — Diagnóstico forma temporal Q(t) post masa
+
+## Objetivo
+
+Documentar el diagnóstico analítico inicial de la forma temporal de los hidrogramas Q(t) después de la corrección de conservación de masa.
+
+## Evidencia auditada
+
+En ComparadorMultiMetodo.jsx se confirmó que Qp, Tp y Volumen se leen desde resultadoQ.
+
+También se confirmó que la alerta Tc/Tp se calcula mediante la relación:
+
+tpRel = resultadoQ.Tp / Tc_final
+
+La alerta se activa cuando:
+
+tpRel < 0.5 o tpRel > 1.5
+
+## Lectura técnica
+
+Después de OT-0022, los volúmenes Q-5 quedaron alineados con la referencia física de volumen esperado.
+
+Por tanto, las alertas Tc/Tp persistentes ya no deben interpretarse como falla de masa, sino como advertencia de forma temporal del hidrograma.
+
+## Diagnóstico preliminar
+
+La alerta Tc/Tp post-masa indica que el tiempo al pico de algunos métodos no está conciliado con el Tc de referencia usado por el Comparador.
+
+Esto puede deberse a:
+
+- forma propia del hidrograma unitario;
+- ancho temporal del método;
+- posición del pico dentro de Q(t);
+- diferencia entre Tc operativo del método y Tc_final del Comparador;
+- carácter comparativo o referencial del método.
+
+## Decisión técnica
+
+No se modifica el motor en esta fase.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+La forma temporal queda diagnosticada como pendiente de evaluación por método antes de cualquier adopción técnica.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+
+## Dictamen
+
+OT-0025B separa claramente dos problemas:
+
+- La masa ya fue corregida en OT-0022.
+- La forma temporal Q(t), especialmente Tp frente a Tc_final, sigue pendiente de revisión metodológica.
+
+## Estado
+
+Diagnóstico documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0025/OT-0025C_cierre_diagnostico_forma_temporal_Qt.md
+++ b/00_ADMIN/bitacora/OT-0025/OT-0025C_cierre_diagnostico_forma_temporal_Qt.md
@@ -1,0 +1,50 @@
+# OT-0025C — Cierre diagnóstico forma temporal Q(t)
+
+## Objetivo
+
+Cerrar la OT-0025 consolidando el diagnóstico analítico de la forma temporal de los hidrogramas Q(t) después de la corrección de conservación de masa.
+
+## Resultado
+
+Se confirmó que, después de OT-0022, la masa y el volumen de los hidrogramas Q-5 quedaron controlados frente a la referencia física.
+
+Las alertas Tc/Tp persistentes se interpretan ahora como advertencias de forma temporal, no como falla de conservación de masa.
+
+## Diagnóstico
+
+La relación Tp/Tc sigue siendo el control visual principal para advertir que un hidrograma puede tener una forma temporal no conciliada con el Tc de referencia.
+
+La forma temporal debe evaluarse por método antes de cualquier adopción técnica.
+
+## Decisión técnica
+
+No se modifica el motor en esta OT.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+La evaluación detallada de métricas temporales queda para una OT posterior.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0025 separa claramente la falla ya corregida de masa de la revisión pendiente de forma temporal.
+
+El siguiente frente recomendado es calcular métricas temporales por método: Tp/Tc, duración equivalente, Qp/Volumen y ancho efectivo del hidrograma.
+
+## Estado
+
+OT-0025 lista para PR.


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0025 — Diagnóstico forma temporal Q(t).

El objetivo fue separar la falla de conservación de masa ya corregida en OT-0022 de la revisión pendiente de forma temporal de los hidrogramas Q(t).

## Cambios incluidos

- Apertura documental del diagnóstico de forma temporal.
- Diagnóstico analítico de Tp/Tc y Qp/Tp/Volumen post masa.
- Cierre técnico de la OT.

## Resultado

Después de OT-0022, los volúmenes Q-5 quedaron controlados frente a la referencia física.

Las alertas Tc/Tp persistentes se interpretan como advertencias de forma temporal del hidrograma, no como falla de masa.

## Decisión técnica

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0025 deja claro que la masa ya fue corregida y que la siguiente revisión debe enfocarse en métricas temporales por método.