### PR TITLE
OT-0037 — Validación resumen técnico Q-5 copiado

### DIFF
--- a/00_ADMIN/bitacora/OT-0037/OT-0037A_apertura_validacion_resumen_tecnico_Q5.md
+++ b/00_ADMIN/bitacora/OT-0037/OT-0037A_apertura_validacion_resumen_tecnico_Q5.md
@@ -1,0 +1,31 @@
+# OT-0037A — Apertura validación resumen técnico Q-5 copiado
+
+## Objetivo
+
+Abrir la validación del resumen técnico Q-5 copiado desde HidroFlow, verificando que la salida sea reproducible, completa y sin campos problemáticos.
+
+## Problema
+
+OT-0030 incorporó el botón Copiar resumen técnico Q-5. Después de validar el expediente hidrológico mínimo en OT-0035 y enriquecerlo con tabla Q-5 en OT-0036, corresponde validar también el resumen técnico Q-5 como salida independiente.
+
+## Alcance
+
+- Validar contenido copiado desde el botón Copiar resumen técnico Q-5.
+- Verificar secciones y frases técnicas obligatorias.
+- Detectar undefined, null, NaN o [object Object].
+- No modificar cálculos.
+- No modificar motor.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0037/OT-0037C_cierre_validacion_resumen_tecnico_Q5.md
+++ b/00_ADMIN/bitacora/OT-0037/OT-0037C_cierre_validacion_resumen_tecnico_Q5.md
@@ -1,0 +1,73 @@
+# OT-0037C — Cierre validación resumen técnico Q-5 copiado
+
+## Objetivo
+
+Cerrar la OT-0037 consolidando la validación del resumen técnico Q-5 copiado desde HidroFlow.
+
+## Resultado práctico
+
+Se validó que el botón Copiar resumen técnico Q-5 genera contenido real en el portapapeles.
+
+El resumen técnico copiado contiene:
+
+- encabezado de resumen técnico Q-5 post auditoría;
+- estado general diagnóstico no adoptivo;
+- síntesis técnica;
+- SCS Unit Hydrograph como candidato principal de referencia;
+- SCS Mod. como variante ajustable;
+- Snyder, Williams & Hann y Clark IUH como métodos comparativos o referenciales;
+- masa y volumen controlados frente a la referencia física;
+- Qp y Tp sujetos a revisión temporal antes de adopción técnica;
+- restricciones técnicas respetadas.
+
+## Patrones problemáticos
+
+La validación confirmó ausencia de:
+
+- undefined.
+- null.
+- NaN.
+- [object Object].
+
+## Corrección aplicada
+
+Se corrigió el flujo de copia del resumen técnico Q-5 para garantizar copia real al portapapeles mediante textarea temporal y document.execCommand.
+
+## Decisión técnica
+
+La validación es de producto reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Validación
+
+El botón fue validado visualmente en navegador.
+
+La salida copiada fue validada con el verificador local vq5.
+
+El working tree quedó limpio después del commit funcional.
+
+## Dictamen
+
+OT-0037 confirma que el resumen técnico Q-5 no solo está visible en la interfaz, sino que puede copiarse como salida técnica reproducible, completa y sin valores problemáticos.
+
+## Estado
+
+OT-0037 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1290,7 +1290,31 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se alteran Qp, Tp, Volumen ni Q(t)."
           ].join("\n");
 
-          navigator.clipboard?.writeText(textoResumenQ5);
+          const areaTextoResumen = document.createElement("textarea");
+          areaTextoResumen.value = textoResumenQ5;
+          areaTextoResumen.setAttribute("readonly", "");
+          areaTextoResumen.style.position = "fixed";
+          areaTextoResumen.style.left = "-9999px";
+          areaTextoResumen.style.top = "-9999px";
+          document.body.appendChild(areaTextoResumen);
+          areaTextoResumen.focus();
+          areaTextoResumen.select();
+
+          let resumenCopiado = false;
+
+          try {
+            resumenCopiado = document.execCommand("copy");
+          } catch {
+            resumenCopiado = false;
+          }
+
+          document.body.removeChild(areaTextoResumen);
+
+          if (resumenCopiado) {
+            window.alert("Resumen técnico Q-5 copiado al portapapeles.");
+          } else {
+            window.prompt("No fue posible copiar automáticamente. Copie manualmente el resumen técnico Q-5:", textoResumenQ5);
+          }
         }}
         style={{ ...estilos.chip, cursor: "pointer", marginBottom: "10px" }}
       >
@@ -1470,6 +1494,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0037 — Validación resumen técnico Q-5 copiado.

El objetivo fue validar que el botón Copiar resumen técnico Q-5 genere una salida técnica reproducible, completa y sin campos problemáticos.

## Cambios incluidos

- Apertura documental de validación del resumen técnico Q-5.
- Corrección del mecanismo de copia del resumen técnico al portapapeles.
- Validación del contenido copiado mediante verificador local.
- Cierre técnico de la OT.

## Resultado práctico

El resumen técnico Q-5 copiado contiene:

- Estado general: diagnóstico no adoptivo.
- SCS Unit Hydrograph como candidato principal de referencia.
- SCS Mod. como variante ajustable.
- Snyder, Williams & Hann y Clark IUH como métodos comparativos/referenciales.
- Masa y volumen controlados frente a la referencia física.
- Qp y Tp sujetos a revisión temporal.
- Restricciones técnicas respetadas.

## Validación

Se confirmó ausencia de:

- undefined.
- null.
- NaN.
- [object Object].

## Decisión técnica

La mejora es de producto reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0037 confirma que HidroFlow ya puede entregar dos salidas reproducibles validadas: el expediente hidrológico mínimo y el resumen técnico Q-5.