### PR TITLE
OT-0041 — Contraste Q-5 vs Método Racional en expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0041/OT-0041A_apertura_contraste_Q5_Racional_expediente.md
+++ b/00_ADMIN/bitacora/OT-0041/OT-0041A_apertura_contraste_Q5_Racional_expediente.md
@@ -1,0 +1,45 @@
+# OT-0041A — Apertura contraste Q-5 vs Método Racional en expediente
+
+## Objetivo
+
+Abrir el frente para explicar la convivencia técnica entre Q-5 y Método Racional dentro del expediente hidrológico mínimo.
+
+## Problema
+
+Después de OT-0040, el expediente hidrológico mínimo contiene tanto el bloque Q-5 auditado como la tabla real del Método Racional.
+
+Sin embargo, ambos resultados no deben interpretarse como equivalentes ni como alternativas adoptivas automáticas.
+
+## Tesis
+
+El expediente debe explicar que:
+
+- Q-5 representa hidrogramas Q(t), volumen, tiempo al pico, forma temporal y dictamen por método.
+- El Método Racional representa un contraste global independiente de caudal pico.
+- Ambos son complementarios, pero no equivalentes.
+- La adopción técnica requiere revisión de competencia metodológica, escala de cuenca, duración Tc y alcance normativo.
+
+## Alcance
+
+- Agregar una sección comparativa al expediente copiable.
+- No modificar cálculos.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No modificar resultados racionales.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0041/OT-0041C_cierre_contraste_Q5_Racional_expediente.md
+++ b/00_ADMIN/bitacora/OT-0041/OT-0041C_cierre_contraste_Q5_Racional_expediente.md
@@ -1,0 +1,68 @@
+# OT-0041C — Cierre contraste Q-5 vs Método Racional en expediente
+
+## Objetivo
+
+Cerrar la OT-0041 consolidando la explicación técnica de convivencia entre Q-5 y Método Racional dentro del expediente hidrológico mínimo.
+
+## Resultado práctico
+
+El expediente hidrológico mínimo ahora incluye una sección de contraste que explica:
+
+- Q-5 como bloque de hidrogramas auditados.
+- Método Racional como contraste global independiente de caudal pico.
+- Q-5 y Método Racional como resultados complementarios, pero no equivalentes.
+- La necesidad de revisión de competencia metodológica, escala de cuenca, duración Tc y alcance normativo antes de cualquier adopción técnica.
+
+## Corrección aplicada
+
+Se corrigió la tabla Q-5 del expediente para evitar que el Método Racional apareciera como si fuera un método Q-5 de hidrogramas.
+
+El Método Racional queda exclusivamente en:
+
+- su sección propia;
+- su tabla racional;
+- la sección de contraste Q-5 vs Método Racional.
+
+## Decisión técnica
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se modifican fórmulas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+No se modifican los resultados racionales.
+
+## Validación
+
+La validación del expediente confirmó:
+
+- presencia de la sección Método Racional;
+- presencia de la tabla Método Racional;
+- presencia de la sección Contraste Q-5 vs Método Racional;
+- presencia de Restricciones técnicas;
+- separación conceptual entre Q-5 y Método Racional;
+- ausencia de mezcla del Método Racional dentro de la tabla Q-5.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0041 deja el expediente hidrológico mínimo con una lectura técnica más robusta: Q-5 y Método Racional conviven como resultados complementarios, no equivalentes ni adoptivos automáticamente.
+
+## Estado
+
+OT-0041 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1370,7 +1370,11 @@ const obtenerResultadoQMetodo = (metodo) => {
               ? `contraste hidrológico; volumen en escala; ${estadoTemporal}; revisar efecto de almacenamiento.`
               : `método comparativo; ${estadoTemporal}.`;
 
-          const metodosQ5Expediente = metodos.filter((metodo) => metodo.tipo === "q");
+          const metodosQ5Expediente = metodos.filter(
+            (metodo) =>
+              metodo.tipo === "q" &&
+              !String(metodo.nombre ?? "").toLowerCase().includes("racional")
+          );
 
           const tablaQ5Markdown = [
             "| Método | Qp | Tp | Volumen | Estado temporal | Dictamen |",
@@ -1452,7 +1456,14 @@ const obtenerResultadoQMetodo = (metodo) => {
                   "Estado: sección informativa; consultar módulo Método Racional."
                 ]),
             "",
-            "## 7. Restricciones técnicas",
+            "",
+            "## 7. Contraste Q-5 vs Método Racional",
+            "Q-5: bloque de hidrogramas auditados. Evalúa Q(t), Qp, Tp, Volumen, estado temporal y dictamen por método.",
+            "Método Racional: contraste global independiente de caudal pico basado en intensidad, coeficiente C, área y Tc.",
+            "Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+            "Criterio de adopción: ningún resultado debe adoptarse automáticamente sin revisión de competencia metodológica, escala de cuenca, duración Tc y alcance normativo.",
+            "",
+            "## 8. Restricciones técnicas",
             "- No se usaron caudales externos como fundamento.",
             "- No se usó SIATA para justificar caudales.",
             "- No se modifica el motor hidrológico.",
@@ -1521,6 +1532,8 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0041 — Contraste Q-5 vs Método Racional en expediente.

El objetivo fue explicar dentro del expediente hidrológico mínimo la convivencia técnica entre Q-5 y Método Racional.

## Cambios incluidos

- Apertura documental del contraste Q-5 vs Método Racional.
- Sección de contraste en el expediente hidrológico mínimo.
- Corrección para evitar que Método Racional aparezca dentro de la tabla Q-5.
- Cierre técnico de la OT.

## Resultado práctico

El expediente ahora diferencia claramente:

- Q-5: bloque de hidrogramas auditados con Q(t), Qp, Tp, Volumen, estado temporal y dictamen por método.
- Método Racional: contraste global independiente de caudal pico basado en intensidad, coeficiente C, área y Tc.

## Decisión técnica

Q-5 y Método Racional son complementarios, pero no equivalentes.

Ningún resultado debe adoptarse automáticamente sin revisión de competencia metodológica, escala de cuenca, duración Tc y alcance normativo.

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Validación

- Build aprobado.
- Método Racional separado de la tabla Q-5.
- Sección de contraste incorporada al expediente.
- Working tree limpio.

## Dictamen

OT-0041 fortalece el expediente hidrológico mínimo al explicar que Q-5 y Método Racional son lecturas complementarias, no equivalentes ni adoptivas automáticamente.