### PR TITLE
OT-0047 — Regresión multi-ruta expediente firmado

### DIFF
--- a/00_ADMIN/bitacora/OT-0047/OT-0047A_apertura_regresion_multiruta_expediente.md
+++ b/00_ADMIN/bitacora/OT-0047/OT-0047A_apertura_regresion_multiruta_expediente.md
@@ -1,0 +1,53 @@
+# OT-0047A — Apertura regresión multi-ruta del expediente firmado
+
+## Objetivo
+
+Abrir la regresión multi-ruta del expediente hidrológico mínimo firmado, verificando que la salida conserve completitud global bajo diferentes rutas reales de navegación.
+
+## Problema
+
+OT-0046 certificó que el expediente firmado conserva completitud global bajo una ruta real validada. Sin embargo, el usuario puede llegar al expediente desde rutas distintas dentro de HidroFlow.
+
+## Tesis
+
+Un producto técnico reproducible debe conservar su integridad no solo en una ruta ideal, sino bajo rutas reales de navegación.
+
+## Alcance
+
+Validar el expediente firmado en varias rutas:
+
+- Refrescar → Hidrogramas → Comparador → copiar expediente.
+- Refrescar → Comparador directo → copiar expediente.
+- Hidrogramas → Racional → Comparador → copiar expediente.
+- Cambiar estación IDF → Comparador → copiar expediente.
+- Cambiar Tr activo → Comparador → copiar expediente.
+
+## Criterios de aceptación
+
+En cada ruta el expediente debe conservar:
+
+- Estación IDF poblada.
+- Lluvia efectiva total poblada.
+- Volumen esperado poblado.
+- Tabla Q-5 con filas reales.
+- Tabla Método Racional.
+- Contraste Q-5 vs Método Racional.
+- Sello técnico de generación.
+- Ausencia de undefined, null, NaN y [object Object].
+
+## Restricciones
+
+- No usar caudales externos como fundamento.
+- No usar SIATA para justificar caudales.
+- No modificar hidroEngine.js.
+- No modificar fórmulas hidrológicas.
+- No alterar Qp.
+- No alterar Tp.
+- No alterar Volumen.
+- No alterar Q(t).
+- No introducir setTimeout.
+- No introducir console.log permanentes.
+
+## Estado
+
+Apertura documental. Sin cambios funcionales.

--- a/00_ADMIN/bitacora/OT-0047/OT-0047C_cierre_regresion_multiruta_expediente.md
+++ b/00_ADMIN/bitacora/OT-0047/OT-0047C_cierre_regresion_multiruta_expediente.md
@@ -1,0 +1,104 @@
+# OT-0047C — Cierre regresión multi-ruta del expediente firmado
+
+## Objetivo
+
+Cerrar la OT-0047 consolidando la regresión multi-ruta del expediente hidrológico mínimo firmado.
+
+## Resultado práctico
+
+Se validó que el expediente firmado conserva su integridad bajo rutas reales de navegación con contexto completo y que bloquea la copia cuando el contexto hidrológico está incompleto.
+
+## Rutas evaluadas
+
+### R1 — Hidrogramas → Comparador
+
+Resultado: OK.
+
+La validación vreg47 confirmó:
+
+- Estación IDF: SAN CRISTOBAL.
+- Lluvia efectiva total: 56.65 mm.
+- Volumen esperado: 2.654.251 m³.
+- Tabla Q-5 con 4 filas.
+- Sin Qp cero evidente.
+- Tabla Método Racional presente.
+- Sello técnico presente.
+- Sin undefined, null, NaN ni [object Object].
+
+### R2 — Comparador directo sin contexto completo
+
+Resultado: bloqueado correctamente.
+
+La guardia del expediente impide copiar una salida firmada incompleta y muestra alerta indicando faltantes, entre ellos:
+
+- Lluvia efectiva total.
+- Volumen esperado.
+- Tabla Q-5 auditada con filas reales.
+
+### R3 — Hidrogramas → Racional → Comparador
+
+Resultado: OK.
+
+Se corrigió la preservación del contexto Q-5 al navegar por rutas intermedias, evitando que Racional borrara los hidrogramas ya publicados.
+
+La validación confirmó:
+
+- Estación IDF poblada.
+- Lluvia efectiva poblada.
+- Volumen esperado poblado.
+- Q-5 con 4 filas.
+- Sin Qp cero evidente.
+- Racional presente.
+- Sello técnico presente.
+
+### R4 — Cambio de estación IDF
+
+Resultado: OK.
+
+La validación confirmó que el expediente mantiene campos críticos poblados después de la ruta de cambio de estación IDF.
+
+### R5 — Cambio Tr activo
+
+Resultado: no ejecutable en esta OT.
+
+La auditoría confirmó que los Tr del Índice Hidrológico son chips visuales y no controles funcionales de estado global.
+
+En HidroFlow existen Tr locales por módulo mediante BtnGroup y setTr, pero no existe todavía un Tr global de diseño controlado desde el Índice.
+
+Por tanto, R5 queda diferida a una OT posterior dedicada a estado global Tr.
+
+## Correcciones aplicadas
+
+- Se agregó guardia para bloquear la copia de expedientes incompletos.
+- Se preservó Q-5 al navegar rutas, evitando pérdida de contexto al pasar por Racional.
+- Se validó que rutas completas sí permiten copia del expediente firmado.
+- Se validó que rutas incompletas no exportan expediente parcial.
+
+## Decisión técnica
+
+No se implementa Tr global en OT-0047.
+
+La activación real de Tr desde el Índice queda propuesta para OT-0048 — Estado global Tr de diseño.
+
+## Restricciones respetadas
+
+- No se usaron caudales externos como fundamento.
+- No se usó SIATA para justificar caudales.
+- No se modificó hidroEngine.js.
+- No se modificaron fórmulas hidrológicas.
+- No se alteró Qp.
+- No se alteró Tp.
+- No se alteró Volumen.
+- No se alteró Q(t).
+- No se introdujeron setTimeout.
+- No se introdujeron console.log permanentes.
+
+## Dictamen
+
+OT-0047 certifica que el expediente hidrológico mínimo firmado es robusto bajo rutas reales con contexto completo y que se protege contra exportaciones parciales cuando falta contexto hidrológico.
+
+El expediente ya no solo se genera: también se defiende frente a uso incompleto.
+
+## Estado
+
+OT-0047 lista para PR.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3595,9 +3595,14 @@ useEffect(() => {
 
     tc_metodos: calcTc(params),
     
-    lluvia_efectiva: false,
-    hidrogramas: [],
-    hidrograma_principal: null,
+    lluvia_efectiva: previo?.lluvia_efectiva ?? false,
+    lluvia_efectiva_total_mm: previo?.lluvia_efectiva_total_mm ?? null,
+    hidrogramas: previo?.hidrogramas ?? {
+      fuente: "pendiente",
+      resultados: []
+    },
+    hidrogramas_resumen: previo?.hidrogramas_resumen ?? null,
+    hidrograma_principal: previo?.hidrograma_principal ?? null,
   }));
 }, [onContextoComparador, params, stn]);
 // Publicación base Tc para despertar el Índice Hidrológico global.
@@ -3772,6 +3777,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1487,6 +1487,49 @@ const obtenerResultadoQMetodo = (metodo) => {
           ]
             .map((valor) => String(valor ?? "").trim())
             .find((valor) => valor && valor !== "—") ?? "SAN CRISTOBAL";
+          const faltantesExpediente = [];
+
+          if (!estacionIdfExpediente) {
+            faltantesExpediente.push("Estación IDF");
+          }
+
+          if (!Number.isFinite(areaKm2)) {
+            faltantesExpediente.push("Área de cuenca");
+          }
+
+          if (!Number.isFinite(peTotalMm)) {
+            faltantesExpediente.push("Lluvia efectiva total");
+          }
+
+          if (!Number.isFinite(volumenEsperadoM3)) {
+            faltantesExpediente.push("Volumen esperado");
+          }
+
+          if (!Array.isArray(filasQ5Markdown) || filasQ5Markdown.length === 0) {
+            faltantesExpediente.push("Tabla Q-5 auditada con filas reales");
+          }
+
+          if (
+            !Array.isArray(contextoBase?.metodo_racional?.resultados) ||
+            contextoBase.metodo_racional.resultados.length === 0
+          ) {
+            faltantesExpediente.push("Tabla Método Racional");
+          }
+
+          if (faltantesExpediente.length > 0) {
+            window.alert(
+              [
+                "Expediente hidrológico mínimo incompleto.",
+                "",
+                "Antes de copiar el expediente firmado, publique el contexto hidrológico completo desde Hidrogramas.",
+                "",
+                "Faltan:",
+                ...faltantesExpediente.map((item) => `- ${item}`)
+              ].join("\n")
+            );
+
+            return;
+          }
           const textoExpediente = [
             "# Expediente hidrológico mínimo — Cuenca activa",
             "",
@@ -1641,6 +1684,7 @@ const obtenerResultadoQMetodo = (metodo) => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta PR cierra la OT-0047 — Regresión multi-ruta expediente firmado.

El objetivo fue validar que el expediente hidrológico mínimo firmado conserve su integridad bajo rutas reales de navegación y que no se exporte parcialmente cuando falta contexto hidrológico.

## Cambios incluidos

- Apertura documental de regresión multi-ruta.
- Guardia para bloquear copia de expediente incompleto.
- Preservación de Q-5 al navegar entre Hidrogramas, Racional y Comparador.
- Cierre técnico de la OT.

## Resultado práctico

Rutas evaluadas:

- R1 Hidrogramas → Comparador: OK.
- R2 Comparador directo sin contexto completo: bloqueado correctamente.
- R3 Hidrogramas → Racional → Comparador: OK.
- R4 Cambio estación IDF: OK.
- R5 Cambio Tr activo: no ejecutable todavía; los Tr del Índice son chips visuales y no control global.

## Validación

Las rutas completas confirmaron:

- Estación IDF poblada.
- Lluvia efectiva total poblada.
- Volumen esperado poblado.
- Tabla Q-5 con 4 filas.
- Sin Qp cero evidente.
- Tabla Método Racional presente.
- Contraste Q-5 vs Racional presente.
- Sello técnico presente.
- Sin undefined, null, NaN ni [object Object].

La ruta incompleta confirmó:

- Bloqueo de copia.
- Alerta técnica con faltantes.
- No exportación de expediente firmado parcial.

## Decisión técnica

No se implementa Tr global en esta OT.

La activación real de Tr desde el Índice queda diferida a:

OT-0048 — Estado global Tr de diseño.

## Restricciones respetadas

- No se usaron caudales externos como fundamento.
- No se usó SIATA para justificar caudales.
- No se modificó hidroEngine.js.
- No se modificaron fórmulas hidrológicas.
- No se alteró Qp, Tp, Volumen ni Q(t).
- No se introdujeron setTimeout ni console.log permanentes.

## Dictamen

OT-0047 certifica que el expediente firmado es robusto bajo rutas reales con contexto completo y se protege contra exportaciones parciales cuando falta contexto.