### PR TITLE
OT-0055C2 — Publica estación IDF en Índice Hidrológico

### DIFF
--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3554,6 +3554,7 @@ useEffect(() => {
     fuente: "motor HidroFlow",
     estacion_idf: stn,
     metodoIDF: "EPM",
+    estacionesAdoptadas: stn ? [{ nombre: stn, peso: 1 }] : [],
     tr_diseno_activo: trStateGlobal?.Tr_activo ?? 25,
     periodos_retorno: TR_LIST,
     metodo_racional: {
@@ -3789,6 +3790,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 


### PR DESCRIPTION
## Objetivo

Publicar la estación IDF adoptada en el contexto consumido por el Índice Hidrológico.

## Cambio aplicado

Se agrega el campo `estacionesAdoptadas` al contexto base publicado desde `HidroFlow.jsx`:

```jsx
estacionesAdoptadas: stn ? [{ nombre: stn, peso: 1 }] : [],