### PR TITLE
OT-0030 — Export técnico Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0030/OT-0030A_apertura_export_tecnico_Q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0030/OT-0030A_apertura_export_tecnico_Q5_auditado.md
@@ -1,0 +1,41 @@
+# OT-0030A — Apertura export técnico Q-5 auditado
+
+## Objetivo
+
+Abrir el frente de export técnico Q-5 auditado, orientado a consolidar en una salida reproducible el estado técnico alcanzado por el bloque Q-5 después de las auditorías de masa, volumen, forma temporal, clasificación y dictamen por método.
+
+## Problema
+
+Q-5 ya contiene una lectura técnica robusta en pantalla, pero todavía no existe una estructura exportable que consolide esa información como evidencia reproducible.
+
+## Tesis
+
+Un resultado hidrológico defendible debe poder exportarse o consolidarse con trazabilidad mínima: qué se calculó, qué se advirtió, qué se clasificó, qué se considera no adoptivo y qué restricciones fueron respetadas.
+
+## Alcance inicial
+
+- Preparar una estructura técnica exportable para Q-5.
+- Consolidar resumen ejecutivo Q-5.
+- Consolidar referencia de volumen esperado.
+- Consolidar estado general no adoptivo.
+- Consolidar jerarquía metodológica.
+- No modificar cálculos.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0030/OT-0030C_cierre_export_tecnico_Q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0030/OT-0030C_cierre_export_tecnico_Q5_auditado.md
@@ -1,0 +1,59 @@
+# OT-0030C — Cierre export técnico Q-5 auditado
+
+## Objetivo
+
+Cerrar la OT-0030 consolidando la primera salida técnica reproducible del bloque Q-5 auditado.
+
+## Resultado práctico
+
+Se agregó un botón para copiar el resumen técnico Q-5 en formato texto/Markdown.
+
+La salida consolida:
+
+- resumen técnico Q-5 post auditoría;
+- estado general diagnóstico no adoptivo;
+- SCS Unit Hydrograph como candidato principal de referencia;
+- SCS Mod. como variante ajustable;
+- Snyder, Williams & Hann y Clark IUH como métodos comparativos/referenciales;
+- masa y volumen controlados;
+- Qp y Tp sujetos a revisión temporal;
+- restricciones técnicas respetadas.
+
+## Decisión técnica
+
+La exportación es informativa y reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0030 convierte el bloque Q-5 auditado en una salida técnica reproducible mediante copia de resumen Markdown, habilitando su uso en informes, bitácoras y expedientes técnicos sin agregar complejidad de PDF o CSV en esta fase.
+
+## Estado
+
+OT-0030 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1267,6 +1267,35 @@ const obtenerResultadoQMetodo = (metodo) => {
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
         Resumen ejecutivo Q-5 post auditoría: SCS Unit Hydrograph queda como candidato principal de referencia; SCS Mod. como variante ajustable; Snyder, Williams & Hann y Clark IUH como comparativos/referenciales. La masa y el volumen están controlados frente a la referencia física; Qp y Tp permanecen sujetos a revisión temporal antes de adopción técnica. Estado general: diagnóstico no adoptivo.
       </div>
+      <button
+        type="button"
+        onClick={() => {
+          const textoResumenQ5 = [
+            "# Resumen técnico Q-5 post auditoría",
+            "",
+            "Estado general: diagnóstico no adoptivo.",
+            "",
+            "Síntesis:",
+            "- SCS Unit Hydrograph: candidato principal de referencia.",
+            "- SCS Mod.: variante ajustable.",
+            "- Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
+            "- Masa y volumen: controlados frente a la referencia física.",
+            "- Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "",
+            "Restricciones:",
+            "- No se usaron caudales externos como fundamento.",
+            "- No se usó SIATA para justificar caudales.",
+            "- No se modifica el motor hidrológico.",
+            "- No se recalculan hidrogramas.",
+            "- No se alteran Qp, Tp, Volumen ni Q(t)."
+          ].join("\n");
+
+          navigator.clipboard?.writeText(textoResumenQ5);
+        }}
+        style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px" }}
+      >
+        Copiar resumen técnico Q-5
+      </button>
       {(() => {
         const areaKm2 = Number(contextoBase?.area_km2);
         const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
@@ -1299,6 +1328,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0030 — Export técnico Q-5 auditado.

El objetivo fue convertir el bloque Q-5 auditado en una salida técnica reproducible mediante copia de resumen técnico en texto/Markdown.

## Cambios incluidos

- Apertura documental del export técnico Q-5.
- Botón para copiar resumen técnico Q-5.
- Cierre técnico de la OT.

## Resultado práctico

Q-5 ahora permite copiar un resumen técnico que consolida:

- Estado general: diagnóstico no adoptivo.
- SCS Unit Hydrograph como candidato principal de referencia.
- SCS Mod. como variante ajustable.
- Snyder, Williams & Hann y Clark IUH como métodos comparativos/referenciales.
- Masa y volumen controlados.
- Qp y Tp sujetos a revisión temporal.
- Restricciones técnicas respetadas.

## Decisión técnica

La exportación es informativa y reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Botón de copia agregado en Q-5.
- Working tree limpio.

## Dictamen

OT-0030 convierte el Q-5 auditado en producto reproducible: una salida técnica copiable para informes, bitácoras y expedientes.