### PR TITLE
OT-0028 — Dictamen técnico automático Q-5 por método

### DIFF
--- a/00_ADMIN/bitacora/OT-0028/OT-0028A_apertura_dictamen_tecnico_Q5_metodo.md
+++ b/00_ADMIN/bitacora/OT-0028/OT-0028A_apertura_dictamen_tecnico_Q5_metodo.md
@@ -1,0 +1,38 @@
+# OT-0028A — Apertura dictamen técnico Q-5 por método
+
+## Objetivo
+
+Abrir el frente de dictamen técnico automático por método Q-5, usando la información ya disponible en el Comparador Hidrológico Multi-Método.
+
+## Problema
+
+Después de OT-0020 a OT-0027, Q-5 ya muestra referencia de volumen esperado, semáforo de escala, jerarquía metodológica, métricas temporales y clasificación temporal. Sin embargo, el usuario todavía debe integrar manualmente esa información para interpretar cada método.
+
+## Tesis
+
+Cada método Q-5 debe mostrar una síntesis ejecutiva que traduzca métricas y estados técnicos en una lectura directa y defendible.
+
+## Alcance
+
+- Generar dictamen textual por método.
+- Usar rol metodológico, escala de volumen y estado temporal.
+- No recalcular hidrogramas.
+- No modificar Qp, Tp, Volumen ni Q(t).
+- No modificar motor hidrológico.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0028/OT-0028C_cierre_dictamen_tecnico_Q5_metodo.md
+++ b/00_ADMIN/bitacora/OT-0028/OT-0028C_cierre_dictamen_tecnico_Q5_metodo.md
@@ -1,0 +1,57 @@
+# OT-0028C — Cierre dictamen técnico Q-5 por método
+
+## Objetivo
+
+Cerrar la OT-0028 consolidando la incorporación de dictámenes técnicos automáticos por método en el bloque Q-5 del Comparador Hidrológico Multi-Método.
+
+## Resultado práctico
+
+Se agregó una frase ejecutiva por método Q-5 usando la información ya disponible:
+
+- rol metodológico;
+- escala de volumen;
+- estado temporal;
+- condición comparativa o referencial.
+
+## Decisión técnica
+
+El dictamen es informativo.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio visual fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El cambio fue validado visualmente en Q-5.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0028 convierte las métricas, jerarquía y clasificación temporal acumuladas en una lectura ejecutiva por método.
+
+El bloque Q-5 queda más defendible para revisión técnica: masa controlada, volumen en escala, métricas temporales, clasificación temporal y dictamen por método.
+
+## Estado
+
+OT-0028 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -801,6 +801,19 @@ const obtenerResultadoQMetodo = (metodo) => {
         <div style={{ ...estilos.muted, marginTop: "4px" }}>
           Estado temporal: {estadoTemporal}
         </div>
+        <div style={{ ...estilos.muted, marginTop: "4px" }}>
+          Dictamen Q-5: {metodo.nombre?.includes("SCS Unit")
+            ? `candidato principal; volumen en escala; ${estadoTemporal}.`
+            : metodo.nombre?.includes("SCS Mod")
+            ? `variante ajustable; volumen en escala; ${estadoTemporal}.`
+            : metodo.nombre?.includes("Snyder")
+            ? `comparativo/referencial; volumen en escala; ${estadoTemporal}; requiere justificación técnica.`
+            : metodo.nombre?.includes("Williams")
+            ? `comparativo sensible; volumen en escala; ${estadoTemporal}; revisar concentración del pico.`
+            : metodo.nombre?.includes("Clark")
+            ? `contraste hidrológico; volumen en escala; ${estadoTemporal}; revisar efecto de almacenamiento.`
+            : `método comparativo; ${estadoTemporal}.`}
+        </div>
         {alertaTcTp ? (
           <div style={{ ...estilos.muted, marginTop: "4px" }}>
             ⚠ Alerta Tc/Tp
@@ -1283,6 +1296,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0028 — Dictamen técnico automático Q-5 por método.

El objetivo fue convertir la información técnica acumulada en Q-5 en una frase ejecutiva por método, facilitando la interpretación hidrológica sin modificar el cálculo.

## Cambios incluidos

- Apertura documental del dictamen técnico Q-5.
- Dictamen automático por método en la celda Tp/Q-5.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora muestra una síntesis ejecutiva por método, combinando:

- rol metodológico;
- volumen en escala;
- estado temporal;
- condición comparativa, sensible, principal o referencial.

## Decisión técnica

El dictamen es informativo.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Cambio visual validado en Q-5.
- Working tree limpio.

## Dictamen

OT-0028 deja el bloque Q-5 con lectura ejecutiva por método: masa controlada, volumen en escala, métricas temporales, clasificación temporal y dictamen técnico.