### PR TITLE
OT-0038 — Coherencia entre salidas reproducibles Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0038/OT-0038A_apertura_coherencia_salidas_reproducibles_Q5.md
+++ b/00_ADMIN/bitacora/OT-0038/OT-0038A_apertura_coherencia_salidas_reproducibles_Q5.md
@@ -1,0 +1,47 @@
+# OT-0038A — Apertura coherencia entre salidas reproducibles Q-5
+
+## Objetivo
+
+Abrir la validación de coherencia entre las dos salidas reproducibles principales de Q-5:
+
+- Resumen técnico Q-5.
+- Expediente hidrológico mínimo.
+
+## Problema
+
+HidroFlow ya permite copiar dos salidas técnicas reproducibles. Ahora debe validarse que ambas sean coherentes entre sí y que no presenten contradicciones técnicas.
+
+## Alcance
+
+- Capturar resumen técnico Q-5 copiado.
+- Capturar expediente hidrológico mínimo copiado.
+- Comparar afirmaciones técnicas clave.
+- Detectar contradicciones o campos problemáticos.
+- No modificar cálculos.
+- No modificar motor.
+
+## Criterios de coherencia
+
+Ambas salidas deben coincidir en:
+
+- Estado general diagnóstico no adoptivo.
+- SCS Unit Hydrograph como candidato principal de referencia.
+- SCS Mod. como variante ajustable.
+- Snyder, Williams & Hann y Clark IUH como comparativos o referenciales.
+- Masa y volumen controlados frente a la referencia física.
+- Qp y Tp sujetos a revisión temporal.
+- Restricciones técnicas respetadas.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0038/OT-0038C_cierre_coherencia_salidas_reproducibles_Q5.md
+++ b/00_ADMIN/bitacora/OT-0038/OT-0038C_cierre_coherencia_salidas_reproducibles_Q5.md
@@ -1,0 +1,74 @@
+# OT-0038C — Cierre coherencia entre salidas reproducibles Q-5
+
+## Objetivo
+
+Cerrar la OT-0038 consolidando la validación de coherencia entre las dos salidas reproducibles principales de Q-5:
+
+- Resumen técnico Q-5.
+- Expediente hidrológico mínimo.
+
+## Resultado práctico
+
+Se validó que ambas salidas son coherentes en sus afirmaciones técnicas principales:
+
+- Estado general: diagnóstico no adoptivo.
+- SCS Unit Hydrograph como candidato principal de referencia.
+- SCS Mod. como variante ajustable.
+- Snyder, Williams & Hann y Clark IUH como métodos comparativos/referenciales.
+- Masa y volumen controlados frente a la referencia física.
+- Qp y Tp sujetos a revisión temporal.
+- Método Racional como contraste global independiente de caudal pico, no perteneciente al bloque Q-5 de hidrogramas.
+- Restricciones técnicas respetadas.
+
+## Correcciones aplicadas
+
+Se alineó la redacción de restricciones entre el resumen técnico Q-5 y el expediente hidrológico mínimo.
+
+También se incorporó la mención explícita del Método Racional como contraste global independiente, manteniendo la separación conceptual frente al bloque Q-5 de hidrogramas.
+
+Se corrigió una cadena JSX partida durante la incorporación de la mención del Método Racional, recuperando build limpio.
+
+## Validación
+
+La comparación local cq5 confirmó:
+
+- coherencia entre resumen técnico Q-5 y expediente mínimo;
+- ausencia de undefined;
+- ausencia de null;
+- ausencia de NaN;
+- ausencia de [object Object];
+- presencia de tabla Q-5 auditada en el expediente;
+- presencia de métodos principales en la tabla Q-5.
+
+## Decisión técnica
+
+La validación es de producto reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0038 confirma que las dos salidas reproducibles principales de HidroFlow son coherentes entre sí.
+
+El Resumen técnico Q-5 y el Expediente hidrológico mínimo dicen lo mismo, respetan restricciones, no presentan valores problemáticos e incorporan la separación conceptual del Método Racional como contraste global independiente.
+
+## Estado
+
+OT-0038 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1280,8 +1280,8 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- SCS Mod.: variante ajustable.",
             "- Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
             "- Masa y volumen: controlados frente a la referencia física.",
-            "- Qp y Tp: sujetos a revisión temporal antes de adopción técnica.
-- Método Racional: contraste global independiente de caudal pico; no forma parte del bloque Q-5 de hidrogramas.",
+            "- Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "- Método Racional: contraste global independiente de caudal pico; no forma parte del bloque Q-5 de hidrogramas.",
             "",
             "Restricciones:",
             "- No se usaron caudales externos como fundamento.",
@@ -1495,6 +1495,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1280,7 +1280,8 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- SCS Mod.: variante ajustable.",
             "- Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
             "- Masa y volumen: controlados frente a la referencia física.",
-            "- Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "- Qp y Tp: sujetos a revisión temporal antes de adopción técnica.
+- Método Racional: contraste global independiente de caudal pico; no forma parte del bloque Q-5 de hidrogramas.",
             "",
             "Restricciones:",
             "- No se usaron caudales externos como fundamento.",
@@ -1494,6 +1495,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1426,8 +1426,8 @@ const obtenerResultadoQMetodo = (metodo) => {
             ...tablaQ5Markdown,
             "",
             "## 6. Restricciones técnicas",
-            "- No se usan caudales externos como fundamento.",
-            "- SIATA no se usa para justificar caudales.",
+            "- No se usaron caudales externos como fundamento.",
+            "- No se usó SIATA para justificar caudales.",
             "- No se modifica el motor hidrológico.",
             "- No se recalculan hidrogramas en este expediente.",
             "- No se alteran Qp, Tp, Volumen ni Q(t)."
@@ -1494,6 +1494,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0038 — Coherencia entre salidas reproducibles Q-5.

El objetivo fue validar que el Resumen técnico Q-5 y el Expediente hidrológico mínimo sean coherentes entre sí.

## Cambios incluidos

- Apertura documental de validación de coherencia.
- Alineación de redacción de restricciones entre resumen y expediente.
- Mención explícita del Método Racional como contraste global independiente.
- Corrección de cadena JSX asociada a la mención del Método Racional.
- Cierre técnico de la OT.

## Resultado práctico

Se confirmó que ambas salidas coinciden en:

- Estado general: diagnóstico no adoptivo.
- SCS Unit Hydrograph como candidato principal de referencia.
- SCS Mod. como variante ajustable.
- Snyder, Williams & Hann y Clark IUH como comparativos/referenciales.
- Masa y volumen controlados.
- Qp y Tp sujetos a revisión temporal.
- Método Racional como contraste global independiente, no perteneciente al bloque Q-5.
- Restricciones técnicas respetadas.

## Validación

La comparación local cq5 confirmó:

- Sin undefined.
- Sin null.
- Sin NaN.
- Sin [object Object].
- Tabla Q-5 auditada presente en expediente.
- Métodos principales presentes en la tabla Q-5.
- Coherencia entre resumen técnico Q-5 y expediente mínimo.

## Decisión técnica

La validación es de producto reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0038 confirma que HidroFlow entrega salidas reproducibles coherentes: Resumen técnico Q-5 y Expediente hidrológico mínimo.