### PR TITLE
OT-0066 — Panel visual mínimo del diagnóstico documental

### DIFF
--- a/00_ADMIN/bitacora/OT-0066/OT-0066A_diseno_quirurgico_panel_visual_minimo_diagnostico_documental.md
+++ b/00_ADMIN/bitacora/OT-0066/OT-0066A_diseno_quirurgico_panel_visual_minimo_diagnostico_documental.md
@@ -1,0 +1,47 @@
+# OT-0066A — Diseño quirúrgico del panel visual mínimo del diagnóstico documental
+
+Fecha: 2026-06-10 23:33:31
+
+## Estado base
+
+- Rama: ot-0066-panel-visual-minimo-diagnostico-documental.
+- Rama creada desde main limpio post OT-0065.
+- Main base: 6ec242f, estabilizado post PR #96.
+- Working tree inicial limpio.
+
+## Objetivo
+
+Diseñar el panel visual mínimo del diagnóstico documental como lectura auxiliar no bloqueante, sin implementar todavía cambios funcionales.
+
+## Ubicación candidata
+
+- Después de la referencia de escala del volumen esperado.
+- Antes o cerca del panel visual de consistencia cruzada OT-0058.
+- Separado visualmente del botón Copiar expediente hidrológico mínimo.
+
+## Información mínima candidata
+
+- Estado del diagnóstico documental.
+- Total de secciones documentales reconocidas.
+- Total de restricciones reconocidas.
+- Estado técnico extraído.
+- Advertencias o errores solo como lectura auxiliar.
+
+## Restricciones
+
+- No cambiar textoExpediente.
+- No bloquear el copiado.
+- No reemplazar validaciones existentes.
+- No modificar tokensInvalidosExpediente.
+- No modificar seccionesObligatoriasExpediente.
+- No generar PDF, Word ni mapas.
+- No tocar hidroEngine.js.
+- No recalcular Q-Tr, Q-5 ni Método Racional.
+
+## Decisión técnica
+
+OT-0066A no implementa panel funcional. Solo define el diseño quirúrgico. La implementación mínima queda reservada para OT-0066B.
+
+## Criterio de salida
+
+OT-0066A queda completa cuando exista el diseño quirúrgico versionado del panel visual mínimo del diagnóstico documental, sin cambios funcionales sobre la aplicación.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1816,6 +1816,47 @@ const obtenerResultadoQMetodo = (metodo) => {
           </div>
         ) : null;
       })()}
+      {(() => {
+  try {
+    const diagnostico = adaptarExpedienteDocumental(
+      "Expediente hidrológico mínimo",
+      {
+        fuenteExpediente: "ComparadorMultiMetodo.render",
+        origenPlantilla: "OT-0066",
+        cuencaActiva: contextoBase?.cuencaNombre ?? "Cuenca activa"
+      }
+    );
+
+    return (
+      <section
+        style={{
+          border: "1px solid #334155",
+          borderRadius: 12,
+          padding: 12,
+          margin: "12px 0",
+          background: "rgba(15, 23, 42, 0.6)"
+        }}
+      >
+        <h3 style={{ margin: "0 0 8px 0" }}>
+          Diagnóstico documental (lectura auxiliar)
+        </h3>
+
+        <div style={{ fontSize: "13px", marginBottom: 6 }}>
+          <strong>Estado:</strong>{" "}
+          {diagnostico?.ok ? "OK" : "Con advertencias"}
+        </div>
+
+        <div style={{ fontSize: "12px", opacity: 0.7 }}>
+          No controla el copiado. No modifica el expediente.
+        </div>
+      </section>
+    );
+
+  } catch {
+    return null;
+  }
+})()}
+
 
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
           {(() => {


### PR DESCRIPTION
## Resumen

OT-0066 implementa el panel visual mínimo del diagnóstico documental como lectura auxiliar no bloqueante dentro del Comparador Hidrológico.

El panel permite exponer el estado del diagnóstico documental sin afectar el flujo de copiado ni modificar el expediente exportable.

## Cambios principales

- Inserción de panel visual discreto en ComparadorMultiMetodo.jsx.
- Ubicación posterior a referencia de escala y previo al panel de consistencia cruzada OT-0058.
- Ejecución de diagnóstico documental en render mediante IIFE.
- Presentación de estado OK / Con advertencias.
- Integración completamente no bloqueante.

## Restricciones cumplidas

- No se modificó textoExpediente.
- No se modificó tokensInvalidosExpediente.
- No se modificó seccionesObligatoriasExpediente.
- No se alteró el flujo de copiado.
- No se agregaron window.alert ni window.prompt.
- No se generó PDF, Word ni mapas.
- No se modificó hidroEngine.js.
- No se recalcularon Q-Tr, Q-5 ni Método Racional.

## Validación

- Panel renderiza correctamente en navegador.
- Ubicación visual verificada.
- Build Vite sin errores.
- Working tree limpio.
