### PR TITLE
OT-0055C3 — Publica distribución temporal en Índice Hidrológico

### DIFF
--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3555,6 +3555,7 @@ useEffect(() => {
     estacion_idf: stn,
     metodoIDF: "EPM",
     estacionesAdoptadas: stn ? [{ nombre: stn, peso: 1 }] : [],
+    distribucionTemporal: "EPM Q1",
     tr_diseno_activo: trStateGlobal?.Tr_activo ?? 25,
     periodos_retorno: TR_LIST,
     metodo_racional: {


### PR DESCRIPTION
## Objetivo

Publicar la curva de distribución temporal adoptada en el contexto consumido por el Índice Hidrológico.

## Cambio aplicado

Se agrega un único campo al contexto base publicado desde `HidroFlow.jsx`:

```jsx
distribucionTemporal: "EPM Q1",