### PR TITLE
OT-0045 — Sello técnico del expediente hidrológico

### DIFF
--- a/00_ADMIN/bitacora/OT-0045/OT-0045A_apertura_sello_tecnico_expediente.md
+++ b/00_ADMIN/bitacora/OT-0045/OT-0045A_apertura_sello_tecnico_expediente.md
@@ -1,0 +1,46 @@
+# OT-0045A — Apertura sello técnico del expediente hidrológico
+
+## Objetivo
+
+Abrir el frente para incorporar un sello técnico de generación al expediente hidrológico mínimo de HidroFlow.
+
+## Problema
+
+OT-0044 confirmó que el expediente hidrológico mínimo tiene plausibilidad hidrológica interna preliminar. Sin embargo, la salida copiada todavía no incluye una sección final explícita de trazabilidad de generación.
+
+## Tesis
+
+Un expediente técnico reproducible debe indicar claramente:
+
+- herramienta que lo generó;
+- tipo de salida;
+- cuenca activa;
+- fecha y hora de generación;
+- estado técnico del expediente;
+- validaciones superadas;
+- alcance no adoptivo sin revisión técnica.
+
+## Alcance
+
+- Agregar sección Sello técnico de generación al expediente copiado.
+- No modificar cálculos.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No modificar resultados racionales.
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0045/OT-0045C_cierre_sello_tecnico_expediente.md
+++ b/00_ADMIN/bitacora/OT-0045/OT-0045C_cierre_sello_tecnico_expediente.md
@@ -1,0 +1,79 @@
+# OT-0045C — Cierre sello técnico del expediente hidrológico
+
+## Objetivo
+
+Cerrar la OT-0045 consolidando la incorporación del sello técnico de generación al expediente hidrológico mínimo de HidroFlow.
+
+## Resultado práctico
+
+El expediente hidrológico mínimo ahora incluye una sección final:
+
+- Sello técnico de generación.
+- Herramienta: HidroFlow.
+- Tipo de salida: Expediente hidrológico mínimo.
+- Cuenca activa.
+- Fecha de generación.
+- Estado técnico.
+- Validaciones superadas.
+- Alcance no adoptivo.
+- Restricción principal de uso técnico.
+
+## Validación
+
+La validación vsello45 confirmó presencia de:
+
+- ## 9. Sello técnico de generación.
+- Herramienta: HidroFlow.
+- Tipo de salida: Expediente hidrológico mínimo.
+- Cuenca activa.
+- Fecha de generación.
+- Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.
+- Validaciones superadas: estructura, coherencia entre salidas, completitud numérica y plausibilidad hidrológica preliminar.
+- Alcance: diagnóstico técnico reproducible no adoptivo hasta revisión hidrológica responsable.
+
+La validación buscar45 confirmó ausencia de:
+
+- undefined.
+- null.
+- NaN.
+- [object Object].
+- Get-Clipboard.
+- Write-Host.
+- Select-String.
+
+## Decisión técnica
+
+La mejora es de trazabilidad del producto reproducible.
+
+No se modifica el motor.
+
+No se recalculan hidrogramas.
+
+No se modifican fórmulas.
+
+No se alteran Qp, Tp, Volumen ni Q(t).
+
+No se modifican resultados racionales.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0045 convierte el expediente hidrológico mínimo en una salida técnica firmada y trazable.
+
+El expediente ya no solo es completo, limpio, numéricamente útil y plausible internamente; ahora declara explícitamente su herramienta generadora, fecha de generación, estado técnico, validaciones superadas y alcance no adoptivo.
+
+## Estado
+
+OT-0045 lista para PR.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1288,7 +1288,17 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se usó SIATA para justificar caudales.",
             "- No se modifica el motor hidrológico.",
             "- No se recalculan hidrogramas.",
-            "- No se alteran Qp, Tp, Volumen ni Q(t)."
+            "- No se alteran Qp, Tp, Volumen ni Q(t).",
+            "",
+            "## 9. Sello técnico de generación",
+            "Herramienta: HidroFlow.",
+            "Tipo de salida: Expediente hidrológico mínimo.",
+            `Cuenca activa: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}.`,
+            `Fecha de generación: ${new Date().toLocaleString("es-CO")}.`,
+            "Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.",
+            "Validaciones superadas: estructura, coherencia entre salidas, completitud numérica y plausibilidad hidrológica preliminar.",
+            "Alcance: diagnóstico técnico reproducible no adoptivo hasta revisión hidrológica responsable.",
+            "Restricción principal: no usar como valor adoptivo final sin revisión de competencia metodológica, escala de cuenca, duración Tc, alcance normativo y criterio profesional."
           ].join("\n");
 
           const areaTextoResumen = document.createElement("textarea");
@@ -1547,7 +1557,17 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se usó SIATA para justificar caudales.",
             "- No se modifica el motor hidrológico.",
             "- No se recalculan hidrogramas en este expediente.",
-            "- No se alteran Qp, Tp, Volumen ni Q(t)."
+            "- No se alteran Qp, Tp, Volumen ni Q(t).",
+            "",
+            "## 9. Sello técnico de generación",
+            "Herramienta: HidroFlow.",
+            "Tipo de salida: Expediente hidrológico mínimo.",
+            `Cuenca activa: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}.`,
+            `Fecha de generación: ${new Date().toLocaleString("es-CO")}.`,
+            "Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.",
+            "Validaciones superadas: estructura, coherencia entre salidas, completitud numérica y plausibilidad hidrológica preliminar.",
+            "Alcance: diagnóstico técnico reproducible no adoptivo hasta revisión hidrológica responsable.",
+            "Restricción principal: no usar como valor adoptivo final sin revisión de competencia metodológica, escala de cuenca, duración Tc, alcance normativo y criterio profesional."
           ].join("\n");
 
           const areaTexto = document.createElement("textarea");
@@ -1611,6 +1631,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0045 — Sello técnico del expediente hidrológico.

El objetivo fue incorporar una sección final de trazabilidad al expediente hidrológico mínimo de HidroFlow.

## Cambios incluidos

- Apertura documental del sello técnico.
- Sección “Sello técnico de generación” en el expediente copiable.
- Cierre técnico de la OT.

## Resultado práctico

El expediente hidrológico mínimo ahora incluye:

- Herramienta: HidroFlow.
- Tipo de salida: Expediente hidrológico mínimo.
- Cuenca activa.
- Fecha de generación.
- Estado técnico.
- Validaciones superadas.
- Alcance no adoptivo.
- Restricción principal de uso técnico.

## Validación

La validación vsello45 confirmó que el sello técnico está presente y completo.

La validación buscar45 confirmó ausencia de:

- undefined.
- null.
- NaN.
- [object Object].
- Get-Clipboard.
- Write-Host.
- Select-String.

## Decisión técnica

La mejora es de trazabilidad del producto reproducible.

No se modifica el motor.

No se recalculan hidrogramas.

No se modifican fórmulas.

No se alteran Qp, Tp, Volumen ni Q(t).

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0045 convierte el expediente hidrológico mínimo en una salida técnica firmada, trazable y reproducible.