### PR TITLE
OT-0055C1 — Publica método IDF en Índice Hidrológico 

### DIFF
--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3553,6 +3553,7 @@ useEffect(() => {
     ...(previo ?? {}),
     fuente: "motor HidroFlow",
     estacion_idf: stn,
+    metodoIDF: "EPM",
     tr_diseno_activo: trStateGlobal?.Tr_activo ?? 25,
     periodos_retorno: TR_LIST,
     metodo_racional: {


### PR DESCRIPTION
## Objetivo

Publicar el método IDF adoptado en el contexto consumido por el Índice Hidrológico.

## Cambio aplicado

Se agrega un único campo al contexto base publicado desde `HidroFlow.jsx`:

```jsx
metodoIDF: "EPM",