### PR TITLE
OT-0026 — Métricas temporales por método Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0026/OT-0026A_apertura_metricas_temporales_metodo_Qt.md
+++ b/00_ADMIN/bitacora/OT-0026/OT-0026A_apertura_metricas_temporales_metodo_Qt.md
@@ -1,0 +1,45 @@
+# OT-0026A — Apertura métricas temporales por método Q(t)
+
+## Objetivo
+
+Abrir el frente de métricas temporales por método Q(t), posterior a la corrección de conservación de masa y al diagnóstico de forma temporal.
+
+## Problema
+
+Después de OT-0022, los volúmenes Q-5 quedaron físicamente controlados. Sin embargo, persisten diferencias importantes en Qp y Tp entre métodos, así como alertas Tc/Tp.
+
+## Tesis
+
+Una vez corregida la masa, la forma temporal del hidrograma debe evaluarse con métricas internas por método, sin usar caudales externos ni calibraciones ajenas.
+
+## Métricas candidatas
+
+- Tp/Tc: relación entre tiempo al pico y Tc de referencia.
+- Duración equivalente: Volumen / Qp.
+- Qp/Volumen: concentración relativa del volumen en el pico.
+- Estado temporal: lectura técnica de si el método responde muy rápido, razonable o retardado.
+
+## Alcance inicial
+
+- Auditar si Qp, Tp, Volumen y Tc_final están disponibles simultáneamente en el comparador.
+- Preparar una métrica visual mínima por método.
+- No modificar el motor.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+
+## Restricciones
+
+- No usar caudales externos como fundamento de corrección.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0026/OT-0026C_cierre_metricas_temporales_metodo_Qt.md
+++ b/00_ADMIN/bitacora/OT-0026/OT-0026C_cierre_metricas_temporales_metodo_Qt.md
@@ -1,0 +1,55 @@
+# OT-0026C — Cierre métricas temporales por método Q(t)
+
+## Objetivo
+
+Cerrar la OT-0026 consolidando la incorporación de métricas temporales internas por método Q(t) en el bloque Q-5.
+
+## Resultado práctico
+
+Se agregó lectura temporal junto al tiempo al pico de cada método Q-5, incluyendo:
+
+- Tp/Tc.
+- Duración equivalente = Volumen / Qp.
+
+Estas métricas ayudan a interpretar si un hidrograma concentra demasiado volumen en el pico, responde demasiado rápido, o presenta una forma temporal retardada frente al Tc de referencia.
+
+## Decisión técnica
+
+La mejora es informativa.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio visual fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El cambio fue validado visualmente en Q-5.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0026 entrega una lectura temporal más defendible del bloque Q-5: después de corregir masa y controlar volumen, ahora cada método expone métricas internas para interpretar la forma temporal del hidrograma.
+
+## Estado
+
+OT-0026 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -786,6 +786,9 @@ const obtenerResultadoQMetodo = (metodo) => {
         <span style={estilos.chip}>
           {resultadoQ.Tp.toFixed(2)} min
         </span>
+        <div style={{ ...estilos.muted, marginTop: "4px" }}>
+          Tp/Tc: {tpRel !== null ? tpRel.toFixed(2) + "x" : "—"} · Dur. eq.: {Number.isFinite(resultadoQ.volumen) && Number.isFinite(resultadoQ.Qp) && resultadoQ.Qp > 0 ? (resultadoQ.volumen / resultadoQ.Qp / 60).toFixed(0) + " min" : "—"}
+        </div>
         {alertaTcTp ? (
           <div style={{ ...estilos.muted, marginTop: "4px" }}>
             ⚠ Alerta Tc/Tp
@@ -1268,6 +1271,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0026 — Métricas temporales por método Q(t).

El objetivo fue agregar métricas internas para interpretar la forma temporal de los hidrogramas Q-5 después de la corrección de conservación de masa.

## Cambios incluidos

- Apertura documental de métricas temporales por método.
- Visualización de métricas junto al Tp:
  - Tp/Tc.
  - Duración equivalente = Volumen / Qp.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora permite interpretar mejor la forma temporal de cada hidrograma, diferenciando masa controlada, volumen en escala y respuesta temporal del método.

## Decisión técnica

La mejora es informativa.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Cambio visual validado en Q-5.
- Working tree limpio.

## Dictamen

OT-0026 entrega una lectura temporal más defendible del bloque Q-5 mediante métricas internas por método.