### PR TITLE
OT-0033 — Expediente hidrológico mínimo de cuenca activa

### DIFF
--- a/00_ADMIN/bitacora/OT-0033/OT-0033A_apertura_expediente_hidrologico_minimo_cuenca.md
+++ b/00_ADMIN/bitacora/OT-0033/OT-0033A_apertura_expediente_hidrologico_minimo_cuenca.md
@@ -1,0 +1,37 @@
+# OT-0033A — Apertura expediente hidrológico mínimo de cuenca activa
+
+## Objetivo
+
+Abrir el frente de expediente hidrológico mínimo de cuenca activa, orientado a consolidar en una salida reproducible la lectura hidrológica principal de HidroFlow.
+
+## Visión
+
+El usuario debe poder aportar coordenadas o seleccionar una cuenca activa, y recibir no solo números, sino una lectura hidrológica trazable, defendible y exportable.
+
+## Alcance inicial
+
+- Auditar datos disponibles de cuenca activa.
+- Auditar datos disponibles del Índice Hidrológico.
+- Auditar datos disponibles de roles Tc.
+- Auditar datos disponibles del resumen Q-5 auditado.
+- Preparar una salida mínima tipo expediente técnico.
+- No modificar motor.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0033/OT-0033C_cierre_expediente_hidrologico_minimo_cuenca.md
+++ b/00_ADMIN/bitacora/OT-0033/OT-0033C_cierre_expediente_hidrologico_minimo_cuenca.md
@@ -1,0 +1,70 @@
+# OT-0033C — Cierre expediente hidrológico mínimo de cuenca activa
+
+## Objetivo
+
+Cerrar la OT-0033 consolidando la primera salida de expediente hidrológico mínimo de cuenca activa en HidroFlow.
+
+## Resultado práctico
+
+Se incorporó un botón para copiar el expediente hidrológico mínimo desde el Comparador Hidrológico Multi-Método.
+
+El expediente consolida:
+
+- identificación de la cuenca activa;
+- área de cuenca;
+- fuente de contexto;
+- CN, CN base, CN efectivo y AMC;
+- Tc del comparador;
+- roles Tc;
+- lluvia efectiva total;
+- volumen esperado;
+- resumen Q-5 auditado;
+- restricciones técnicas respetadas.
+
+## Botones disponibles
+
+El bloque Q-5 ahora cuenta con dos salidas reproducibles:
+
+- Copiar resumen técnico Q-5.
+- Copiar expediente hidrológico mínimo.
+
+## Decisión técnica
+
+La salida es informativa y reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El botón Copiar expediente hidrológico mínimo fue validado visualmente en el Comparador Q-5.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0033 convierte la lectura hidrológica auditada en un expediente mínimo copiable, acercando HidroFlow a la visión de producto: cuenca activa, parámetros hidrológicos, roles Tc, volumen esperado, Q-5 auditado y restricciones técnicas en una salida reproducible.
+
+## Estado
+
+OT-0033 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1296,6 +1296,66 @@ const obtenerResultadoQMetodo = (metodo) => {
       >
         Copiar resumen técnico Q-5
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          const areaKm2 = Number(contextoBase?.area_km2);
+          const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
+          const volumenEsperadoM3 =
+            Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
+              ? areaKm2 * peTotalMm * 1000
+              : null;
+
+          const textoExpediente = [
+            "# Expediente hidrológico mínimo — Cuenca activa",
+            "",
+            "## 1. Identificación",
+            `Cuenca: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}`,
+            `Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`,
+            `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
+            "",
+            "## 2. Parámetros hidrológicos base",
+            `CN: ${contextoBase?.CN ?? "—"}`,
+            `CN base: ${contextoBase?.CN_base ?? "—"}`,
+            `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,
+            `AMC: ${contextoBase?.AMC ?? "—"}`,
+            "",
+            "## 3. Tiempo de concentración y roles Tc",
+            `Tc comparador: ${Tc_final !== null && Tc_final !== undefined ? Number(Tc_final).toFixed(1) + " min" : "—"}`,
+            "Roles Tc:",
+            "- Tc global Índice: referencia hidrológica general.",
+            "- Tc operativo Q(t): ruta interna del hidrograma.",
+            "- Duración evento: 3 h para almacenamiento/regulación.",
+            "- Lag / forma SCS: parámetro derivado para forma temporal.",
+            "- Tc comparador: referencia especializada para coherencia Q-5.",
+            "",
+            "## 4. Volumen de referencia",
+            `Lluvia efectiva total: ${Number.isFinite(peTotalMm) ? peTotalMm.toFixed(2) + " mm" : "—"}`,
+            `Volumen esperado: ${volumenEsperadoM3 ? volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 }) + " m³" : "—"}`,
+            "Fórmula: Pe(mm) × Área(km²) × 1000.",
+            "",
+            "## 5. Resumen Q-5 auditado",
+            "Estado general: diagnóstico no adoptivo.",
+            "SCS Unit Hydrograph: candidato principal de referencia.",
+            "SCS Mod.: variante ajustable.",
+            "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
+            "Masa y volumen: controlados frente a referencia física.",
+            "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "",
+            "## 6. Restricciones técnicas",
+            "- No se usan caudales externos como fundamento.",
+            "- SIATA no se usa para justificar caudales.",
+            "- No se modifica el motor hidrológico.",
+            "- No se recalculan hidrogramas en este expediente.",
+            "- No se alteran Qp, Tp, Volumen ni Q(t)."
+          ].join("\n");
+
+          navigator.clipboard?.writeText(textoExpediente);
+        }}
+        style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px", marginLeft: "8px" }}
+      >
+        Copiar expediente hidrológico mínimo
+      </button>
       {(() => {
         const areaKm2 = Number(contextoBase?.area_km2);
         const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
@@ -1328,6 +1388,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0033 — Expediente hidrológico mínimo de cuenca activa.

El objetivo fue consolidar en una salida reproducible la lectura hidrológica principal de HidroFlow para la cuenca activa.

## Cambios incluidos

- Apertura documental del expediente hidrológico mínimo.
- Botón para copiar expediente hidrológico mínimo desde el Comparador Q-5.
- Cierre técnico de la OT.

## Resultado práctico

El Comparador Q-5 ahora permite copiar:

- resumen técnico Q-5;
- expediente hidrológico mínimo.

El expediente consolida:

- identificación de cuenca;
- área;
- CN, CN base, CN efectivo y AMC;
- Tc del comparador;
- roles Tc;
- lluvia efectiva total;
- volumen esperado;
- resumen Q-5 auditado;
- restricciones técnicas respetadas.

## Decisión técnica

La salida es informativa y reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Botón Copiar expediente hidrológico mínimo validado visualmente.
- Working tree limpio.

## Dictamen

OT-0033 convierte la lectura hidrológica auditada en expediente mínimo copiable, acercando HidroFlow a una salida técnica reproducible de cuenca activa.