### PR TITLE
PRÁCTICA-001G — Plantillas portables base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ HidroFlow - copia.jsx
 
 # Inventarios locales generados por tooling HidroFlow
 10_LOGS/inventario_hidroflow_*.txt
+
+# HidroFlow configuracion local por maquina
+.hidroflow.local.json

--- a/.hidroflow.local.example.json
+++ b/.hidroflow.local.example.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.1",
+  "descripcion": "Plantilla de configuracion local portable de HidroFlow. Copiar como .hidroflow.local.json en cada maquina y ajustar rutas locales.",
+  "hf_root": "<RUTA_LOCAL_HIDROFLOW>",
+  "rutas": {
+    "proyectos": "<HF_ROOT>/05_PROYECTOS",
+    "exportaciones": "<HF_ROOT>/06_EXPORTACIONES",
+    "modulos": "<HF_ROOT>/03_MODULOS",
+    "toolbox": "<HF_ROOT>/07_TOOLBOX",
+    "bitacora": "<HF_ROOT>/00_ADMIN/bitacora"
+  },
+  "geomorfologia": {
+    "backend_geomorfologia": "arcpy",
+    "ruta_mdt": "<RUTA_LOCAL_MDT>",
+    "ruta_gdb_rectora": "<RUTA_LOCAL_GDB_RECTORA>",
+    "sistema_referencia_trabajo": "MAGNA-SIRGAS_2018_Origen-Nacional"
+  },
+  "reglas": {
+    "consumir_gdb_directamente_desde_app": false,
+    "consumir_exportaciones_canonicas": true,
+    "versionar_datos_pesados_en_git": false,
+    "crear_carpeta_por_fuente_hidrica": true
+  }
+}

--- a/00_ADMIN/bitacora/PRACTICA-001/PRÁCTICA-001G_plantillas_portables_base.md
+++ b/00_ADMIN/bitacora/PRACTICA-001/PRÁCTICA-001G_plantillas_portables_base.md
@@ -1,0 +1,40 @@
+# PRÁCTICA-001G — Plantillas portables base
+
+## 1. Propósito
+
+Crear plantillas versionables para que HidroFlow pueda configurarse de forma portable en distintas máquinas sin endurecer rutas absolutas dentro del código fuente.
+
+## 2. Artefactos creados
+
+```text
+.hidroflow.local.example.json
+05_PROYECTOS/Iguana/manifesto.proyecto.example.json
+```
+
+## 3. Archivo local no versionable
+
+El archivo real de configuración por máquina será:
+
+```text
+.hidroflow.local.json
+```
+
+Este archivo no debe versionarse si contiene rutas locales específicas, por lo cual queda protegido en .gitignore.
+
+## 4. Configuración local portable
+
+La plantilla .hidroflow.local.example.json define variables conceptuales como HF_ROOT, rutas base, ruta MDT, GDB rectora, backend geomorfológico y reglas de consumo.
+
+## 5. Manifiesto por fuente hídrica
+
+La plantilla manifesto.proyecto.example.json define la estructura mínima del proyecto Iguana, sus rutas portables, productos espaciales mínimos y productos tabulares mínimos.
+
+## 6. Decisión arquitectónica
+
+HidroFlow no debe depender de rutas absolutas rígidas ni de configuraciones locales incrustadas en el código.
+
+La App debe consumir exportaciones canónicas validadas, no una GDB externa directamente.
+
+## 7. Próximo paso
+
+Validar estructura de plantillas, versionarlas en Git y abrir Pull Request PRÁCTICA-001G.

--- a/05_PROYECTOS/Iguana/manifesto.proyecto.example.json
+++ b/05_PROYECTOS/Iguana/manifesto.proyecto.example.json
@@ -1,0 +1,41 @@
+{
+  "version": "0.1",
+  "nombre_fuente_hidrica": "Iguana",
+  "codigo_proyecto": "IGUANA_PC80",
+  "descripcion": "Plantilla de manifiesto portable por fuente hidrica. Copiar como manifesto.proyecto.json y ajustar rutas locales si aplica.",
+  "rutas": {
+    "proyecto": "<HF_ROOT>/05_PROYECTOS/Iguana",
+    "exportaciones": "<HF_ROOT>/06_EXPORTACIONES/Iguana",
+    "tablas": "<HF_ROOT>/06_EXPORTACIONES/Iguana/02_Tablas",
+    "mapas": "<HF_ROOT>/06_EXPORTACIONES/Iguana/01_Mapas",
+    "perfiles": "<HF_ROOT>/06_EXPORTACIONES/Iguana/03_Perfiles",
+    "reportes": "<HF_ROOT>/06_EXPORTACIONES/Iguana/04_Reportes",
+    "hms": "<HF_ROOT>/06_EXPORTACIONES/Iguana/05_HMS"
+  },
+  "geomorfologia": {
+    "backend_geomorfologia": "arcpy",
+    "ruta_mdt": "<RUTA_LOCAL_MDT>",
+    "ruta_gdb_rectora": "<RUTA_LOCAL_GDB_RECTORA>",
+    "sistema_referencia_trabajo": "MAGNA-SIRGAS_2018_Origen-Nacional"
+  },
+  "productos_espaciales_minimos": [
+    "PC_Obra_Iguana",
+    "PC_Snap_Obra_Iguana",
+    "Cuenca_Obra_Iguana",
+    "Cabecera_Candidata_Iguana",
+    "Eje_Principal_Continuo_Iguana",
+    "Perfil_Puntos_QC_Iguana",
+    "Tramos_Geomorf_QC_Iguana",
+    "Parametros_Geomorf_Iguana"
+  ],
+  "productos_tabulares_minimos": [
+    "Parametros_Geomorf_Iguana_*.csv",
+    "PC_Obra_Iguana_*.csv",
+    "PC_Snap_Obra_Iguana_*.csv",
+    "Cabecera_Candidata_Iguana_*.csv",
+    "Perfil_Puntos_QC_Iguana_*.csv",
+    "Tramos_Geomorf_QC_Iguana_*.csv"
+  ],
+  "estado": "plantilla",
+  "fecha_creacion": "YYYY-MM-DD"
+}


### PR DESCRIPTION
## Objetivo

Crear plantillas versionables para que HidroFlow pueda configurarse de forma portable en distintas máquinas sin endurecer rutas absolutas dentro del código fuente.

## Alcance

Esta PR agrega los artefactos base para la portabilidad operativa de HidroFlow:

- Plantilla de configuración local portable.
- Plantilla de manifiesto por fuente hídrica.
- Protección del archivo real de configuración local mediante `.gitignore`.
- Bitácora técnica de PRÁCTICA-001G.

## Artefactos creados

```text
.hidroflow.local.example.json
05_PROYECTOS/Iguana/manifesto.proyecto.example.json
00_ADMIN/bitacora/PRACTICA-001/PRÁCTICA-001G_plantillas_portables_base.md