### PR TITLE
OT-0039 — Método Racional en expediente mínimo

### DIFF
--- a/00_ADMIN/bitacora/OT-0039/OT-0039A_apertura_metodo_racional_en_expediente.md
+++ b/00_ADMIN/bitacora/OT-0039/OT-0039A_apertura_metodo_racional_en_expediente.md
@@ -1,0 +1,46 @@
+# OT-0039A — Apertura Método Racional en expediente hidrológico mínimo
+
+## Objetivo
+
+Abrir el frente para integrar el Método Racional como contraste global independiente dentro del expediente hidrológico mínimo de cuenca activa.
+
+## Problema
+
+OT-0038 dejó coherentes las salidas reproducibles Q-5 y expediente, e incorporó la mención del Método Racional como contraste global independiente.
+
+Sin embargo, el expediente todavía no contiene una sección propia del Método Racional con datos o lectura técnica mínima.
+
+## Tesis
+
+El expediente hidrológico mínimo debe distinguir claramente entre:
+
+- Q-5 como bloque de hidrogramas auditados.
+- Método Racional como contraste global independiente de caudal pico.
+- Roles Tc usados en cada ruta.
+
+## Alcance inicial
+
+- Auditar datos disponibles del Método Racional.
+- Identificar si existe tabla por periodo de retorno.
+- Identificar campos Q, I, P, C, Tc y Tr disponibles.
+- Preparar una sección mínima para el expediente copiable.
+- No modificar el motor.
+- No recalcular resultados.
+- No alterar Qp, Tp, Volumen ni Q(t).
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0039/OT-0039C_cierre_metodo_racional_en_expediente.md
+++ b/00_ADMIN/bitacora/OT-0039/OT-0039C_cierre_metodo_racional_en_expediente.md
@@ -1,0 +1,70 @@
+# OT-0039C — Cierre Método Racional en expediente hidrológico mínimo
+
+## Objetivo
+
+Cerrar la OT-0039 consolidando la incorporación del Método Racional como contraste global independiente dentro del expediente hidrológico mínimo.
+
+## Resultado práctico
+
+Se agregó una sección propia en el expediente hidrológico mínimo:
+
+- Método Racional como contraste global independiente.
+- Uso como contraste de caudal pico.
+- Disponibilidad de resultados en el módulo Método Racional.
+- Separación explícita frente al bloque Q-5 de hidrogramas.
+- Criterio no adoptivo principal sin revisión de competencia, duración Tc y alcance normativo.
+
+## Evidencia
+
+La auditoría confirmó que calcRacional y ModRacional existen en HidroFlow.jsx.
+
+También confirmó que los resultados numéricos del Método Racional están disponibles dentro del módulo Racional, pero no en el scope actual del ComparadorMultiMetodo ni del expediente.
+
+## Decisión técnica
+
+No se duplica calcRacional dentro del Comparador.
+
+No se recalcula el Método Racional en el expediente.
+
+No se inventa una tabla racional sin publicar primero resultados reales al contexto exportable.
+
+La integración actual queda como sección informativa y trazable.
+
+## Validación
+
+El expediente copiado fue validado con vexp39.
+
+La validación confirmó:
+
+- presencia de la sección Método Racional;
+- presencia de contraste global independiente;
+- presencia de módulo Método Racional;
+- separación frente al bloque Q-5;
+- presencia de Restricciones técnicas;
+- ausencia de undefined;
+- ausencia de null;
+- ausencia de NaN;
+- ausencia de [object Object].
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0039 integra el Método Racional en el expediente mínimo como contraste global independiente, sin mezclarlo con el bloque Q-5 de hidrogramas.
+
+La tabla racional real queda pendiente para una OT posterior, cuando los resultados del módulo Racional sean publicados al contexto exportable.
+
+## Estado
+
+OT-0039 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1426,7 +1426,14 @@ const obtenerResultadoQMetodo = (metodo) => {
             "Tabla Q-5 auditada:",
             ...tablaQ5Markdown,
             "",
-            "## 6. Restricciones técnicas",
+            "",
+            "## 6. Método Racional — contraste global independiente",
+            "Uso: contraste global independiente de caudal pico.",
+            "Disponibilidad: resultados consultables en el módulo Método Racional.",
+            "Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.",
+            "Criterio técnico: no adoptivo principal para esta cuenca sin revisión de competencia, duración Tc y alcance normativo.",
+            "",
+            "## 7. Restricciones técnicas",
             "- No se usaron caudales externos como fundamento.",
             "- No se usó SIATA para justificar caudales.",
             "- No se modifica el motor hidrológico.",
@@ -1495,6 +1502,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0039 — Método Racional en expediente mínimo.

El objetivo fue integrar el Método Racional dentro del expediente hidrológico mínimo como contraste global independiente, sin mezclarlo con el bloque Q-5 de hidrogramas.

## Cambios incluidos

- Apertura documental del Método Racional en expediente.
- Sección Método Racional dentro del expediente hidrológico mínimo.
- Validación del expediente copiado con vexp39.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo ahora incluye una sección específica:

- Método Racional — contraste global independiente.
- Uso como contraste de caudal pico.
- Resultados consultables en el módulo Método Racional.
- No pertenece al bloque Q-5 de hidrogramas.
- No adoptivo principal sin revisión de competencia, duración Tc y alcance normativo.

## Decisión técnica

No se duplica calcRacional dentro del Comparador.

No se recalcula el Método Racional en el expediente.

No se incorpora tabla racional todavía porque los resultados numéricos no están publicados al contexto exportable.

## Validación

La validación local vexp39 confirmó:

- sección Método Racional presente;
- separación frente a Q-5 presente;
- restricciones técnicas presentes;
- ausencia de undefined;
- ausencia de null;
- ausencia de NaN;
- ausencia de [object Object].

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0039 amplía el expediente mínimo hacia una lectura hidrológica global: Q-5 queda como bloque de hidrogramas auditados y Método Racional queda como contraste global independiente.