### PR TITLE
OT-0035 — Validación expediente copiado

### DIFF
--- a/00_ADMIN/bitacora/OT-0035/OT-0035A_apertura_validacion_expediente_copiado.md
+++ b/00_ADMIN/bitacora/OT-0035/OT-0035A_apertura_validacion_expediente_copiado.md
@@ -1,0 +1,31 @@
+# OT-0035A — Apertura validación del expediente copiado
+
+## Objetivo
+
+Abrir la validación del expediente hidrológico mínimo copiado desde HidroFlow, verificando que la salida contenga datos reales, estructura completa y ausencia de campos críticos vacíos.
+
+## Problema
+
+OT-0034 enriqueció el expediente hidrológico mínimo con datos reales disponibles. Ahora debe validarse el contenido copiado para asegurar que sea útil como evidencia técnica reproducible.
+
+## Alcance
+
+- Capturar el contenido copiado desde el botón Copiar expediente hidrológico mínimo.
+- Verificar secciones obligatorias.
+- Detectar campos críticos vacíos, null, undefined, NaN o marcadores no resueltos.
+- No modificar cálculos.
+- No modificar motor.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0035/OT-0035C_cierre_validacion_expediente_copiado.md
+++ b/00_ADMIN/bitacora/OT-0035/OT-0035C_cierre_validacion_expediente_copiado.md
@@ -1,0 +1,89 @@
+# OT-0035C — Cierre validación expediente copiado
+
+## Objetivo
+
+Cerrar la OT-0035 consolidando la validación del expediente hidrológico mínimo copiado desde HidroFlow.
+
+## Resultado práctico
+
+Se validó que el botón Copiar expediente hidrológico mínimo genera contenido real en el portapapeles.
+
+El expediente copiado contiene las secciones obligatorias:
+
+- Expediente hidrológico mínimo.
+- Identificación.
+- Parámetros hidrológicos base.
+- Tiempo de concentración y roles Tc.
+- Volumen de referencia.
+- Resumen Q-5 auditado.
+- Restricciones técnicas.
+
+## Campos críticos validados
+
+La validación confirmó presencia de:
+
+- Cuenca.
+- Área.
+- Fuente de contexto.
+- Estación IDF.
+- Pendiente media.
+- Longitud cauce principal.
+- CN.
+- CN base.
+- CN efectivo.
+- AMC.
+- Tc comparador.
+- Lluvia efectiva total.
+- Volumen esperado.
+
+## Patrones problemáticos
+
+La validación confirmó ausencia de:
+
+- undefined.
+- null.
+- NaN.
+- [object Object].
+
+## Corrección aplicada
+
+Se corrigió el flujo de copia del expediente para garantizar copia real al portapapeles mediante mecanismo robusto basado en textarea temporal y document.execCommand.
+
+## Decisión técnica
+
+La validación es de producto reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El botón fue validado visualmente en navegador.
+
+La salida copiada fue validada con el verificador local vexp.
+
+El working tree quedó limpio después de los commits funcionales.
+
+## Dictamen
+
+OT-0035 confirma que el expediente hidrológico mínimo no solo está pintado en la interfaz, sino que puede copiarse como salida técnica reproducible con campos críticos presentes y sin valores problemáticos.
+
+## Estado
+
+OT-0035 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1353,7 +1353,43 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se alteran Qp, Tp, Volumen ni Q(t)."
           ].join("\n");
 
-          navigator.clipboard?.writeText(textoExpediente);
+          const copiarPorTextarea = () => {
+            const areaTexto = document.createElement("textarea");
+            areaTexto.value = textoExpediente;
+            areaTexto.setAttribute("readonly", "");
+            areaTexto.style.position = "fixed";
+            areaTexto.style.left = "-9999px";
+            areaTexto.style.top = "-9999px";
+            document.body.appendChild(areaTexto);
+            areaTexto.select();
+
+            let copiado = false;
+
+            try {
+              copiado = document.execCommand("copy");
+            } catch {
+              copiado = false;
+            }
+
+            document.body.removeChild(areaTexto);
+            return copiado;
+          };
+
+          if (navigator.clipboard?.writeText) {
+            navigator.clipboard.writeText(textoExpediente).then(() => {
+              window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+            }).catch(() => {
+              if (copiarPorTextarea()) {
+                window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+              } else {
+                window.prompt("Copie manualmente el expediente hidrológico mínimo:", textoExpediente);
+              }
+            });
+          } else if (copiarPorTextarea()) {
+            window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+          } else {
+            window.prompt("Copie manualmente el expediente hidrológico mínimo:", textoExpediente);
+          }
         }}
         style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px", marginLeft: "8px" }}
       >
@@ -1391,6 +1427,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1353,44 +1353,31 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se alteran Qp, Tp, Volumen ni Q(t)."
           ].join("\n");
 
-          const copiarPorTextarea = () => {
-            const areaTexto = document.createElement("textarea");
-            areaTexto.value = textoExpediente;
-            areaTexto.setAttribute("readonly", "");
-            areaTexto.style.position = "fixed";
-            areaTexto.style.left = "-9999px";
-            areaTexto.style.top = "-9999px";
-            document.body.appendChild(areaTexto);
-            areaTexto.select();
+          const areaTexto = document.createElement("textarea");
+          areaTexto.value = textoExpediente;
+          areaTexto.setAttribute("readonly", "");
+          areaTexto.style.position = "fixed";
+          areaTexto.style.left = "-9999px";
+          areaTexto.style.top = "-9999px";
+          document.body.appendChild(areaTexto);
+          areaTexto.focus();
+          areaTexto.select();
 
-            let copiado = false;
+          let copiado = false;
 
-            try {
-              copiado = document.execCommand("copy");
-            } catch {
-              copiado = false;
-            }
-
-            document.body.removeChild(areaTexto);
-            return copiado;
-          };
-
-          if (navigator.clipboard?.writeText) {
-            navigator.clipboard.writeText(textoExpediente).then(() => {
-              window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
-            }).catch(() => {
-              if (copiarPorTextarea()) {
-                window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
-              } else {
-                window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
-              }
-            });
-          } else if (copiarPorTextarea()) {
-            window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
-          } else {
-            window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
+          try {
+            copiado = document.execCommand("copy");
+          } catch {
+            copiado = false;
           }
-        }}
+
+          document.body.removeChild(areaTexto);
+
+          if (copiado) {
+            window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+          } else {
+            window.prompt("No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:", textoExpediente);
+          }        }}
         style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px", marginLeft: "8px" }}
       >
         Copiar expediente hidrológico mínimo
@@ -1427,6 +1414,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1377,18 +1377,18 @@ const obtenerResultadoQMetodo = (metodo) => {
 
           if (navigator.clipboard?.writeText) {
             navigator.clipboard.writeText(textoExpediente).then(() => {
-              window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+              window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
             }).catch(() => {
               if (copiarPorTextarea()) {
-                window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+                window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
               } else {
-                window.prompt("Copie manualmente el expediente hidrológico mínimo:", textoExpediente);
+                window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
               }
             });
           } else if (copiarPorTextarea()) {
-            window.alert("Expediente hidrológico mínimo copiado al portapapeles.");
+            window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
           } else {
-            window.prompt("Copie manualmente el expediente hidrológico mínimo:", textoExpediente);
+            window.prompt("Expediente hidrológico mínimo generado. Copie manualmente el texto:", textoExpediente);
           }
         }}
         style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px", marginLeft: "8px" }}
@@ -1427,6 +1427,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0035 — Validación expediente copiado.

El objetivo fue validar que el botón Copiar expediente hidrológico mínimo genere una salida técnica reproducible, completa y sin campos problemáticos.

## Cambios incluidos

- Apertura documental de validación del expediente copiado.
- Corrección del mecanismo de copia del expediente al portapapeles.
- Validación del expediente copiado mediante verificador local.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo copiado contiene:

- identificación;
- parámetros hidrológicos base;
- tiempo de concentración y roles Tc;
- volumen de referencia;
- resumen Q-5 auditado;
- restricciones técnicas.

## Validación

Se verificó presencia de campos críticos:

- Cuenca.
- Área.
- Fuente de contexto.
- Estación IDF.
- Pendiente media.
- Longitud cauce principal.
- CN.
- CN base.
- CN efectivo.
- AMC.
- Tc comparador.
- Lluvia efectiva total.
- Volumen esperado.

También se confirmó ausencia de:

- undefined.
- null.
- NaN.
- [object Object].

## Decisión técnica

La mejora es de producto reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0035 confirma que HidroFlow ya puede entregar un expediente hidrológico mínimo copiable, validado y reproducible.