### PR TITLE
OT-0034 — Expediente mínimo con datos reales

### DIFF
--- a/00_ADMIN/bitacora/OT-0034/OT-0034A_apertura_expediente_minimo_datos_reales.md
+++ b/00_ADMIN/bitacora/OT-0034/OT-0034A_apertura_expediente_minimo_datos_reales.md
@@ -1,0 +1,37 @@
+# OT-0034A — Apertura poblar expediente mínimo con datos reales
+
+## Objetivo
+
+Abrir el frente para poblar el expediente hidrológico mínimo con datos reales disponibles de la cuenca activa y del contexto hidrológico de HidroFlow.
+
+## Problema
+
+OT-0033 incorporó el botón para copiar el expediente hidrológico mínimo, pero la salida debe validarse y enriquecerse para evitar campos vacíos, genéricos o insuficientes.
+
+## Tesis
+
+El expediente mínimo debe consolidar datos reales ya disponibles en HidroFlow, sin recalcular ni modificar el motor.
+
+## Alcance
+
+- Publicar estación IDF en el contexto del Comparador.
+- Incluir pendiente media y longitud de cauce cuando estén disponibles.
+- Enriquecer el texto copiado del expediente mínimo.
+- Mantener intactos Qp, Tp, Volumen y Q(t).
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0034/OT-0034C_cierre_expediente_minimo_datos_reales.md
+++ b/00_ADMIN/bitacora/OT-0034/OT-0034C_cierre_expediente_minimo_datos_reales.md
@@ -1,0 +1,62 @@
+# OT-0034C — Cierre expediente mínimo con datos reales
+
+## Objetivo
+
+Cerrar la OT-0034 consolidando el enriquecimiento del expediente hidrológico mínimo con datos reales disponibles de la cuenca activa y del contexto hidrológico de HidroFlow.
+
+## Resultado práctico
+
+El expediente hidrológico mínimo copiable fue enriquecido con:
+
+- estación IDF;
+- pendiente media;
+- longitud de cauce principal;
+- datos de cuenca activa;
+- CN, CN base, CN efectivo y AMC;
+- Tc del comparador;
+- roles Tc;
+- lluvia efectiva total;
+- volumen esperado;
+- resumen Q-5 auditado;
+- restricciones técnicas respetadas.
+
+## Decisión técnica
+
+La mejora es informativa y reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio fue aplicado sobre HidroFlow.jsx y ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El expediente mínimo fue enriquecido con campos reales disponibles en el contexto.
+
+El working tree quedó limpio después del push.
+
+## Dictamen
+
+OT-0034 convierte el expediente hidrológico mínimo de una estructura inicial copiable a una salida más útil, poblada con datos reales de cuenca activa y contexto hidrológico.
+
+## Estado
+
+OT-0034 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2169,6 +2169,7 @@ const leerT = (punto, indice) => {
   onContextoComparador((previo) => ({
     ...(previo ?? {}),
     fuente: "motor HidroFlow",
+    estacion_idf: name ?? null,
     lluvia_efectiva: Boolean(lluvEfect),
     lluvia_efectiva_total_mm: lluviaEfectivaTotalMm,
     hidrogramas: hidrogramasResumen,
@@ -3506,6 +3507,7 @@ useEffect(() => {
 
   onContextoComparador({
     fuente: "motor HidroFlow",
+    estacion_idf: stn,
 
     cuencaNombre:
       params?.nombreCuenca ??
@@ -3552,7 +3554,7 @@ useEffect(() => {
     hidrogramas: [],
     hidrograma_principal: null,
   });
-}, [onContextoComparador, params]);
+}, [onContextoComparador, params, stn]);
 // Publicación base Tc para despertar el Índice Hidrológico global.
 // No reemplaza el estado especializado publicado por ComparadorMultiMetodo.
 useEffect(() => {
@@ -3725,6 +3727,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1313,6 +1313,9 @@ const obtenerResultadoQMetodo = (metodo) => {
             `Cuenca: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}`,
             `Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`,
             `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
+            `Estación IDF: ${contextoBase?.estacion_idf ?? contextoBase?.estacionIDF ?? "—"}`,
+            `Pendiente media: ${Number.isFinite(Number(contextoBase?.pendiente_media_pct)) ? Number(contextoBase.pendiente_media_pct).toFixed(2) + " %" : "—"}`,
+            `Longitud cauce principal: ${Number.isFinite(Number(contextoBase?.longitud_cauce_km)) ? Number(contextoBase.longitud_cauce_km).toFixed(3) + " km" : "—"}`,
             "",
             "## 2. Parámetros hidrológicos base",
             `CN: ${contextoBase?.CN ?? "—"}`,
@@ -1388,6 +1391,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0034 — Expediente mínimo con datos reales.

El objetivo fue enriquecer el expediente hidrológico mínimo copiable con datos reales disponibles de la cuenca activa y del contexto hidrológico de HidroFlow.

## Cambios incluidos

- Apertura documental del enriquecimiento del expediente mínimo.
- Publicación de estación IDF hacia el contexto del Comparador.
- Inclusión de estación IDF, pendiente media y longitud de cauce principal en el expediente copiable.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo ahora consolida:

- cuenca activa;
- área;
- fuente de contexto;
- estación IDF;
- pendiente media;
- longitud de cauce principal;
- CN, CN base, CN efectivo y AMC;
- Tc del comparador;
- roles Tc;
- lluvia efectiva total;
- volumen esperado;
- resumen Q-5 auditado;
- restricciones técnicas respetadas.

## Decisión técnica

La salida es informativa y reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Campos reales incorporados al expediente mínimo.
- Working tree limpio.

## Dictamen

OT-0034 convierte el expediente hidrológico mínimo en una salida más útil y trazable, poblada con datos reales disponibles de la cuenca activa.