### PR TITLE
PRÁCTICA-001I — Estructura documental base HidroFlow

### DIFF
--- a/00_ADMIN/bitacora/PRACTICA-001/PRÁCTICA-001I_estructura_documental_base.md
+++ b/00_ADMIN/bitacora/PRACTICA-001/PRÁCTICA-001I_estructura_documental_base.md
@@ -1,0 +1,22 @@
+# PRÁCTICA-001I — Estructura documental base HidroFlow
+
+## 1. Propósito
+
+Crear la estructura documental base de HidroFlow para iniciar la transición hacia documentación de usuario, documentación de software, manual operativo y arquitectura consolidada.
+
+## 2. Artefactos creados
+
+```text
+00_ADMIN/documentacion/GUIA_USUARIO_HIDROFLOW.md
+00_ADMIN/documentacion/GUIA_SOFTWARE_HIDROFLOW.md
+00_ADMIN/documentacion/MANUAL_OPERATIVO_HIDROFLOW.md
+00_ADMIN/documentacion/ARQUITECTURA_HIDROFLOW.md
+```
+
+## 3. Decisión arquitectónica
+
+HidroFlow no se considera maduro solo por ejecutar cálculos. Debe ser documentado, portable, auditable, transferible y operable por terceros.
+
+## 4. Próximo paso
+
+Versionar la estructura documental base y abrir Pull Request PRÁCTICA-001I.

--- a/00_ADMIN/documentacion/ARQUITECTURA_HIDROFLOW.md
+++ b/00_ADMIN/documentacion/ARQUITECTURA_HIDROFLOW.md
@@ -1,0 +1,17 @@
+# Arquitectura HidroFlow
+
+## 1. Propósito
+
+Este documento consolidará la arquitectura de HidroFlow como sistema portable, auditable, modular y mantenible.
+
+## 2. Estructura conceptual
+
+HidroFlow se organiza alrededor de código versionado, configuración portable, módulos técnicos, proyectos por fuente hídrica, exportaciones canónicas, tooling operativo y documentación.
+
+## 3. Principios
+
+HidroFlow debe ser portable, documentado, auditable, modular, trazable y operable desde distintas máquinas sin depender de rutas absolutas rígidas.
+
+## 4. Estado
+
+Documento base creado como parte de PRÁCTICA-001I. Su contenido detallado se desarrollará en fases posteriores.

--- a/00_ADMIN/documentacion/GUIA_SOFTWARE_HIDROFLOW.md
+++ b/00_ADMIN/documentacion/GUIA_SOFTWARE_HIDROFLOW.md
@@ -1,0 +1,13 @@
+# Guía del software HidroFlow
+
+## 1. Propósito
+
+Esta guía está orientada a personas que mantienen, desarrollan, auditan o integran HidroFlow.
+
+## 2. Alcance futuro
+
+La guía deberá explicar la arquitectura del repositorio, la estructura de carpetas, la configuración portable, los manifiestos por fuente hídrica, el Módulo 1 de Geomorfología, el backend ArcGIS Pro / ArcPy, la futura ruta hacia backend abierto, el motor hidrológico, la App React HidroFlow, el tooling PowerShell y las reglas de auditoría técnica.
+
+## 3. Estado
+
+Documento base creado como parte de PRÁCTICA-001I. Su contenido detallado se desarrollará en fases posteriores de madurez.

--- a/00_ADMIN/documentacion/GUIA_USUARIO_HIDROFLOW.md
+++ b/00_ADMIN/documentacion/GUIA_USUARIO_HIDROFLOW.md
@@ -1,0 +1,13 @@
+# Guía de usuario HidroFlow
+
+## 1. Propósito
+
+Esta guía está orientada a personas que usan HidroFlow para configurar, ejecutar, revisar y exportar resultados hidrológicos y geomorfológicos.
+
+## 2. Alcance futuro
+
+La guía deberá explicar cómo configurar HidroFlow, seleccionar una fuente hídrica, referenciar un MDT, generar productos geomorfológicos, revisar exportaciones, interpretar el Índice Hidrológico, interpretar el Comparador Multi-Método y generar el expediente hidrológico.
+
+## 3. Estado
+
+Documento base creado como parte de PRÁCTICA-001I. Su contenido detallado se desarrollará en fases posteriores de madurez.

--- a/00_ADMIN/documentacion/MANUAL_OPERATIVO_HIDROFLOW.md
+++ b/00_ADMIN/documentacion/MANUAL_OPERATIVO_HIDROFLOW.md
@@ -1,0 +1,20 @@
+# Manual operativo HidroFlow
+
+## 1. Propósito
+
+Este manual documentará la operación diaria de HidroFlow, incluyendo comandos, flujo Git, bitácoras, Pull Requests, sincronización post-merge, validación de build y manejo de advertencias.
+
+## 2. Comando obligatorio post-merge
+
+El comando operativo post-merge debe entregarse siempre completo:
+
+```powershell
+cd D:
+Set-Location "D:\HidroFlow"
+. "D:\HidroFlow\07_TOOLBOX\powershell\hidroflow-git-tools.ps1"
+Sincronizar-MainPostMerge
+```
+
+## 3. Regla operativa reforzada
+
+No se deben entregar comandos recortados, rutas truncadas ni nombres de archivo incompletos. Todo comando HidroFlow debe ser completo, ejecutable y auditable.


### PR DESCRIPTION
## Objetivo

Crear la estructura documental base de HidroFlow para iniciar la transición hacia documentación formal de usuario, documentación de software, manual operativo y arquitectura consolidada.

## Alcance

Esta PR crea la carpeta documental base:

```text
00_ADMIN/documentacion/
