### PR TITLE
OT-0031 — Revisión de Tc altos frente a GT-AS-004

### DIFF
--- a/00_ADMIN/bitacora/OT-0031/OT-0031A_apertura_revision_Tc_altos_GT_AS_004.md
+++ b/00_ADMIN/bitacora/OT-0031/OT-0031A_apertura_revision_Tc_altos_GT_AS_004.md
@@ -1,0 +1,61 @@
+# OT-0031A — Apertura revisión Tc altos frente a GT-AS-004
+
+## Objetivo
+
+Abrir la revisión hidrológica de los tiempos de concentración altos y su relación con la guía GT-AS-004, para diferenciar usos metodológicos de Tc dentro de HidroFlow.
+
+## Problema
+
+HidroFlow muestra varias rutas Tc:
+
+- Tc global del Índice Hidrológico.
+- Tc operativo de Hidrogramas/Q(t).
+- Tc especializado del Comparador.
+- Tc usado en Método Racional.
+- Tc asociado a métodos sintéticos alternativos.
+
+Algunos valores altos pueden provenir de mezclar conceptos: duración de lluvia para almacenamiento/regulación, tiempo de concentración para caudal pico, lag time del hidrograma SCS y métodos alternativos de comparación.
+
+## Marco GT-AS-004
+
+La guía GT-AS-004 orienta el diseño de sistemas de almacenamiento y regulación de aguas lluvias.
+
+Para hidrogramas, la guía prioriza el hidrograma unitario sintético SCS y exige justificación para metodologías alternativas.
+
+Para almacenamiento/regulación, la guía trabaja con hidrogramas post y pre/natural y volumen acumulado asociado a evento de 3 horas.
+
+Para caudal pico de elementos hidráulicos, la guía diferencia el cálculo con duración equivalente al tiempo de concentración o criterio normativo aplicable.
+
+## Tesis
+
+Los Tc altos no deben corregirse por intuición ni por comparación externa. Deben clasificarse según uso hidrológico:
+
+- Tc de intensidad/IDF.
+- Tc de generación Q(t).
+- Tiempo de rezago/forma SCS.
+- Duración de lluvia de almacenamiento.
+- Tc de métodos alternativos.
+
+## Alcance inicial
+
+- Auditar dónde se usa Tc en HidroFlow.
+- Separar Tc de diseño pico, Tc operativo Q(t), lag time y duración 3 h.
+- Identificar si hay ruido conceptual introducido por interpretación de GT-AS-004.
+- No modificar motor en esta fase.
+
+## Restricciones
+
+- No usar caudales externos como fundamento de corrección.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0031/OT-0031B_clasificacion_conceptual_rutas_Tc_GT_AS_004.md
+++ b/00_ADMIN/bitacora/OT-0031/OT-0031B_clasificacion_conceptual_rutas_Tc_GT_AS_004.md
@@ -1,0 +1,83 @@
+# OT-0031B — Clasificación conceptual de rutas Tc frente a GT-AS-004
+
+## Objetivo
+
+Clasificar conceptualmente los diferentes usos de Tc dentro de HidroFlow, para evitar mezclar tiempos de concentración, duración de evento, lag time y referencias especializadas del comparador.
+
+## Evidencia auditada
+
+En ComparadorMultiMetodo.jsx se identificó que Tc_final se calcula mediante seleccionarTc(""hidrograma"", metodosTc, contextoTc).
+
+También se identificó que Q-5 usa Tc_final como referencia para:
+
+- Tp/Tc.
+- alerta Tc/Tp.
+- estado temporal.
+- dictamen Q-5.
+- resumen ejecutivo Q-5.
+
+## Marco GT-AS-004
+
+La guía GT-AS-004 orienta la generación de hidrogramas mediante el hidrograma unitario sintético SCS.
+
+También diferencia el uso de hidrogramas y volumen de almacenamiento/regulación frente al caudal pico de elementos hidráulicos, donde la duración puede asociarse al tiempo de concentración o criterio normativo aplicable.
+
+La guía trabaja el volumen de almacenamiento/regulación con hidrogramas post y pre/natural y evento de 3 horas.
+
+## Clasificación conceptual propuesta
+
+### 1. Tc-IDF / caudal pico
+
+Uso asociado a intensidad de lluvia y caudal pico para elementos hidráulicos.
+
+No debe confundirse automáticamente con la duración total del evento de almacenamiento.
+
+### 2. Tc-Q(t) operativo
+
+Uso interno del módulo Hidrogramas para construir o parametrizar Q(t).
+
+Este Tc puede diferir del Tc global del Índice o del Tc especializado del Comparador.
+
+### 3. Lag / forma SCS
+
+Uso temporal asociado a la forma del hidrograma unitario SCS.
+
+No equivale necesariamente al Tc adoptivo ni a la duración total de lluvia.
+
+### 4. Duración de evento 3 h
+
+Uso asociado a almacenamiento/regulación y volumen acumulado.
+
+No debe interpretarse como Tc de la cuenca.
+
+### 5. Tc especializado del Comparador
+
+Uso derivado de seleccionarTc(""hidrograma"") para evaluar coherencia y referencia técnica en Q-5.
+
+### 6. Tc de métodos alternativos
+
+Uso comparativo o referencial.
+
+No debe desplazar automáticamente la ruta SCS principal sin justificación técnica.
+
+## Dictamen
+
+Los Tc altos no deben corregirse por intuición.
+
+Primero deben ubicarse según su rol hidrológico.
+
+Parte del ruido conceptual observado en HidroFlow proviene de usar valores Tc de rutas distintas como si fueran equivalentes.
+
+## Decisión técnica
+
+No se modifica el motor.
+
+No se modifican fórmulas.
+
+No se altera Qp, Tp, Volumen ni Q(t).
+
+Esta OT documenta la clasificación conceptual necesaria para futuras decisiones de cálculo.
+
+## Estado
+
+Diagnóstico documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0031/OT-0031C_cierre_revision_Tc_altos_GT_AS_004.md
+++ b/00_ADMIN/bitacora/OT-0031/OT-0031C_cierre_revision_Tc_altos_GT_AS_004.md
@@ -1,0 +1,55 @@
+# OT-0031C — Cierre revisión Tc altos frente a GT-AS-004
+
+## Objetivo
+
+Cerrar la OT-0031 consolidando la revisión conceptual de los tiempos de concentración altos frente al marco metodológico de GT-AS-004.
+
+## Resultado
+
+Se clasificaron las principales rutas Tc visibles en HidroFlow:
+
+- Tc-IDF / caudal pico.
+- Tc-Q(t) operativo.
+- Lag / forma SCS.
+- Duración de evento 3 h.
+- Tc especializado del Comparador.
+- Tc de métodos alternativos.
+
+## Marco técnico
+
+GT-AS-004 diferencia usos hidrológicos que no deben confundirse:
+
+- generación de hidrogramas mediante SCS;
+- volumen de almacenamiento/regulación asociado a hidrogramas post y pre/natural;
+- evento de 3 horas para almacenamiento/regulación;
+- caudal pico de elementos hidráulicos asociado a duración equivalente al Tc o criterio normativo aplicable;
+- metodologías alternativas sujetas a justificación técnica.
+
+## Decisión técnica
+
+No se corrigen los Tc altos en esta OT.
+
+La acción correcta fue clasificar los Tc según su rol hidrológico antes de modificar cualquier cálculo.
+
+## Restricciones respetadas
+
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0031 reduce el ruido conceptual asociado a Tc altos: HidroFlow debe distinguir entre Tc de intensidad/caudal pico, Tc operativo de Q(t), lag SCS, duración de evento para almacenamiento y Tc especializado/comparativo.
+
+Esta clasificación queda como base para futuras decisiones funcionales o visuales sobre tiempos hidrológicos.
+
+## Estado
+
+OT-0031 lista para PR.


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0031 — Revisión de Tc altos frente a GT-AS-004.

El objetivo fue clasificar conceptualmente las rutas Tc visibles en HidroFlow para evitar mezclar tiempo de concentración, duración de evento, lag SCS, Tc operativo Q(t) y Tc especializado del Comparador.

## Cambios incluidos

- Apertura documental de revisión Tc altos frente a GT-AS-004.
- Clasificación conceptual de rutas Tc.
- Cierre técnico de la OT.

## Resultado

Se documentan las rutas Tc principales:

- Tc-IDF / caudal pico.
- Tc-Q(t) operativo.
- Lag / forma SCS.
- Duración de evento 3 h.
- Tc especializado del Comparador.
- Tc de métodos alternativos.

## Decisión técnica

No se corrigen Tc altos en esta OT.

La OT establece primero el marco conceptual para que futuras decisiones funcionales no mezclen usos hidrológicos distintos.

## Restricciones respetadas

- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0031 reduce el ruido conceptual asociado a Tc altos y deja una base clara para futuras decisiones sobre tiempos hidrológicos en HidroFlow.