### PR TITLE
OT-0056F — Validación expediente copiado Q-Tr disponible

### DIFF
--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2202,6 +2202,17 @@ const leerT = (punto, indice) => {
             ? derivarEstadoQTrActivo({
                 ...qTrActivoPrevio,
                 ...siguienteContexto,
+                // OT-0056F preserva estacion IDF en Q-Tr activo cuando Hidrogramas refresca el contexto.
+                estacion_idf:
+                  siguienteContexto.estacion_idf ??
+                  qTrActivoPrevio.estacion_idf ??
+                  previo?.estacion_idf ??
+                  previo?.estacionIDF ??
+                  previo?.estacion ??
+                  previo?.nombre_estacion ??
+                  previo?.idf?.nombre ??
+                  previo?.idf?.estacion ??
+                  null,
                 tr_diseno_activo: qTrActivoPrevio.tr_activo ?? previo?.tr_diseno_activo ?? 25,
                 metodo_idf: qTrActivoPrevio.metodo_idf ?? previo?.metodo_idf ?? null,
                 distribucion_temporal: qTrActivoPrevio.distribucion_temporal ?? previo?.distribucion_temporal ?? null,
@@ -3805,7 +3816,7 @@ useEffect(() => {
           setParams={setParams}
         />
       )}
-      {tab==="hidro"      &&<ModHidrogramas params={params} est={est} name={name} onContextoComparador={onContextoComparador} />}
+      {tab==="hidro"      &&<ModHidrogramas params={params} est={est} name={stn} onContextoComparador={onContextoComparador} />}
       {tab==="racional"   &&<ModRacional   params={params} est={est} name={stn} onContextoComparador={onContextoComparador}/>}
       {tab==="sar"        &&<ModSAR        params={params} est={est} name={stn}/>}
       {tab === "Influencia" && (


### PR DESCRIPTION
## Resumen

Corrige la propagación de estación IDF hacia Hidrogramas y preserva `estacion_idf` al refrescar el estado Q-Tr activo, permitiendo validar el expediente copiado con Q-Tr activo disponible.

## Alcance

- Modifica `ModHidrogramas` para recibir `name={stn}`.
- Preserva `estacion_idf` dentro de `derivarEstadoQTrActivo` cuando Hidrogramas refresca el contexto.
- Corrige el estado Q-Tr activo de incompleto a disponible.
- Mantiene Pe total publicado.

## Validación

- Q-Tr activo visualmente disponible.
- Estación IDF visible: SAN CRISTOBAL.
- Pe total visible: 56,6523 mm.
- Campos mínimos completos.
- Expediente real copiado al portapapeles.
- Longitud del expediente copiado: 4791 caracteres.
- Expediente validado sin:
  - undefined
  - null
  - NaN
  - [object Object]
- Secciones obligatorias presentes:
  - Q-Tr activo
  - Q-5 auditado
  - Método Racional
  - Contraste Q-5 vs Método Racional
  - Restricciones técnicas
  - Sello técnico
- Build Vite aprobado.

## Restricciones cumplidas

- No modifica ComparadorMultiMetodo.jsx.
- No modifica Q-5.
- No modifica Método Racional.
- No recalcula caudales.
- Cambio acotado a HidroFlow.jsx.