### PR TITLE
OT-0055C4 — Publica S e Ia en Índice Hidrológico

### DIFF
--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3606,6 +3606,8 @@ useEffect(() => {
     CN_base: params?.cnBase ?? params?.CN ?? cnBase,
     CN_efectivo: params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase,
     AMC: params?.AMC ?? params?.amcActual ?? params?.amc ?? "II",
+    S_mm: Number((25400 / Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) - 254).toFixed(2)),
+    Ia_mm: Number((0.2 * (25400 / Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) - 254)).toFixed(2)),
 
     tc_metodos: calcTc(params),
     


### PR DESCRIPTION
## Objetivo

Publicar los parámetros S e Ia del método SCS-C((0.2 * (25400 / Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) - 254)).toFixed(2)),Publicar los parámetros S e Ia del método SCS-CN en el contexto consumido por el Índice Hidrológico.

## Cambio aplicado

Se agregan dos campos al contexto base publicado desde `HidroFlow.jsx`:

```jsx
S_mm: Number((25400 / Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) - 254).toFixed(2)),
