### PR TITLE
OT-0064 — Integración interna silenciosa del diagnóstico documental

### DIFF
--- a/00_ADMIN/bitacora/OT-0064/OT-0064A_diseno_quirurgico_patch_diagnostico_documental_silencioso.md
+++ b/00_ADMIN/bitacora/OT-0064/OT-0064A_diseno_quirurgico_patch_diagnostico_documental_silencioso.md
@@ -1,0 +1,103 @@
+# OT-0064A — Diseño quirúrgico del patch funcional de diagnóstico documental silencioso
+
+Fecha: 2026-06-10 22:46:18
+
+## Estado base
+
+- Rama: ot-0064-integracion-interna-silenciosa-diagnostico-documental.
+- Rama creada desde main limpio post OT-0063.
+- Main base: 42c1bb4, estabilizado post PR #94.
+- OT-0063 dejó auditado y diseñado el diagnóstico documental no invasivo.
+- Working tree inicial limpio.
+
+## Objetivo
+
+Diseñar el patch funcional mínimo para integrar internamente el diagnóstico documental silencioso, sin aplicar todavía cambios funcionales sobre ComparadorMultiMetodo.jsx.
+
+## Servicio candidato
+
+Servicio puro existente:
+
+01_APP/HIDROFLOW/src/services/documentos/adaptarExpedienteDocumental.js
+
+Función candidata:
+
+adaptarExpedienteDocumental(textoExpediente, metadatosDocumento)
+
+## Import futuro propuesto
+
+El import futuro, si se autoriza OT-0064B, deberá agregarse en ComparadorMultiMetodo.jsx como import de servicio puro.
+
+Forma conceptual:
+
+import adaptarExpedienteDocumental from '../services/documentos/adaptarExpedienteDocumental';
+
+El import no debe introducir React adicional, estado global, motor hidrológico ni dependencias de exportación.
+
+## Punto exacto futuro de ejecución
+
+El diagnóstico futuro deberá ejecutarse inmediatamente después de:
+
+const textoExpediente = [...].join('\\n');
+
+y antes de la validación existente de tokens inválidos y secciones obligatorias.
+
+## Comportamiento permitido
+
+El diagnóstico interno podrá:
+
+- Ejecutar adaptarExpedienteDocumental sobre textoExpediente.
+- Recibir metadatos mínimos de trazabilidad.
+- Emitir console.warn si el diagnóstico falla.
+- Mantenerse no bloqueante.
+- No modificar textoExpediente.
+- No modificar el flujo de copiado.
+
+## Comportamiento prohibido
+
+- No bloquear el copiado si el diagnóstico documental falla.
+- No agregar window.alert nuevo.
+- No agregar window.prompt nuevo.
+- No reemplazar tokensInvalidosExpediente.
+- No reemplazar seccionesObligatoriasExpediente.
+- No cambiar texto copiado al portapapeles.
+- No crear UI visible.
+- No generar PDF.
+- No generar Word.
+- No generar mapas.
+- No tocar hidroEngine.js.
+- No recalcular Q-Tr, Q-5 ni Método Racional.
+
+## Pseudopatch futuro
+
+const diagnosticoDocumental = adaptarExpedienteDocumental(textoExpediente, {
+  fuenteExpediente: 'ComparadorMultiMetodo.textoExpediente',
+  origenPlantilla: 'OT-0064',
+  cuencaActiva: contextoBase?.cuencaNombre ?? 'Cuenca activa'
+});
+
+if (!diagnosticoDocumental.ok) {
+  console.warn('Diagnóstico documental no invasivo:', diagnosticoDocumental);
+}
+
+Este pseudopatch no debe bloquear ni modificar el flujo existente.
+
+## Validaciones requeridas para OT-0064B
+
+- Confirmar import del adaptador.
+- Confirmar llamada posterior a textoExpediente.
+- Confirmar ausencia de modificación del texto copiado.
+- Confirmar ausencia de nuevas alertas o prompts.
+- Confirmar ausencia de cambios en tokensInvalidosExpediente.
+- Confirmar ausencia de cambios en seccionesObligatoriasExpediente.
+- Confirmar ausencia de referencias a hidroEngine.js.
+- Confirmar ausencia de PDF, Word, mapas y exportaciones complejas.
+- Confirmar build Vite.
+
+## Decisión técnica
+
+OT-0064A no implementa el patch funcional. Solo define su diseño quirúrgico. La implementación mínima queda reservada para OT-0064B.
+
+## Criterio de salida
+
+OT-0064A queda completa cuando exista el diseño quirúrgico versionado del patch funcional de diagnóstico documental silencioso, sin cambios funcionales sobre la aplicación.

--- a/00_ADMIN/bitacora/OT-0064/OT-0064B_integracion_interna_silenciosa_diagnostico_documental.md
+++ b/00_ADMIN/bitacora/OT-0064/OT-0064B_integracion_interna_silenciosa_diagnostico_documental.md
@@ -1,0 +1,38 @@
+# OT-0064B — Integración interna silenciosa del diagnóstico documental
+
+Fecha: 2026-06-10 22:54:17
+
+## Estado base
+
+- Rama: ot-0064-integracion-interna-silenciosa-diagnostico-documental.
+- OT-0064A cerrada en commit 494f62a.
+- Main base: 42c1bb4, estabilizado post OT-0063.
+- Working tree inicial limpio.
+
+## Objetivo
+
+Integrar internamente el adaptador documental como diagnóstico silencioso no bloqueante, usando el textoExpediente real y sin alterar el flujo de copiado.
+
+## Intervención autorizada
+
+- Agregar import del servicio puro adaptarExpedienteDocumental.
+- Ejecutar diagnóstico justo después de construir textoExpediente.
+- Usar try/catch para impedir bloqueo del copiado.
+- Usar console.warn solo si el diagnóstico falla.
+
+## Restricciones
+
+- No modificar textoExpediente.
+- No modificar tokensInvalidosExpediente.
+- No modificar seccionesObligatoriasExpediente.
+- No reemplazar validación existente.
+- No bloquear copiado.
+- No agregar window.alert ni window.prompt.
+- No crear UI visible.
+- No generar PDF, Word ni mapas.
+- No tocar hidroEngine.js.
+- No recalcular Q-Tr, Q-5 ni Método Racional.
+
+## Criterio de salida
+
+OT-0064B queda completa cuando el diagnóstico documental silencioso esté integrado, el build Vite apruebe y se confirme que no cambió el flujo de copiado ni el texto exportable.

--- a/00_ADMIN/bitacora/OT-0064/OT-0064C_cierre_integracion_interna_silenciosa_diagnostico_documental.md
+++ b/00_ADMIN/bitacora/OT-0064/OT-0064C_cierre_integracion_interna_silenciosa_diagnostico_documental.md
@@ -1,0 +1,59 @@
+# OT-0064C — Cierre integral de integración interna silenciosa del diagnóstico documental
+
+Fecha: 2026-06-10 23:03:32
+
+## Estado base
+
+- Rama: ot-0064-integracion-interna-silenciosa-diagnostico-documental.
+- Main base: 42c1bb4, estabilizado post OT-0063.
+- OT-0064A cerrada en commit 494f62a.
+- OT-0064B cerrada en commit c025a5e.
+- Working tree previo al cierre: limpio.
+
+## Ciclo OT-0064 ejecutado
+
+### OT-0064A — Diseño quirúrgico del patch funcional
+
+- Commit: 494f62a docs(expediente): diseña patch diagnostico documental silencioso
+- Resultado: se definió el punto exacto de integración posterior a textoExpediente y previo a validación/copiado.
+
+### OT-0064B — Integración interna silenciosa
+
+- Commit: c025a5e feat(expediente): integra diagnostico documental silencioso
+- Resultado: se importó adaptarExpedienteDocumental en ComparadorMultiMetodo.jsx.
+- Resultado: se ejecuta diagnóstico documental sobre textoExpediente real.
+- Resultado: el diagnóstico es silencioso, no bloqueante y solo emite console.warn si falla.
+
+## Validación técnica
+
+- Build Vite aprobado en OT-0064B.
+- Validación focal confirmó permanencia de tokensInvalidosExpediente.
+- Validación focal confirmó permanencia de seccionesObligatoriasExpediente.
+- Validación focal confirmó permanencia del mensaje de validación fallida.
+- Validación focal confirmó permanencia del botón Copiar expediente hidrológico mínimo.
+- Validación focal no detectó incorporación de PDF, Word, mapas ni exportadores complejos.
+
+## Restricciones cumplidas
+
+- No se modificó textoExpediente.
+- No se modificó tokensInvalidosExpediente.
+- No se modificó seccionesObligatoriasExpediente.
+- No se reemplazó la validación existente.
+- No se bloquea el copiado.
+- No se agregaron window.alert ni window.prompt nuevos.
+- No se creó UI visible.
+- No se generó PDF.
+- No se generó Word.
+- No se generaron mapas.
+- No se modificó hidroEngine.js.
+- No se recalculó Q-Tr.
+- No se recalculó Q-5.
+- No se recalculó Método Racional.
+
+## Resultado final
+
+OT-0064 integra internamente el diagnóstico documental silencioso en el comparador sin alterar el flujo de copiado ni el expediente exportable.
+
+## Criterio de cierre
+
+OT-0064 queda lista para Pull Request hacia main como integración interna silenciosa del diagnóstico documental.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -4,6 +4,7 @@ import { setTcState } from "../agents/tcAgent";
 import { calcTc, mapTcResultados } from "../services/hidroEngine";
 import { seleccionarTc } from "../services/tcSelector";
 import { derivarRangoCompetenteTc } from "../services/tc/derivarRangoCompetenteTc";
+import adaptarExpedienteDocumental from "../services/documentos/adaptarExpedienteDocumental";
 
 import {
   resumenComparadorCatalogo,
@@ -1710,6 +1711,19 @@ const obtenerResultadoQMetodo = (metodo) => {
             "- No se alteran Qp, Tp, Volumen ni Q(t).",
             "",
           ].join("\n");
+          try {
+            const diagnosticoDocumentalExpediente = adaptarExpedienteDocumental(textoExpediente, {
+              fuenteExpediente: "ComparadorMultiMetodo.textoExpediente",
+              origenPlantilla: "OT-0064",
+              cuencaActiva: contextoBase?.cuencaNombre ?? "Cuenca activa"
+            });
+
+            if (!diagnosticoDocumentalExpediente.ok) {
+              console.warn("Diagnóstico documental no invasivo:", diagnosticoDocumentalExpediente);
+            }
+          } catch (errorDiagnosticoDocumental) {
+            console.warn("Diagnóstico documental no invasivo no ejecutado:", errorDiagnosticoDocumental);
+          }
 
               // OT-0056E valida expediente copiado antes de enviarlo al portapapeles.
               const tokensInvalidosExpediente = ["undefined", "null", "NaN", "[object Object]"];


### PR DESCRIPTION
## Resumen

OT-0064 integra internamente el diagnóstico documental silencioso en el comparador, sin alterar el flujo de copiado ni el texto exportable.

## Cambios principales

- Diseño quirúrgico del patch funcional.
- Import del servicio puro `adaptarExpedienteDocumental`.
- Ejecución del diagnóstico documental sobre `textoExpediente` real.
- Diagnóstico no bloqueante mediante `try/catch`.
- `console.warn` solo si el diagnóstico falla.
- Cierre integral de la integración silenciosa.

## Restricciones cumplidas

- No se modificó `textoExpediente`.
- No se modificó `tokensInvalidosExpediente`.
- No se modificó `seccionesObligatoriasExpediente`.
- No se reemplazó la validación existente.
- No se bloquea el copiado.
- No se agregaron `window.alert` ni `window.prompt` nuevos.
- No se creó UI visible.
- No se generó PDF, Word ni mapas.
- No se modificó `hidroEngine.js`.
- No se recalcularon Q-Tr, Q-5 ni Método Racional.

## Validación

- Build Vite aprobado.
- Validaciones focales aprobadas.
- Working tree limpio.