### PR TITLE
OT-0036 — Tabla Q-5 en expediente hidrológico mínimo

### DIFF
--- a/00_ADMIN/bitacora/OT-0036/OT-0036A_apertura_tabla_Q5_expediente.md
+++ b/00_ADMIN/bitacora/OT-0036/OT-0036A_apertura_tabla_Q5_expediente.md
@@ -1,0 +1,37 @@
+# OT-0036A — Apertura tabla Q-5 en expediente hidrológico mínimo
+
+## Objetivo
+
+Abrir el frente para incorporar una tabla Q-5 resumida dentro del expediente hidrológico mínimo copiado desde HidroFlow.
+
+## Problema
+
+OT-0035 validó que el expediente hidrológico mínimo se copia correctamente y contiene campos críticos completos. Sin embargo, el expediente todavía resume Q-5 de forma textual y no incluye una tabla compacta por método.
+
+## Objetivo práctico
+
+Agregar al expediente copiado una tabla resumida Q-5 con:
+
+- método;
+- Qp;
+- Tp;
+- Volumen;
+- estado temporal;
+- dictamen técnico.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0036/OT-0036C_cierre_tabla_Q5_expediente.md
+++ b/00_ADMIN/bitacora/OT-0036/OT-0036C_cierre_tabla_Q5_expediente.md
@@ -1,0 +1,57 @@
+# OT-0036C — Cierre tabla Q-5 en expediente hidrológico mínimo
+
+## Objetivo
+
+Cerrar la OT-0036 consolidando la incorporación de una tabla Q-5 auditada dentro del expediente hidrológico mínimo copiado desde HidroFlow.
+
+## Resultado práctico
+
+El expediente hidrológico mínimo ahora incluye una tabla Q-5 resumida por método con:
+
+- Método.
+- Qp.
+- Tp.
+- Volumen.
+- Estado temporal.
+- Dictamen técnico.
+
+## Decisión técnica
+
+La tabla es informativa y reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El cambio fue aplicado sobre ComparadorMultiMetodo.jsx.
+
+El build fue aprobado antes del commit funcional.
+
+El working tree quedó limpio después del push.
+
+La tabla Q-5 queda incorporada al expediente mínimo copiable.
+
+## Dictamen
+
+OT-0036 mejora el expediente hidrológico mínimo al incluir una tabla técnica Q-5 auditada por método, fortaleciendo la trazabilidad y utilidad del expediente como salida reproducible.
+
+## Estado
+
+OT-0036 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1306,6 +1306,59 @@ const obtenerResultadoQMetodo = (metodo) => {
               ? areaKm2 * peTotalMm * 1000
               : null;
 
+          const formatearNumeroExpediente = (valor, decimales = 2) =>
+            Number.isFinite(Number(valor))
+              ? Number(valor).toLocaleString("es-CO", {
+                  minimumFractionDigits: decimales,
+                  maximumFractionDigits: decimales
+                })
+              : "—";
+
+          const obtenerEstadoTemporalExpediente = (resultadoQ) => {
+            const tcReferencia = Number(Tc_final);
+            const tpRel =
+              Number.isFinite(resultadoQ?.Tp) &&
+              Number.isFinite(tcReferencia) &&
+              tcReferencia > 0
+                ? resultadoQ.Tp / tcReferencia
+                : null;
+
+            return tpRel === null
+              ? "sin referencia temporal"
+              : tpRel < 0.5
+              ? "respuesta rápida"
+              : tpRel <= 1.5
+              ? "rango temporal razonable"
+              : "respuesta retardada";
+          };
+
+          const obtenerDictamenQ5Expediente = (metodo, estadoTemporal) =>
+            metodo.nombre?.includes("SCS Unit")
+              ? `candidato principal; volumen en escala; ${estadoTemporal}.`
+              : metodo.nombre?.includes("SCS Mod")
+              ? `variante ajustable; volumen en escala; ${estadoTemporal}.`
+              : metodo.nombre?.includes("Snyder")
+              ? `comparativo/referencial; volumen en escala; ${estadoTemporal}; requiere justificación técnica.`
+              : metodo.nombre?.includes("Williams")
+              ? `comparativo sensible; volumen en escala; ${estadoTemporal}; revisar concentración del pico.`
+              : metodo.nombre?.includes("Clark")
+              ? `contraste hidrológico; volumen en escala; ${estadoTemporal}; revisar efecto de almacenamiento.`
+              : `método comparativo; ${estadoTemporal}.`;
+
+          const metodosQ5Expediente = metodos.filter((metodo) => metodo.tipo === "q");
+
+          const tablaQ5Markdown = [
+            "| Método | Qp | Tp | Volumen | Estado temporal | Dictamen |",
+            "|---|---:|---:|---:|---|---|",
+            ...metodosQ5Expediente.map((metodo) => {
+              const resultadoQ = obtenerResultadoQMetodo(metodo);
+              const estadoTemporal = obtenerEstadoTemporalExpediente(resultadoQ);
+              const dictamen = obtenerDictamenQ5Expediente(metodo, estadoTemporal);
+              const nombreMetodo = String(metodo.nombre ?? "Método Q-5").replaceAll("|", "/");
+
+              return `| ${nombreMetodo} | ${formatearNumeroExpediente(resultadoQ?.Qp)} m³/s | ${formatearNumeroExpediente(resultadoQ?.Tp)} min | ${formatearNumeroExpediente(resultadoQ?.volumen)} m³ | ${estadoTemporal} | ${dictamen} |`;
+            })
+          ];
           const textoExpediente = [
             "# Expediente hidrológico mínimo — Cuenca activa",
             "",
@@ -1344,6 +1397,9 @@ const obtenerResultadoQMetodo = (metodo) => {
             "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
             "Masa y volumen: controlados frente a referencia física.",
             "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "",
+            "Tabla Q-5 auditada:",
+            ...tablaQ5Markdown,
             "",
             "## 6. Restricciones técnicas",
             "- No se usan caudales externos como fundamento.",
@@ -1414,6 +1470,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0036 — Tabla Q-5 en expediente hidrológico mínimo.

El objetivo fue incorporar una tabla Q-5 auditada dentro del expediente hidrológico mínimo copiable.

## Cambios incluidos

- Apertura documental de tabla Q-5 en expediente.
- Tabla Q-5 resumida dentro del expediente copiado.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo ahora incluye una tabla Q-5 con:

- Método.
- Qp.
- Tp.
- Volumen.
- Estado temporal.
- Dictamen técnico.

## Decisión técnica

La tabla es informativa y reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Tabla Q-5 agregada al expediente copiable.
- Working tree limpio.

## Dictamen

OT-0036 fortalece el expediente mínimo como salida técnica reproducible al incorporar una tabla Q-5 auditada por método.