### PR TITLE
OT-0027 — Clasificación temporal de métodos Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0027/OT-0027A_apertura_clasificacion_temporal_metodos_Qt.md
+++ b/00_ADMIN/bitacora/OT-0027/OT-0027A_apertura_clasificacion_temporal_metodos_Qt.md
@@ -1,0 +1,37 @@
+# OT-0027A — Apertura clasificación temporal de métodos Q(t)
+
+## Objetivo
+
+Abrir el frente de clasificación temporal de métodos Q(t), usando las métricas incorporadas en OT-0026 para convertir Tp/Tc en una decisión técnica visible por método.
+
+## Problema
+
+Después de OT-0026, Q-5 muestra métricas temporales como Tp/Tc y duración equivalente. Sin embargo, todavía falta traducir esas métricas en una lectura técnica inmediata por método.
+
+## Tesis
+
+Cada método Q(t) debe exponer un estado temporal comprensible, sin modificar Qp, Tp, Volumen ni Q(t).
+
+## Criterio inicial
+
+- Tp/Tc < 0.50: respuesta rápida.
+- 0.50 <= Tp/Tc <= 1.50: rango temporal razonable.
+- Tp/Tc > 1.50: respuesta retardada.
+- Sin Tc o sin Tp válido: sin referencia temporal.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0027/OT-0027C_cierre_clasificacion_temporal_metodos_Qt.md
+++ b/00_ADMIN/bitacora/OT-0027/OT-0027C_cierre_clasificacion_temporal_metodos_Qt.md
@@ -1,0 +1,66 @@
+# OT-0027C — Cierre clasificación temporal de métodos Q(t)
+
+## Objetivo
+
+Cerrar la OT-0027 consolidando la clasificación temporal de métodos Q(t) en el bloque Q-5 del Comparador Hidrológico Multi-Método.
+
+## Resultado práctico
+
+Se agregó una lectura de estado temporal por método a partir de la relación Tp/Tc.
+
+La clasificación incorporada permite distinguir:
+
+- respuesta rápida;
+- rango temporal razonable;
+- respuesta retardada;
+- sin referencia temporal.
+
+## Criterio aplicado
+
+- Tp/Tc < 0.50: respuesta rápida.
+- 0.50 <= Tp/Tc <= 1.50: rango temporal razonable.
+- Tp/Tc > 1.50: respuesta retardada.
+- Sin Tc o sin Tp válido: sin referencia temporal.
+
+## Decisión técnica
+
+La clasificación es informativa.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio visual fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El cambio fue validado visualmente en Q-5.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0027 convierte las métricas temporales de OT-0026 en una lectura técnica directa por método.
+
+El bloque Q-5 queda con masa controlada, volumen en escala, jerarquía metodológica, métricas temporales y clasificación temporal visible.
+
+## Estado
+
+OT-0027 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -781,6 +781,15 @@ const obtenerResultadoQMetodo = (metodo) => {
     const alertaTcTp =
       tpRel !== null && (tpRel < 0.5 || tpRel > 1.5);
 
+    const estadoTemporal =
+      tpRel === null
+        ? "sin referencia temporal"
+        : tpRel < 0.5
+        ? "respuesta rápida"
+        : tpRel <= 1.5
+        ? "rango temporal razonable"
+        : "respuesta retardada";
+
     return (
       <div>
         <span style={estilos.chip}>
@@ -788,6 +797,9 @@ const obtenerResultadoQMetodo = (metodo) => {
         </span>
         <div style={{ ...estilos.muted, marginTop: "4px" }}>
           Tp/Tc: {tpRel !== null ? tpRel.toFixed(2) + "x" : "—"} · Dur. eq.: {Number.isFinite(resultadoQ.volumen) && Number.isFinite(resultadoQ.Qp) && resultadoQ.Qp > 0 ? (resultadoQ.volumen / resultadoQ.Qp / 60).toFixed(0) + " min" : "—"}
+        </div>
+        <div style={{ ...estilos.muted, marginTop: "4px" }}>
+          Estado temporal: {estadoTemporal}
         </div>
         {alertaTcTp ? (
           <div style={{ ...estilos.muted, marginTop: "4px" }}>
@@ -1271,6 +1283,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0027 — Clasificación temporal de métodos Q(t).

El objetivo fue convertir las métricas temporales incorporadas en OT-0026 en una lectura técnica directa por método dentro del bloque Q-5.

## Cambios incluidos

- Apertura documental de clasificación temporal.
- Clasificación visual por método usando Tp/Tc:
  - respuesta rápida;
  - rango temporal razonable;
  - respuesta retardada;
  - sin referencia temporal.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora muestra, junto al Tp, una lectura temporal más clara:

- Tp/Tc.
- Duración equivalente.
- Estado temporal.

## Decisión técnica

La clasificación es informativa.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Cambio visual validado en Q-5.
- Working tree limpio.

## Dictamen

OT-0027 deja el bloque Q-5 con una lectura temporal más defendible: masa controlada, volumen en escala, métricas temporales y clasificación temporal por método.