### PR TITLE
OT-0043 — Control completitud numérica expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0043/OT-0043A_apertura_completitud_numerica_expediente.md
+++ b/00_ADMIN/bitacora/OT-0043/OT-0043A_apertura_completitud_numerica_expediente.md
@@ -1,0 +1,46 @@
+# OT-0043A — Apertura control de completitud numérica del expediente
+
+## Objetivo
+
+Abrir el control de completitud numérica del expediente hidrológico mínimo después de la validación integral estructural realizada en OT-0042.
+
+## Problema
+
+OT-0042 certificó que el expediente está completo en estructura, coherente y libre de valores problemáticos como undefined, null, NaN y [object Object].
+
+Sin embargo, algunos campos pueden estar presentes pero no contener valores útiles, por ejemplo campos con guion largo (—) o valores cero no representativos.
+
+## Tesis
+
+Un expediente técnico reproducible no solo debe estar bien estructurado; también debe contener valores numéricos útiles en sus campos críticos.
+
+## Alcance
+
+Validar completitud numérica de:
+
+- área;
+- pendiente media;
+- longitud de cauce principal;
+- CN, CN base, CN efectivo;
+- Tc comparador;
+- lluvia efectiva total;
+- volumen esperado;
+- tabla Q-5;
+- tabla Método Racional.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0043/OT-0043C_cierre_completitud_numerica_expediente.md
+++ b/00_ADMIN/bitacora/OT-0043/OT-0043C_cierre_completitud_numerica_expediente.md
@@ -1,0 +1,84 @@
+# OT-0043C — Cierre control de completitud numérica del expediente
+
+## Objetivo
+
+Cerrar la OT-0043 consolidando el control de completitud numérica del expediente hidrológico mínimo.
+
+## Resultado práctico
+
+Se validó que el expediente hidrológico mínimo no solo está completo en estructura, sino que contiene valores numéricos útiles en sus campos críticos.
+
+## Correcciones aplicadas
+
+Se corrigió la preservación del contexto numérico exportable para evitar pérdida de:
+
+- lluvia efectiva total;
+- volumen esperado.
+
+También se corrigió la lectura de resultados reales Q-5 en el expediente, incorporando claves reales del motor como:
+
+- Qpico;
+- tPico;
+- volTotal.
+
+Además, se evitó que valores nulos o vacíos fueran formateados como 0,00.
+
+## Validación
+
+La validación vexp43 confirmó:
+
+- Cuenca presente.
+- Área presente y numérica.
+- Estación IDF presente.
+- Pendiente media presente y numérica.
+- Longitud de cauce principal presente y numérica.
+- CN, CN base y CN efectivo presentes.
+- AMC presente.
+- Tc comparador presente y numérico.
+- Lluvia efectiva total presente: 56.65 mm.
+- Volumen esperado presente: 2.654.251 m³.
+- Tabla Q-5 auditada presente.
+- Tabla Método Racional presente.
+- Sin filas técnicas con cero inicial evidente.
+- Sin undefined.
+- Sin null.
+- Sin NaN.
+- Sin [object Object].
+- Sin contaminación por comandos de validación.
+
+## Decisión técnica
+
+La validación es de producto reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se modifican fórmulas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+No se modifican resultados racionales.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0043 certifica que el expediente hidrológico mínimo es una salida técnica completa, limpia y numéricamente útil.
+
+El expediente pasa de estar bien estructurado a estar técnicamente poblado con valores reales disponibles del contexto exportable.
+
+## Estado
+
+OT-0043 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3527,7 +3527,8 @@ useEffect(() => {
           Number(params.CN)
         )
       : [];
-  onContextoComparador({
+  onContextoComparador((previo) => ({
+    ...(previo ?? {}),
     fuente: "motor HidroFlow",
     estacion_idf: stn,
     metodo_racional: {
@@ -3584,7 +3585,7 @@ useEffect(() => {
     lluvia_efectiva: false,
     hidrogramas: [],
     hidrograma_principal: null,
-  });
+  }));
 }, [onContextoComparador, params, stn]);
 // Publicación base Tc para despertar el Índice Hidrológico global.
 // No reemplaza el estado especializado publicado por ComparadorMultiMetodo.
@@ -3758,6 +3759,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -611,9 +611,9 @@ const obtenerResultadoQMetodo = (metodo) => {
   }
 
   return {
-    Qp: extraerNumero(match, ["Qp", "qp", "q_pico", "caudalPico", "caudal_pico"]),
-    Tp: extraerNumero(match, ["Tp", "tp", "t_pico", "tiempoPico", "tiempo_pico"]),
-    volumen: extraerNumero(match, ["volumen", "V", "vol", "volume"]),
+    Qp: extraerNumero(match, ["Qp", "qp", "Qpico", "qPico", "q_pico", "caudalPico", "caudal_pico"]),
+    Tp: extraerNumero(match, ["Tp", "tp", "tPico", "TPico", "t_pico", "tiempoPico", "tiempo_pico"]),
+    volumen: extraerNumero(match, ["volumen", "V", "vol", "volume", "volTotal", "vol_total", "volumenTotal"]),
     disponible: true,
   };
 };
@@ -1331,13 +1331,20 @@ const obtenerResultadoQMetodo = (metodo) => {
               ? areaKm2 * peTotalMm * 1000
               : null;
 
-          const formatearNumeroExpediente = (valor, decimales = 2) =>
-            Number.isFinite(Number(valor))
-              ? Number(valor).toLocaleString("es-CO", {
+          const formatearNumeroExpediente = (valor, decimales = 2) => {
+            if (valor === null || valor === undefined || valor === "") {
+              return "—";
+            }
+
+            const numero = Number(valor);
+
+            return Number.isFinite(numero)
+              ? numero.toLocaleString("es-CO", {
                   minimumFractionDigits: decimales,
                   maximumFractionDigits: decimales
                 })
               : "—";
+          };
 
           const obtenerEstadoTemporalExpediente = (resultadoQ) => {
             const tcReferencia = Number(Tc_final);
@@ -1532,6 +1539,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0043 — Control completitud numérica expediente.

El objetivo fue certificar que el expediente hidrológico mínimo no solo esté completo en estructura, sino también poblado con valores numéricos útiles.

## Cambios incluidos

- Apertura documental del control de completitud numérica.
- Preservación del contexto numérico exportable.
- Corrección de lectura de resultados reales Q-5 usando claves del motor.
- Cierre técnico de la OT.

## Resultado práctico

La validación vexp43 confirmó:

- Lluvia efectiva total: 56.65 mm.
- Volumen esperado: 2.654.251 m³.
- Tabla Q-5 auditada presente.
- Tabla Método Racional presente.
- Sin filas técnicas con cero inicial evidente.
- Sin undefined, null, NaN ni [object Object].

## Decisión técnica

La mejora es de producto reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se modifican fórmulas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0043 certifica que el expediente hidrológico mínimo es completo, limpio y numéricamente útil como salida técnica reproducible.