### PR TITLE
OT-0040 — Método Racional al contexto exportable

### DIFF
--- a/00_ADMIN/bitacora/OT-0040/OT-0040A_apertura_racional_contexto_exportable.md
+++ b/00_ADMIN/bitacora/OT-0040/OT-0040A_apertura_racional_contexto_exportable.md
@@ -1,0 +1,41 @@
+# OT-0040A — Apertura publicación Método Racional al contexto exportable
+
+## Objetivo
+
+Abrir el frente para publicar los resultados reales del Método Racional al contexto exportable de HidroFlow, de forma que el expediente hidrológico mínimo pueda incluir una tabla racional real.
+
+## Problema
+
+OT-0039 integró el Método Racional como contraste global independiente dentro del expediente mínimo, pero solo como sección informativa.
+
+La auditoría confirmó que calcRacional y ModRacional existen en HidroFlow.jsx y que los resultados racionales se calculan en el módulo Racional, pero no están disponibles todavía en el scope del ComparadorMultiMetodo ni del expediente.
+
+## Tesis
+
+El expediente debe consumir resultados reales publicados desde la ruta original del Método Racional, sin duplicar fórmulas ni recalcular de forma paralela dentro del Comparador.
+
+## Alcance inicial
+
+- Auditar el flujo actual de ModRacional.
+- Identificar dónde publicar resultados racionales al contexto.
+- Publicar tabla racional al contexto exportable si es seguro.
+- Preparar consumo posterior en el expediente.
+- No duplicar calcRacional.
+- No modificar fórmulas.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0040/OT-0040C_cierre_racional_contexto_exportable.md
+++ b/00_ADMIN/bitacora/OT-0040/OT-0040C_cierre_racional_contexto_exportable.md
@@ -1,0 +1,70 @@
+# OT-0040C — Cierre publicación Método Racional al contexto exportable
+
+## Objetivo
+
+Cerrar la OT-0040 consolidando la publicación de resultados reales del Método Racional al contexto exportable de HidroFlow.
+
+## Resultado práctico
+
+El expediente hidrológico mínimo ahora incluye una sección del Método Racional con tabla exportable:
+
+- Tr.
+- I.
+- P.
+- C.
+- Q.
+
+## Decisión técnica
+
+Los resultados racionales se publican desde la ruta existente de HidroFlow usando calcRacional.
+
+El Comparador consume los resultados desde el contexto exportable.
+
+No se duplica calcRacional dentro del Comparador.
+
+No se recalcula de forma paralela en el expediente.
+
+## Validación
+
+La validación v40ok confirmó:
+
+- presencia del expediente hidrológico mínimo;
+- presencia de la sección Método Racional;
+- presencia de Tc racional exportado;
+- presencia de Tabla Método Racional;
+- presencia de encabezado Tr, I, P, C, Q;
+- presencia de Restricciones técnicas;
+- ausencia de ANTES_OT0040;
+- ausencia de function vexp;
+- ausencia de function v40;
+- ausencia de function v40ok;
+- ausencia de Get-Clipboard;
+- ausencia de Select-String;
+- ausencia de Write-Host;
+- ausencia de undefined;
+- ausencia de null;
+- ausencia de NaN;
+- ausencia de [object Object].
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0040 convierte el Método Racional de sección informativa a tabla real exportable dentro del expediente hidrológico mínimo.
+
+El expediente queda más completo: Q-5 como bloque de hidrogramas auditados y Método Racional como contraste global independiente con resultados tabulados.
+
+## Estado
+
+OT-0040 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3505,9 +3505,40 @@ useEffect(() => {
     ? params.CN
     : 75;
 
+  const metodosTcRacional = calcTc(params).filter((r) => Number.isFinite(r?.h) && r.h > 0);
+  const tcRacionalMin =
+    metodosTcRacional.length > 0
+      ? metodosTcRacional.reduce((suma, metodo) => suma + Number(metodo.min || 0), 0) /
+        metodosTcRacional.length
+      : null;
+
+  const estacionRacional = ESTACIONES_EPM[stn];
+
+  const resultadosRacionalExportable =
+    estacionRacional &&
+    Number.isFinite(Number(params?.area)) &&
+    Number.isFinite(Number(params?.CN)) &&
+    Number.isFinite(Number(tcRacionalMin)) &&
+    Number(tcRacionalMin) > 0
+      ? calcRacional(
+          estacionRacional,
+          Number(params.area),
+          Number(tcRacionalMin),
+          Number(params.CN)
+        )
+      : [];
   onContextoComparador({
     fuente: "motor HidroFlow",
     estacion_idf: stn,
+    metodo_racional: {
+      fuente: "calcRacional",
+      uso: "contraste global independiente de caudal pico",
+      estado: "informativo_no_adoptivo",
+      tc_min: Number.isFinite(Number(tcRacionalMin))
+        ? Number(Number(tcRacionalMin).toFixed(2))
+        : null,
+      resultados: resultadosRacionalExportable
+    },
 
     cuencaNombre:
       params?.nombreCuenca ??
@@ -3727,6 +3758,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1429,9 +1429,28 @@ const obtenerResultadoQMetodo = (metodo) => {
             "",
             "## 6. Método Racional — contraste global independiente",
             "Uso: contraste global independiente de caudal pico.",
-            "Disponibilidad: resultados consultables en el módulo Método Racional.",
             "Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.",
             "Criterio técnico: no adoptivo principal para esta cuenca sin revisión de competencia, duración Tc y alcance normativo.",
+            ...(Array.isArray(contextoBase?.metodo_racional?.resultados) &&
+            contextoBase.metodo_racional.resultados.length > 0
+              ? [
+                  `Tc racional exportado: ${
+                    Number.isFinite(Number(contextoBase?.metodo_racional?.tc_min))
+                      ? Number(contextoBase.metodo_racional.tc_min).toFixed(2) + " min"
+                      : "—"
+                  }`,
+                  "",
+                  "Tabla Método Racional:",
+                  "| Tr | I | P | C | Q |",
+                  "|---:|---:|---:|---:|---:|",
+                  ...contextoBase.metodo_racional.resultados.map((r) =>
+                    `| ${r.Tr} | ${formatearNumeroExpediente(r.I)} mm/h | ${formatearNumeroExpediente(r.P)} mm | ${formatearNumeroExpediente(r.C, 4)} | ${formatearNumeroExpediente(r.Q)} m³/s |`
+                  )
+                ]
+              : [
+                  "Disponibilidad: resultados no disponibles en el contexto exportable.",
+                  "Estado: sección informativa; consultar módulo Método Racional."
+                ]),
             "",
             "## 7. Restricciones técnicas",
             "- No se usaron caudales externos como fundamento.",
@@ -1502,6 +1521,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0040 — Método Racional al contexto exportable.

El objetivo fue publicar resultados reales del Método Racional al contexto exportable para incluir una tabla racional dentro del expediente hidrológico mínimo.

## Cambios incluidos

- Apertura documental de publicación del Método Racional.
- Publicación de resultados racionales al contexto exportable.
- Consumo de la tabla racional en el expediente hidrológico mínimo.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo ahora incluye:

- Tc racional exportado.
- Tabla Método Racional.
- Tr.
- I.
- P.
- C.
- Q.

## Decisión técnica

No se duplica calcRacional en el Comparador.

No se recalcula el Método Racional de forma paralela en el expediente.

El expediente consume resultados reales publicados desde HidroFlow.

## Validación

La validación v40ok confirmó:

- Sección Método Racional presente.
- Tc racional exportado presente.
- Tabla Método Racional presente.
- Encabezado Tr, I, P, C, Q presente.
- Sin undefined.
- Sin null.
- Sin NaN.
- Sin [object Object].
- Sin contaminación del portapapeles por comandos de validación.

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0040 convierte el Método Racional en una tabla real exportable dentro del expediente