### PR TITLE
PRÁCTICA-002A-0 — Auditoría de inventarios existentes geomorfológicos

### DIFF
--- a/00_ADMIN/bitacora/PRACTICA-002/PRÁCTICA-002A-0_auditoria_segura_inventarios_existentes_20260608_122208.md
+++ b/00_ADMIN/bitacora/PRACTICA-002/PRÁCTICA-002A-0_auditoria_segura_inventarios_existentes_20260608_122208.md
@@ -1,0 +1,1025 @@
+# PRÁCTICA-002A-0 — Auditoría segura de inventarios existentes de verdad geomorfológica
+
+Fecha: 06/08/2026 12:22:08
+Rama: practica-002a-0-auditoria-inventarios-geomorfologicos-existentes
+
+## 1. Propósito
+
+Auditar inventarios existentes de verdad geomorfológica antes de crear PRÁCTICA-002A, evitando repetir información ya documentada y evitando búsquedas autorreferenciales.
+
+Principio no negociable: todo se documenta, se analiza y se decide con evidencia.
+
+## 2. Estado Git inicial
+
+?? 00_ADMIN/bitacora/PRACTICA-002/
+
+## 3. Log reciente
+
+b60f291 Merge pull request #62 from luisger88/practica-001k-checklist-operacional-hidroflow
+7928440 docs(checklist): crea checklist operacional HidroFlow v1
+fe3df05 Merge pull request #61 from luisger88/practica-001j-manual-operativo-hidroflow
+ea8c869 docs(manual): crea manual operativo HidroFlow v1
+8df02ad Merge pull request #60 from luisger88/ot-0050-auditoria-quirurgica-indice-hidrologico
+434e6d7 docs(indice): audita indice hidrologico sin cambio funcional
+16f32fe Merge pull request #59 from luisger88/ot-0049-saneamiento-quirurgico-motor-indice
+82316a2 fix(motor): elimina duplicate key area_km2 en contexto
+19df8ee Merge pull request #58 from luisger88/practica-001i-estructura-documental-base
+95d14ca docs(documentacion): crea estructura documental base HidroFlow
+2ce216c Merge pull request #57 from luisger88/practica-001h-radar-documentacion-usuario-software
+5a0710f docs(documentacion): registra radar guias usuario y software
+dfac405 Merge pull request #56 from luisger88/practica-001g-plantillas-portables-base
+fabce02 docs(arquitectura): agrega plantillas portables base
+4f116bf Merge pull request #55 from luisger88/practica-001f-configuracion-portable-manifiesto
+9b2612c docs(arquitectura): define configuracion portable y manifiesto
+d75de94 Merge pull request #54 from luisger88/practica-001e-entrada-portable-param
+7c386e2 docs(geomorfologia): define entrada portable del Modulo 1
+e787809 Merge pull request #53 from luisger88/practica-001d-radar-independencia-arcgis-coordenadas
+787b4fe docs(geomorfologia): registra radar independencia ArcGIS y coordenadas
+
+## 4. Documentos existentes relacionados en PRÁCTICA-001
+
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md
+Length        : 207166
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md
+Length        : 13087
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_gdb_red_hidrica_aaron_20260607_181751.md
+Length        : 988
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md
+Length        : 4658
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md
+Length        : 612720
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md
+Length        : 18646
+LastWriteTime : 7/06/2026 7:49:43 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md
+Length        : 1843
+LastWriteTime : 7/06/2026 8:27:45 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001D_radar_independencia_arcgis_parametrizacion_coordenadas.md
+Length        : 2178
+LastWriteTime : 7/06/2026 9:38:05 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001E_entrada_portable_parametrizable_modulo1.md
+Length        : 3562
+LastWriteTime : 7/06/2026 10:38:24 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001F_configuracion_portable_manifiesto_proyecto.md
+Length        : 4028
+LastWriteTime : 7/06/2026 11:03:30 p. m.
+
+FullName      : D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001G_plantillas_portables_base.md
+Length        : 1368
+LastWriteTime : 7/06/2026 11:34:52 p. m.
+
+
+## 5. Evidencia de campos geomorfológicos críticos en documentos PRÁCTICA-001B y PRÁCTICA-001C
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md
+
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:21:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:20:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:22:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:21:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:23:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:22:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:44:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:52:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:45:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:53:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:46:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:54:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:52:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:60:EJE_RUTA = os.path.join(GDB, "Eje_Principal_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:53:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:61:EJE_CONTINUO = os.path.join(GDB, "Eje_Principal_Continuo_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:54:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:62:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:58:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:66:PERFIL_VAR = os.path.join(GDB, "Perfil_Puntos_VAR_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:59:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:67:PERFIL_QC = os.path.join(GDB, "Perfil_Puntos_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:60:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:68:PERFIL_QUIEBRES = os.path.join(GDB, "Perfil_Puntos_QUIEBRES_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:63:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:71:PUNTOS_QUIEBRE_QC = os.path.join(GDB, "Puntos_Quiebre_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:64:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:72:TRAMOS_QC = os.path.join(GDB, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:65:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:73:TRAMOS_LINEAS_QC = os.path.join(GDB, "Tramos_Geomorf_Lineas_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:66:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:74:PARAMS = os.path.join(GDB, "Parametros_Geomorf_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:67:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:75:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:249:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:386:    if arcpy.Exists(CUENCA_POLY) and not reset_cuenca:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:250:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:387:        msg("Cuenca_Obra_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:251:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:388:    else:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:260:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:397:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:261:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:398:        msg("OK: Cuenca_Obra_Iguana creada")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:262:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:399:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:266:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:404:        (CUENCA_R, "Cuenca_R_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:267:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:405:        (CUENCA_POLY, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:268:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:406:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:271:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:423:        (STREAMNET, "StreamNet_Strahler_150k"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:272:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:424:        (CUENCA_POLY, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:273:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:425:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:506:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:910:        count = int(arcpy.management.GetCount(EJE_CONTINUO)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:507:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:911:        msg("Eje_Principal_Continuo_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:508:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:912:        msg("Features eje continuo: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:510:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:914:        if count != 1:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:511:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:915:            raise Exception("Eje_Principal_Continuo_Iguana existe pero no tiene 1 feature.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:512:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:916:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:527:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:933:    if count != 1:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:528:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:934:        raise Exception("Eje_Principal_Continuo_Iguana no quedo como una sola feature.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:529:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:935:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:530:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:936:    msg("OK: Eje_Principal_Continuo_Iguana creado")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:531:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:937:    msg("Features eje continuo: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:545:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:951:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:546:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:952:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:547:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:953:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:619:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1035:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:620:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1036:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:621:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1037:        (PERFIL_Z, "Perfil_Puntos_Z_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:773:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1336:        count = int(arcpy.management.GetCount(PERFIL_QC)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:774:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1337:        msg("Perfil_Puntos_QC_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:775:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1338:        msg("Total puntos QC: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:816:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1468:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:817:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1469:    msg("OK: Perfil_Puntos_QC_Iguana creado")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:818:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1470:    msg("Total puntos: " + str(total))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:821:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1488:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:822:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1489:        (PERFIL_QC, "Perfil_Puntos_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:823:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1490:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:883:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1687:        msg("Puntos_Quiebre_QC_Iguana: " + str(int(arcpy.management.GetCount(PUNTOS_QUIEBRE_QC)[0])))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:884:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1688:        msg("Tramos_Geomorf_QC_Iguana: " + str(int(arcpy.management.GetCount(TRAMOS_QC)[0])))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:885:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1689:        return
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:935:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1914:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:936:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1915:    arcpy.management.CreateTable(GDB, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:937:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1916:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:952:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2083:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:953:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2084:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:954:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2085:        (PC_SNAP, "PC_Snap_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:955:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2086:        (TRAMOS_QC, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:956:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2087:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1014:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2264:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1015:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2265:        (CUENCA_POLY, "Cuenca_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1016:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2266:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1017:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2267:        (RED_HIDRICA, "Red_Hidrica_Obra_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1018:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2268:        (PERFIL_SEG_QC, "Perfil_Puntos_SEG_QC_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1019:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2269:        (TRAMOS_QC, "Tramos_Geomorf_QC_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1020:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2270:        (PUNTOS_QUIEBRE_QC, "Puntos_Quiebre_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1021:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2283:                "LONG_RED_KM",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1022:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2284:                "DENS_DREN",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1023:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2285:                "Z_SALIDA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1024:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2286:                "Z_CABECERA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1025:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2287:                "DESNIVEL_M",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1026:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2288:                "PEND_MED_PCT",
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1027:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2297:                msg("Perimetro km: " + str(round(row[1], 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1045:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2332:            long_cauce_m += row[0]
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1046:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2345:    densidad_drenaje = long_red_km / area_km2 if area_km2 > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1047:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2346:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1048:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2347:    # Z salida/cabecera desde perfil QC orientado
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1049:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2348:    z_salida = None
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1050:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2349:    z_cabecera = None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1051:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2350:    meas_min = 999999999
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1058:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2359:                meas_min = meas
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1059:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2360:                z_salida = z
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1060:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2361:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1062:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2363:                meas_max = meas
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1063:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2364:                z_cabecera = z
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1064:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2365:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1067:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2368:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1068:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2369:    desnivel_m = z_cabecera - z_salida
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1069:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2370:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1070:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2371:    pend_media_cauce_pct = (
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1071:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2372:        (desnivel_m / long_perfil_m) * 100.0
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1072:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2373:        if long_perfil_m > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1076:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2381:    kf = (
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1077:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2382:        area_km2 / (long_perfil_km ** 2)
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1078:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2383:        if long_perfil_km > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1080:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2385:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1081:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2386:    n_tramos_qc = int(arcpy.management.GetCount(TRAMOS_QC)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1082:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2387:    n_quiebres_qc = int(arcpy.management.GetCount(PUNTOS_QUIEBRE_QC)[0])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1083:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2388:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1084:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2389:    # Crear tabla
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1085:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2390:    arcpy.management.CreateTable(GDB, "Parametros_Geomorf_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1086:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2391:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1087:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2392:    campos = [
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1088:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2398:        ("LONG_RED_KM", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1089:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2399:        ("DENS_DREN", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1090:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2400:        ("Z_SALIDA", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1091:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2401:        ("Z_CABECERA", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1092:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2402:        ("DESNIVEL_M", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1093:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2403:        ("PEND_MED_PCT", "DOUBLE"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1094:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2409:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1098:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2413:            nombre,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1099:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2426:            "LONG_RED_KM",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1100:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2427:            "DENS_DREN",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1101:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2428:            "Z_SALIDA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1102:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2429:            "Z_CABECERA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1103:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2430:            "DESNIVEL_M",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1104:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2431:            "PEND_MED_PCT",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1105:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2441:            perim_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1106:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2442:            long_cauce_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1107:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2443:            long_perfil_km,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1108:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2444:            long_red_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1109:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2445:            densidad_drenaje,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1110:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2446:            z_salida,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1111:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2447:            z_cabecera,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1112:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2448:            desnivel_m,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1113:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2449:            pend_media_cauce_pct,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1114:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2458:    msg("Perimetro km: " + str(round(perim_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1115:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2459:    msg("Longitud cauce km: " + str(round(long_cauce_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1116:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2460:    msg("Longitud perfil km: " + str(round(long_perfil_km, 4)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1117:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2461:    msg("Longitud red km: " + str(round(long_red_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1118:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2462:    msg("Densidad drenaje: " + str(round(densidad_drenaje, 4)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1119:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2463:    msg("Z salida: " + str(round(z_salida, 2)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1120:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2464:    msg("Z cabecera: " + str(round(z_cabecera, 2)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1121:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2465:    msg("Desnivel m: " + str(round(desnivel_m, 2)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1122:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2466:    msg("Pendiente media cauce %: " + str(round(pend_media_cauce_pct, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1252:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:17:# ------------------------------------------------------------
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1253:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:18:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1254:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:19:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1267:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:32:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1268:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:33:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1269:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:34:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1320:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:18:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1321:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:19:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1322:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:20:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1338:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:36:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1339:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:37:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1340:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:38:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1343:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:41:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1344:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:42:EJE_CONTINUO = os.path.join(GDB, "Eje_Principal_Continuo_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1345:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:43:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1349:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:47:PERFIL_VAR = os.path.join(GDB, "Perfil_Puntos_VAR_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1350:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:48:PERFIL_QC = os.path.join(GDB, "Perfil_Puntos_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1351:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:49:PERFIL_QUIEBRES = os.path.join(GDB, "Perfil_Puntos_QUIEBRES_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1354:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:52:PUNTOS_QUIEBRE_QC = os.path.join(GDB, "Puntos_Quiebre_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1355:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:53:TRAMOS_QC = os.path.join(GDB, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1356:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:54:TRAMOS_LINEAS_QC = os.path.join(GDB, "Tramos_Geomorf_Lineas_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1357:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:55:PARAMS = os.path.join(GDB, "Parametros_Geomorf_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1358:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:56:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1374:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:123:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1375:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:138:        "LONG_RED_KM",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1376:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:139:        "DENS_DREN",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1377:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:140:        "Z_SALIDA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1378:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:141:        "Z_CABECERA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1379:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:142:        "DESNIVEL_M",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1380:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:143:        "PEND_MED_PCT",
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1381:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:159:        return
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1416:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:214:        (CUENCA_R, "Cuenca_R_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1417:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:215:        (CUENCA_POLY, "Cuenca_Obra_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_auditoria_rutas_scripts_geomorfologia_20260607_183031.md:1418:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:216:        (RED_HIDRICA, "Red_Hidrica_Obra_Iguana"),
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md
+
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:1:# PRÁCTICA-001B — Contenido GDB rectora MDT_Terreno_Base
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:2:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:3:Fecha: 2026-06-07 19:04:56.498966
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:4:GDB: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:5:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:11:### Cabecera_Candidata_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:12:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Cabecera_Candidata_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:13:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:18:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:19:### Cuenca_Obra_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:20:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Cuenca_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:21:- Geometría: Polygon
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:27:### Eje_Continuo_Cabecera_PC80
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:28:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Eje_Continuo_Cabecera_PC80
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:29:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:34:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:35:### Eje_Principal_Continuo_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:36:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Eje_Principal_Continuo_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:37:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:43:### Eje_Principal_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:44:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Eje_Principal_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:45:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:51:### Nodos_Control_Ruta_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:52:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Nodos_Control_Ruta_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:53:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:59:### Nodos_Control_Topo_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:60:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Nodos_Control_Topo_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:61:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:67:### Nodos_Red_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:68:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Nodos_Red_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:69:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:75:### Nodos_Topo_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:76:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Nodos_Topo_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:77:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:83:### PC_Obra_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:84:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\PC_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:85:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:91:### PC_Snap_Obra_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:92:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\PC_Snap_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:93:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:99:### Perfil_Puntos_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:100:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:101:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:106:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:107:### Perfil_Puntos_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:108:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:109:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:115:### Perfil_Puntos_QUIEBRES_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:116:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_QUIEBRES_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:117:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:123:### Perfil_Puntos_SEG_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:124:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_SEG_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:125:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:131:### Perfil_Puntos_SEG_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:132:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_SEG_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:133:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:139:### Perfil_Puntos_VAR_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:140:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_VAR_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:141:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:147:### Perfil_Puntos_ZM_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:148:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_ZM_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:149:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:155:### Perfil_Puntos_Z_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:156:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Perfil_Puntos_Z_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:157:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:163:### Puntos_Quiebre_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:164:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Puntos_Quiebre_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:165:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:171:### Puntos_Quiebre_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:172:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Puntos_Quiebre_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:173:- Geometría: Point
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:179:### Red_Candidata_Z_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:180:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Red_Candidata_Z_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:181:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:187:### Red_Hidrica_Obra_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:188:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Red_Hidrica_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:189:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:195:### StreamNet_Strahler_150k
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:196:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\StreamNet_Strahler_150k
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:197:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:203:### Tramos_Geomorf_Lineas_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:204:- Ruta: D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb\Tramos_Geomorf_Lineas_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:205:- Geometría: Polyline
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:208:- Extent: 4705949.941862951, 2251731.570019791, 4713075.449990106, 2258027.105553698
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:209:- Campos: OBJECTID, Shape, Shape_Length, ID_TRAMO, MEAS_INI, MEAS_FIN, LONG_TRAMO_M, Z_INI, Z_FIN, DZ_TRAMO_M, PEND_MEDIA, PEND_SUAV_MEDIA, N_PUNTOS, N_FLAG50, N_FLAG100, N_QUIEBRES, CLASE_TRAMO, TIPO_DOM
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:210:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:244:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:245:### Parametros_Geomorf_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:246:- Registros: 1
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:247:- Campos: OBJECTID, NOMBRE, AREA_KM2, PERIM_KM, LONG_CAUC_KM, LONG_PERF_KM, LONG_RED_KM, DENS_DREN, Z_SALIDA, Z_CABECERA, DESNIVEL_M, PEND_MED_PCT, KC_COMPAC, KF_FORMA, N_TRAMOS_QC, N_QUIEBRES
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:248:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:254:- Registros: 18
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:255:- Campos: OBJECTID, ID_TRAMO, MEAS_INI, MEAS_FIN, LONG_TRAMO_M, Z_INI, Z_FIN, DZ_TRAMO_M, PEND_MEDIA, PEND_SUAV_MEDIA, N_PUNTOS, N_FLAG50, N_FLAG100, N_QUIEBRES, CLASE_TRAMO, TIPO_DOM
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:256:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:257:### Tramos_Geomorf_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:258:- Registros: 4
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:259:- Campos: OBJECTID, ID_TRAMO, MEAS_INI, MEAS_FIN, LONG_TRAMO_M, Z_INI, Z_FIN, DZ_TRAMO_M, PEND_MEDIA, PEND_SUAV_MEDIA, N_PUNTOS, N_FLAG50, N_FLAG100, N_QUIEBRES, CLASE_TRAMO, TIPO_DOM
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:260:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:266:## 6. Conclusión automática preliminar
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:267:- Este reporte inventaria la GDB rectora externa usada por el módulo geomorfológico.
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_GDB_rectora_MDT_Terreno_Base_20260607_190446.md:268:- No modifica datos.
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_contenido_gdb_red_hidrica_aaron_20260607_181751.md
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md
+
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:1:# PRÁCTICA-001B — Diagnóstico de GDB rectora geomorfológica
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:2:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:14:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:15:## 2. GDB rectora real
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:16:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:17:La GDB rectora real del Módulo 1 de Geomorfología es:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:18:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:19:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:20:D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:21:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:26:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:27:La GDB rectora contiene productos derivados críticos:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:28:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:30:Cabecera_Candidata_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:31:Cuenca_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:32:Eje_Continuo_Cabecera_PC80
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:33:Eje_Principal_Continuo_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:34:Eje_Principal_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:41:Perfil_Puntos_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:42:Perfil_Puntos_QC_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:43:Perfil_Puntos_QUIEBRES_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:77:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:78:Parametros_Geomorf_Iguana: 1 registro
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:79:Tabla_Aristas_Iguana: 187 registros
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:80:Tramos_Geomorf_Iguana: 18 registros
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:81:Tramos_Geomorf_QC_Iguana: 4 registros
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:82:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:83:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:84:Campos principales de Parametros_Geomorf_Iguana:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:85:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:86:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:87:NOMBRE, AREA_KM2, PERIM_KM, LONG_CAUC_KM, LONG_PERF_KM, LONG_RED_KM, DENS_DREN, Z_SALIDA, Z_CABECERA, DESNIVEL_M, PEND_MED_PCT, KC_COMPAC, KF_FORMA, N_TRAMOS_QC, N_QUIEBRES
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:88:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:101:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:102:Faltan: contrato canónico geomorfológico, manifiesto de GDB rectora, inventario oficial de campos, relación GDB externa → exportaciones → HidroFlow App, reglas de actualización para nuevo punto de control y estrategia de independencia futura de ArcGIS Pro.
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:103:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:110:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:111:D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:112:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:113:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:114:Productos mínimos: PC_Obra_Iguana, PC_Snap_Obra_Iguana, Cuenca_Obra_Iguana, Cabecera_Candidata_Iguana, Eje_Principal_Continuo_Iguana, Perfil_Puntos_QC_Iguana y Tramos_Geomorf_QC_Iguana.
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:115:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:121:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:122:Productos mínimos: Parametros_Geomorf_Iguana_*.csv, PC_Obra_Iguana_*.csv, PC_Snap_Obra_Iguana_*.csv, Cabecera_Candidata_Iguana_*.csv, Perfil_Puntos_QC_Iguana_*.csv y Tramos_Geomorf_QC_Iguana_*.csv.
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:123:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:125:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:126:La GDB externa MDT_Terreno_Base.gdb queda reconocida como fuente espacial rectora del Módulo 1 para Iguaná PC_80. Las exportaciones tabulares en D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas quedan reconocidas como fuente tabular consumible por HidroFlow App.
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:127:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:129:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_diagnostico_GDB_rectora_geomorfologia.md:130:Construir un contrato canónico geomorfológico que relacione GDB rectora externa → productos espaciales mínimos → tablas exportadas → cuencasCatalogo.js / contexto HidroFlow → motor hidrológico → Índice / Comparador / Expediente.
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md
+
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:79:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260524_013443.xlsx         
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:80:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:81:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv.xml      
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:82:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.xlsx         
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:83:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:84:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv.xml      
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:85:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.xlsx         
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:86:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260523_234806.csv                     
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:97:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260524_013443.xlsx               
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:98:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv            
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:99:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv.xml        
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:100:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.xlsx           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:101:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv            
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:102:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv.xml        
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:103:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.xlsx           
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:104:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260523_234806.csv        
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:133:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.xlsx   
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:134:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:135:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv.xml       
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:136:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.xlsx          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:137:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:138:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv.xml       
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:139:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.xlsx          
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:140:D:\HidroFlow\06_EXPORTACIONES\Iguana\03_Perfiles                                                      
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:162:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:20:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:163:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:21:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:164:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:22:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:171:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:52:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:172:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:53:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:173:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:54:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:179:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:60:EJE_RUTA = os.path.join(GDB, "Eje_Principal_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:180:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:61:EJE_CONTINUO = os.path.join(GDB, "Eje_Principal_Continuo_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:181:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:62:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:185:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:66:PERFIL_VAR = os.path.join(GDB, "Perfil_Puntos_VAR_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:186:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:67:PERFIL_QC = os.path.join(GDB, "Perfil_Puntos_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:187:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:68:PERFIL_QUIEBRES = os.path.join(GDB, "Perfil_Puntos_QUIEBRES_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:190:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:71:PUNTOS_QUIEBRE_QC = os.path.join(GDB, "Puntos_Quiebre_QC_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:191:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:74:PARAMS = os.path.join(GDB, "Parametros_Geomorf_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:192:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:75:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:373:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:386:    if arcpy.Exists(CUENCA_POLY) and not reset_cuenca:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:374:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:387:        msg("Cuenca_Obra_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:375:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:388:    else:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:645:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:910:        count = int(arcpy.management.GetCount(EJE_CONTINUO)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:646:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:911:        msg("Eje_Principal_Continuo_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:647:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:912:        msg("Features eje continuo: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:649:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:914:        if count != 1:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:650:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:915:            raise Exception("Eje_Principal_Continuo_Iguana existe pero no tiene 1 feature.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:651:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:916:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:664:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:933:    if count != 1:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:665:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:934:        raise Exception("Eje_Principal_Continuo_Iguana no quedo como una sola feature.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:666:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:935:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:667:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:936:    msg("OK: Eje_Principal_Continuo_Iguana creado")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:668:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:937:    msg("Features eje continuo: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:681:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:951:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:682:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:952:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:683:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:953:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:755:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1035:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:756:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1036:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:757:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1037:        (PERFIL_Z, "Perfil_Puntos_Z_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:916:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1336:        count = int(arcpy.management.GetCount(PERFIL_QC)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:917:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1337:        msg("Perfil_Puntos_QC_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:918:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1338:        msg("Total puntos QC: " + str(count))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:962:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1468:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:963:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1469:    msg("OK: Perfil_Puntos_QC_Iguana creado")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:964:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1470:    msg("Total puntos: " + str(total))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:967:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1488:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:968:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1489:        (PERFIL_QC, "Perfil_Puntos_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:969:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1490:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1032:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1687:        msg("Puntos_Quiebre_QC_Iguana: " + str(int(arcpy.management.GetCount(PUNTOS_QUIEBRE_QC)[0])))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1033:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1688:        msg("Tramos_Geomorf_QC_Iguana: " + str(int(arcpy.management.GetCount(TRAMOS_QC)[0])))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1034:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1689:        return
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1087:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1914:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1088:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1915:    arcpy.management.CreateTable(GDB, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1089:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:1916:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1119:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2083:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1120:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2084:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1121:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2085:        (PC_SNAP, "PC_Snap_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1122:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2086:        (TRAMOS_QC, "Tramos_Geomorf_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1123:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2087:    ])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1179:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2264:    validar_requeridos([
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1180:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2265:        (CUENCA_POLY, "Cuenca_Obra_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1181:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2266:        (EJE_CONTINUO, "Eje_Principal_Continuo_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1182:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2267:        (RED_HIDRICA, "Red_Hidrica_Obra_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1183:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2268:        (PERFIL_SEG_QC, "Perfil_Puntos_SEG_QC_Iguana"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1184:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2269:        (TRAMOS_QC, "Tramos_Geomorf_QC_Iguana"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1185:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2270:        (PUNTOS_QUIEBRE_QC, "Puntos_Quiebre_QC_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1188:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2273:    if arcpy.Exists(PARAMS) and not reset_parametros:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1189:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2274:        msg("Parametros_Geomorf_Iguana ya existe - se reutiliza.")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1190:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2275:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1193:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2278:            [
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1194:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2284:                "DENS_DREN",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1195:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2285:                "Z_SALIDA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1196:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2286:                "Z_CABECERA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1197:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2287:                "DESNIVEL_M",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1198:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2288:                "PEND_MED_PCT",
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1199:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2297:                msg("Perimetro km: " + str(round(row[1], 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1227:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2341:            long_red_m += row[0]
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1228:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2345:    densidad_drenaje = long_red_km / area_km2 if area_km2 > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1229:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2346:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1230:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2347:    # Z salida/cabecera desde perfil QC orientado
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1231:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2348:    z_salida = None
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1232:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2349:    z_cabecera = None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1233:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2350:    meas_min = 999999999
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1240:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2363:                meas_max = meas
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1241:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2364:                z_cabecera = z
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1242:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2365:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1245:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2368:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1246:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2369:    desnivel_m = z_cabecera - z_salida
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1247:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2370:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1248:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2371:    pend_media_cauce_pct = (
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1249:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2372:        (desnivel_m / long_perfil_m) * 100.0
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1250:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2373:        if long_perfil_m > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1254:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2381:    kf = (
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1255:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2382:        area_km2 / (long_perfil_km ** 2)
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1256:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2383:        if long_perfil_km > 0 else None
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1258:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2385:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1259:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2386:    n_tramos_qc = int(arcpy.management.GetCount(TRAMOS_QC)[0])
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1260:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2387:    n_quiebres_qc = int(arcpy.management.GetCount(PUNTOS_QUIEBRE_QC)[0])
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1261:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2388:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1262:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2389:    # Crear tabla
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1263:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2390:    arcpy.management.CreateTable(GDB, "Parametros_Geomorf_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1264:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2391:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1265:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2392:    campos = [
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1266:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2399:        ("DENS_DREN", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1267:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2400:        ("Z_SALIDA", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1268:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2401:        ("Z_CABECERA", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1269:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2402:        ("DESNIVEL_M", "DOUBLE"),
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1270:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2403:        ("PEND_MED_PCT", "DOUBLE"),
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1271:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2409:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1280:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2420:        [
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1281:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2427:            "DENS_DREN",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1282:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2428:            "Z_SALIDA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1283:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2429:            "Z_CABECERA",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1284:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2430:            "DESNIVEL_M",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1285:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2431:            "PEND_MED_PCT",
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1286:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2441:            perim_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1287:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2442:            long_cauce_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1288:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2443:            long_perfil_km,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1289:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2444:            long_red_km,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1290:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2445:            densidad_drenaje,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1291:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2446:            z_salida,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1292:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2447:            z_cabecera,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1293:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2448:            desnivel_m,
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1294:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2449:            pend_media_cauce_pct,
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1295:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2458:    msg("Perimetro km: " + str(round(perim_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1296:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2459:    msg("Longitud cauce km: " + str(round(long_cauce_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1297:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2460:    msg("Longitud perfil km: " + str(round(long_perfil_km, 4)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1298:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2461:    msg("Longitud red km: " + str(round(long_red_km, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1299:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2462:    msg("Densidad drenaje: " + str(round(densidad_drenaje, 4)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1300:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2463:    msg("Z salida: " + str(round(z_salida, 2)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1301:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2464:    msg("Z cabecera: " + str(round(z_cabecera, 2)))
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1302:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2465:    msg("Desnivel m: " + str(round(desnivel_m, 2)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1303:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_Run_v1.py:2466:    msg("Pendiente media cauce %: " + str(round(pend_media_cauce_pct, 4)))
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1427:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:17:# ------------------------------------------------------------
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1428:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:18:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1429:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:19:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1436:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:32:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1437:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:33:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1438:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v1.py:34:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1521:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:18:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1522:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:19:GDB = r"D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb"
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1523:> 03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:20:arcpy.env.workspace = GDB
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1530:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:36:CUENCA_R = os.path.join(GDB, "Cuenca_R_Obra_Iguana")
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1531:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:37:CUENCA_POLY = os.path.join(GDB, "Cuenca_Obra_Iguana")
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_20260607_174239.md:1532:  03_MODULOS\M01_Geomorfologia\scripts\_activos\HFGeomorfologia_Modulo1_v2.py:38:RED_HIDRICA = os.path.join(GDB, "Red_Hidrica_Obra_Iguana")
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md
+
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:49:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260524_013443.xlsx         
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:50:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:51:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv.xml      
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:52:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.xlsx         
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:53:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:54:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv.xml      
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:55:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.xlsx         
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:56:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260523_234806.csv                     
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:67:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260524_013443.xlsx               
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:68:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv            
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:69:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv.xml        
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:70:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.xlsx           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:71:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv            
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:72:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv.xml        
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:73:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.xlsx           
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:74:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260523_234806.csv        
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:103:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.xlsx   
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:104:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:105:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv.xml       
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:106:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.xlsx          
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:107:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv           
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:108:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv.xml       
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:109:D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.xlsx          
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:110:D:\HidroFlow\06_EXPORTACIONES\Iguana\03_Perfiles                                                      
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:126:Cabecera_Candidata_Iguana_20260524_013443.xlsx          D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:127:Parametros_Geomorf_Iguana_20260523_234806.csv           D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:128:Parametros_Geomorf_Iguana_20260523_234806.csv.xml       D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:129:Parametros_Geomorf_Iguana_20260523_234806.xlsx          D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:130:Parametros_Geomorf_Iguana_20260524_013443.csv           D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:131:Parametros_Geomorf_Iguana_20260524_013443.csv.xml       D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:132:Parametros_Geomorf_Iguana_20260524_013443.xlsx          D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:133:PC_Obra_Iguana_20260523_234806.csv                      D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:144:PC_Snap_Obra_Iguana_20260524_013443.xlsx                D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:145:Perfil_Puntos_QC_Iguana_20260523_234806.csv             D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:146:Perfil_Puntos_QC_Iguana_20260523_234806.csv.xml         D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:147:Perfil_Puntos_QC_Iguana_20260523_234806.xlsx            D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:148:Perfil_Puntos_QC_Iguana_20260524_013443.csv             D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:149:Perfil_Puntos_QC_Iguana_20260524_013443.csv.xml         D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:150:Perfil_Puntos_QC_Iguana_20260524_013443.xlsx            D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:151:Perfil_Puntos_SEG_QC_Iguana_20260523_234806.csv         D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:180:Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.xlsx    D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:181:Tramos_Geomorf_QC_Iguana_20260523_234806.csv            D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:182:Tramos_Geomorf_QC_Iguana_20260523_234806.csv.xml        D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:183:Tramos_Geomorf_QC_Iguana_20260523_234806.xlsx           D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:184:Tramos_Geomorf_QC_Iguana_20260524_013443.csv            D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:185:Tramos_Geomorf_QC_Iguana_20260524_013443.csv.xml        D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:186:Tramos_Geomorf_QC_Iguana_20260524_013443.xlsx           D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tabla…
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001B_inventario_espacial_geomorfologico_LIMPIO_20260607_180118.md:187:
+
+
+### Archivo auditado
+D:\HidroFlow\00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md
+
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:9:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:10:D:\Distrito_de_Medellin\Modelo_D_Terreno\MDT_Terreno_Base\MDT_Terreno_Base.gdb
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:11:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:23:PC_Snap_Obra_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:24:Cuenca_Obra_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:25:Cabecera_Candidata_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:26:Eje_Principal_Continuo_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:27:Perfil_Puntos_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:28:Tramos_Geomorf_QC_Iguana
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:29:Parametros_Geomorf_Iguana
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:30:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:40:```text
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:41:Parametros_Geomorf_Iguana_*.csv
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:42:PC_Obra_Iguana_*.csv
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:44:Cabecera_Candidata_Iguana_*.csv
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:45:Perfil_Puntos_QC_Iguana_*.csv
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:46:Tramos_Geomorf_QC_Iguana_*.csv
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:47:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:50:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:51:### 6.1 Parametros_Geomorf
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:52:
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:54:NOMBRE
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:55:AREA_KM2
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:56:PERIM_KM
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:57:LONG_CAUC_KM
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:58:LONG_PERF_KM
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:59:LONG_RED_KM
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:60:DENS_DREN
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:61:Z_SALIDA
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:62:Z_CABECERA
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:63:DESNIVEL_M
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:64:PEND_MED_PCT
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:65:KC_COMPAC
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:66:KF_FORMA
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:67:N_TRAMOS_QC
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:68:N_QUIEBRES
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:69:```
+  00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:80:
+> 00_ADMIN\bitacora\PRACTICA-001\PRÁCTICA-001C_contrato_canonico_geomorfologico.md:81:Definir el mapeo campo por campo entre Parametros_Geomorf_Iguana, cuencasCatalogo.js y el contexto hidrológico exportable.
+
+
+## 6. Inventario acotado de 05_PROYECTOS/Iguana
+
+
+FullName      : D:\HidroFlow\05_PROYECTOS\Iguana\manifesto.proyecto.example.json
+Length        : 1484
+LastWriteTime : 7/06/2026 11:34:52 p. m.
+
+
+## 7. Inventario acotado de 06_EXPORTACIONES/Iguana
+
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260523_234806.csv
+Length        : 39
+LastWriteTime : 23/05/2026 11:48:29 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260523_234806.csv.xml
+Length        : 4133
+LastWriteTime : 23/05/2026 11:48:29 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260523_234806.xlsx
+Length        : 4995
+LastWriteTime : 23/05/2026 11:48:27 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260524_013443.csv
+Length        : 39
+LastWriteTime : 24/05/2026 1:35:02 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260524_013443.csv.xml
+Length        : 4133
+LastWriteTime : 24/05/2026 1:35:02 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Cabecera_Candidata_Iguana_20260524_013443.xlsx
+Length        : 4994
+LastWriteTime : 24/05/2026 1:35:00 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv
+Length        : 413
+LastWriteTime : 23/05/2026 11:48:11 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.csv.xml
+Length        : 13903
+LastWriteTime : 23/05/2026 11:48:11 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260523_234806.xlsx
+Length        : 5362
+LastWriteTime : 23/05/2026 11:48:09 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv
+Length        : 413
+LastWriteTime : 24/05/2026 1:34:44 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.csv.xml
+Length        : 13903
+LastWriteTime : 24/05/2026 1:34:44 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Parametros_Geomorf_Iguana_20260524_013443.xlsx
+Length        : 5362
+LastWriteTime : 24/05/2026 1:34:43 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260523_234806.csv
+Length        : 55
+LastWriteTime : 23/05/2026 11:48:30 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260523_234806.csv.xml
+Length        : 4556
+LastWriteTime : 23/05/2026 11:48:30 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260523_234806.xlsx
+Length        : 5017
+LastWriteTime : 23/05/2026 11:48:29 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260524_013443.csv
+Length        : 55
+LastWriteTime : 24/05/2026 1:35:04 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260524_013443.csv.xml
+Length        : 4556
+LastWriteTime : 24/05/2026 1:35:04 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Obra_Iguana_20260524_013443.xlsx
+Length        : 5016
+LastWriteTime : 24/05/2026 1:35:02 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260523_234806.csv
+Length        : 12
+LastWriteTime : 23/05/2026 11:48:32 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260523_234806.csv.xml
+Length        : 3373
+LastWriteTime : 23/05/2026 11:48:32 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260523_234806.xlsx
+Length        : 4966
+LastWriteTime : 23/05/2026 11:48:31 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260524_013443.csv
+Length        : 12
+LastWriteTime : 24/05/2026 1:35:05 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260524_013443.csv.xml
+Length        : 3373
+LastWriteTime : 24/05/2026 1:35:05 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\PC_Snap_Obra_Iguana_20260524_013443.xlsx
+Length        : 4966
+LastWriteTime : 24/05/2026 1:35:04 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv
+Length        : 722567
+LastWriteTime : 23/05/2026 11:48:20 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.csv.xml
+Length        : 18804
+LastWriteTime : 23/05/2026 11:48:20 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260523_234806.xlsx
+Length        : 434592
+LastWriteTime : 23/05/2026 11:48:18 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv
+Length        : 722567
+LastWriteTime : 24/05/2026 1:34:54 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.csv.xml
+Length        : 18804
+LastWriteTime : 24/05/2026 1:34:54 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_QC_Iguana_20260524_013443.xlsx
+Length        : 434595
+LastWriteTime : 24/05/2026 1:34:52 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260523_234806.csv
+Length        : 876513
+LastWriteTime : 23/05/2026 11:48:18 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260523_234806.csv.xml
+Length        : 25651
+LastWriteTime : 23/05/2026 11:48:18 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260523_234806.xlsx
+Length        : 557359
+LastWriteTime : 23/05/2026 11:48:16 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260524_013443.csv
+Length        : 876513
+LastWriteTime : 24/05/2026 1:34:51 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260524_013443.csv.xml
+Length        : 25651
+LastWriteTime : 24/05/2026 1:34:51 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_SEG_QC_Iguana_20260524_013443.xlsx
+Length        : 557360
+LastWriteTime : 24/05/2026 1:34:49 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260523_234806.csv
+Length        : 636199
+LastWriteTime : 23/05/2026 11:48:23 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260523_234806.csv.xml
+Length        : 15493
+LastWriteTime : 23/05/2026 11:48:23 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260523_234806.xlsx
+Length        : 358427
+LastWriteTime : 23/05/2026 11:48:21 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260524_013443.csv
+Length        : 636199
+LastWriteTime : 24/05/2026 1:34:56 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260524_013443.csv.xml
+Length        : 15493
+LastWriteTime : 24/05/2026 1:34:56 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_VAR_Iguana_20260524_013443.xlsx
+Length        : 358427
+LastWriteTime : 24/05/2026 1:34:54 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260523_234806.csv
+Length        : 346745
+LastWriteTime : 23/05/2026 11:48:25 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260523_234806.csv.xml
+Length        : 11491
+LastWriteTime : 23/05/2026 11:48:25 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260523_234806.xlsx
+Length        : 232078
+LastWriteTime : 23/05/2026 11:48:23 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260524_013443.csv
+Length        : 346745
+LastWriteTime : 24/05/2026 1:34:58 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260524_013443.csv.xml
+Length        : 11491
+LastWriteTime : 24/05/2026 1:34:58 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Perfil_Puntos_ZM_Iguana_20260524_013443.xlsx
+Length        : 232081
+LastWriteTime : 24/05/2026 1:34:57 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260523_234806.csv
+Length        : 1134
+LastWriteTime : 23/05/2026 11:48:27 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260523_234806.csv.xml
+Length        : 25849
+LastWriteTime : 23/05/2026 11:48:27 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260523_234806.xlsx
+Length        : 5870
+LastWriteTime : 23/05/2026 11:48:25 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260524_013443.csv
+Length        : 1134
+LastWriteTime : 24/05/2026 1:35:00 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260524_013443.csv.xml
+Length        : 25849
+LastWriteTime : 24/05/2026 1:35:00 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Puntos_Quiebre_QC_Iguana_20260524_013443.xlsx
+Length        : 5871
+LastWriteTime : 24/05/2026 1:34:59 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\schema.ini
+Length        : 8552
+LastWriteTime : 24/05/2026 1:35:05 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260523_234806.csv
+Length        : 1062
+LastWriteTime : 23/05/2026 11:48:15 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260523_234806.csv.xml
+Length        : 15317
+LastWriteTime : 23/05/2026 11:48:15 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260523_234806.xlsx
+Length        : 5781
+LastWriteTime : 23/05/2026 11:48:13 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.csv
+Length        : 1062
+LastWriteTime : 24/05/2026 1:34:48 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.csv.xml
+Length        : 15317
+LastWriteTime : 24/05/2026 1:34:48 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_Lineas_QC_Iguana_20260524_013443.xlsx
+Length        : 5781
+LastWriteTime : 24/05/2026 1:34:46 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv
+Length        : 967
+LastWriteTime : 23/05/2026 11:48:13 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.csv.xml
+Length        : 13800
+LastWriteTime : 23/05/2026 11:48:13 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260523_234806.xlsx
+Length        : 5735
+LastWriteTime : 23/05/2026 11:48:11 p. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv
+Length        : 967
+LastWriteTime : 24/05/2026 1:34:46 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.csv.xml
+Length        : 13800
+LastWriteTime : 24/05/2026 1:34:46 a. m.
+
+FullName      : D:\HidroFlow\06_EXPORTACIONES\Iguana\02_Tablas\Tramos_Geomorf_QC_Iguana_20260524_013443.xlsx
+Length        : 5735
+LastWriteTime : 24/05/2026 1:34:45 a. m.
+
+
+## 8. Plantillas y manifiestos portables conocidos
+
+
+FullName      : D:\HidroFlow\.hidroflow.local.example.json
+Length        : 876
+LastWriteTime : 7/06/2026 11:34:52 p. m.
+
+
+FullName      : D:\HidroFlow\05_PROYECTOS\Iguana\manifesto.proyecto.example.json
+Length        : 1484
+LastWriteTime : 7/06/2026 11:34:52 p. m.
+
+
+## 9. Evidencia Git acotada de prácticas relacionadas
+
+95d14ca (origin/practica-001i-estructura-documental-base, practica-001i-estructura-documental-base) docs(documentacion): crea estructura documental base HidroFlow
+5a0710f (origin/practica-001h-radar-documentacion-usuario-software, practica-001h-radar-documentacion-usuario-software) docs(documentacion): registra radar guias usuario y software
+fabce02 (origin/practica-001g-plantillas-portables-base, practica-001g-plantillas-portables-base) docs(arquitectura): agrega plantillas portables base
+9b2612c (origin/practica-001f-configuracion-portable-manifiesto, practica-001f-configuracion-portable-manifiesto) docs(arquitectura): define configuracion portable y manifiesto
+7c386e2 (origin/practica-001e-entrada-portable-param, practica-001e-entrada-portable-param) docs(geomorfologia): define entrada portable del Modulo 1
+787b4fe (origin/practica-001d-radar-independencia-arcgis-coordenadas, practica-001d-radar-independencia-arcgis-coordenadas) docs(geomorfologia): registra radar independencia ArcGIS y coordenadas
+c23a65d (origin/practica-001c-contrato-canonico-geomorfologico, practica-001c-contrato-canonico-geomorfologico) docs(geomorfologia): define contrato canonico geomorfologico
+1c47cb1 (origin/practica-001b-diagnostico-gdb-rectora-, practica-001b-diagnostico-gdb-rectora-) docs(geomorfologia): documenta descarte de red hidrica visual
+a4529c3 docs(geomorfologia): diagnostica GDB rectora de Modulo 1
+eac30ac (origin/practica-001-auditoria-arquitectura-geomorfologia-motor, practica-001-auditoria-arquitectura-geomorfologia-motor) tools(auditoria): consolida ejecutor modular V4 HidroFlow
+
+## 10. Lectura arquitectónica preliminar
+
+La PRÁCTICA-002A no debe repetir inventarios existentes. Debe reutilizar documentos ya versionados y crear únicamente lo que falte para convertir la verdad geomorfológica en contrato vivo para el motor HidroFlow.
+
+Hipótesis preliminar:
+
+```text
+1. Ya existe inventario GDB rectora.
+2. Ya existe inventario de productos espaciales mínimos.
+3. Ya existe inventario preliminar de parámetros geomorfológicos.
+4. Ya existe contrato canónico preliminar.
+5. Ya existen plantillas/manifiestos portables.
+6. Vacío probable: contrato vivo motor-consumidor y fitness functions automáticas.
+```
+
+## 11. Estado Git final
+
+?? 00_ADMIN/bitacora/PRACTICA-002/


### PR DESCRIPTION
## Objetivo

Auditar inventarios existentes de verdad geomorfológica antes de crear PRÁCTICA-002A, evitando repetir información ya documentada.

## Hallazgo principal

La auditoría confirma que ya existen documentos relevantes en PRÁCTICA-001:

```text
PRÁCTICA-001B — Diagnóstico GDB rectora geomorfológica
PRÁCTICA-001B — Inventario espacial geomorfológico
PRÁCTICA-001C — Contrato canónico geomorfológico