### PR TITLE
OT-0072 — Validación visual y técnica del panel qSeries

### DIFF
--- a/00_ADMIN/bitacora/OT-0072/OT-0072A_auditoria_visual_tecnica_panel_qseries.md
+++ b/00_ADMIN/bitacora/OT-0072/OT-0072A_auditoria_visual_tecnica_panel_qseries.md
@@ -1,0 +1,59 @@
+# OT-0072A — Auditoría visual y técnica del panel qSeries
+
+Fecha: 2026-06-12 20:03:44
+
+## Estado base
+
+- Rama: ot-0072-validacion-visual-tecnica-panel-qseries.
+- Rama creada desde main limpio post OT-0071.
+- Main base: 4a478a1, merge post PR #101.
+- OT-0071 dejó implementado el panel diagnóstico qSeries no invasivo.
+- Working tree inicial limpio.
+
+## Objetivo
+
+Validar visual y técnicamente el panel diagnóstico qSeries en navegador, confirmando que aparece como lectura no invasiva antes del Bloque Q-5 y que no altera el flujo hidrológico existente.
+
+## Elementos a validar en navegador
+
+- El panel diagnóstico qSeries aparece visible.
+- El panel se ubica antes del Bloque Q-5.
+- El panel muestra estado de disponibilidad qSeries.
+- El panel muestra total de métodos evaluados.
+- El panel muestra publicados.
+- El panel muestra parciales.
+- El panel muestra no disponibles.
+- El panel muestra inconsistentes.
+- El Bloque Q-5 sigue visible e intacto.
+- No se muestra qSeries cruda.
+- No se muestran puntos tiempo-caudal.
+- No aparecen métricas De, W50, W25, pendientes ni asimetría.
+- No cambia el flujo de copiado del expediente.
+
+## Validación técnica de código
+
+Se validará que el panel usa diagnosticoQSeries.resumen y que no se introducen cálculos morfológicos ni modificaciones al motor.
+
+## Restricciones
+
+- No modificar ComparadorMultiMetodo.jsx en OT-0072A.
+- No modificar HidroFlow.jsx.
+- No modificar hidroEngine.js.
+- No recalcular hidrogramas.
+- No alterar Qp, Tp, Volumen ni Q(t).
+- No calcular De, W50, W25, pendientes ni asimetría.
+- No generar PDF, Word ni mapas.
+
+## Criterio de salida
+
+OT-0072A queda completa cuando exista auditoría versionada de validación visual y técnica del panel qSeries, sin cambios funcionales sobre la aplicación.
+
+## Resultado de validación
+
+- Panel diagnóstico qSeries visible en navegador.
+- Panel ubicado como lectura auxiliar antes del Bloque Q-5.
+- Bloque Q-5 permanece visible e intacto.
+- No se observó qSeries cruda.
+- No se observaron métricas De, W50, W25, pendientes ni asimetría.
+- Build Vite aprobado.
+- No se modificó código funcional en esta OT.

--- a/00_ADMIN/bitacora/OT-0072/OT-0072B_cierre_validacion_visual_tecnica_panel_qseries.md
+++ b/00_ADMIN/bitacora/OT-0072/OT-0072B_cierre_validacion_visual_tecnica_panel_qseries.md
@@ -1,0 +1,40 @@
+# OT-0072B — Cierre de validación visual y técnica del panel qSeries
+
+Fecha: 2026-06-12 20:13:36
+
+## Estado base
+
+- Rama: ot-0072-validacion-visual-tecnica-panel-qseries.
+- OT-0072A cerrada en commit 0908ce4.
+- Build Vite aprobado.
+- Working tree previo al cierre: limpio.
+
+## Resultado de validación visual
+
+- Panel diagnóstico qSeries visible en navegador.
+- Panel ubicado antes del Bloque Q-5.
+- Estado mostrado: No disponible.
+- Total mostrado: 5.
+- Publicados: 0.
+- Parciales: 0.
+- No disponibles: 5.
+- Inconsistentes: 0.
+
+## Restricciones confirmadas
+
+- No se mostró qSeries cruda.
+- No se mostraron puntos tiempo-caudal.
+- No se calcularon De, W50, W25, pendientes ni asimetría.
+- El Bloque Q-5 permaneció visible e intacto.
+- No se modificó hidroEngine.js.
+- No se modificó HidroFlow.jsx.
+- No se recalcularon hidrogramas.
+- No se alteraron Qp, Tp, Volumen ni Q(t).
+
+## Decisión técnica
+
+OT-0072 valida el panel qSeries como lectura visual no invasiva. El panel informa disponibilidad de qSeries, pero no habilita todavía métricas de forma ni adopción técnica.
+
+## Criterio de cierre
+
+OT-0072 queda lista para Pull Request hacia main como validación visual y técnica del panel qSeries.


### PR DESCRIPTION
## Resumen

OT-0072 valida visual y técnicamente el panel diagnóstico qSeries incorporado en OT-0071, confirmando que se presenta como lectura no invasiva antes del Bloque Q-5.

## Cambios principales

- Auditoría visual y técnica del panel qSeries.
- Validación en navegador.
- Confirmación de ubicación antes del Bloque Q-5.
- Confirmación de valores visibles del panel.
- Cierre documental de la validación.

## Valores validados

- Estado: No disponible.
- Total: 5.
- Publicados: 0.
- Parciales: 0.
- No disponibles: 5.
- Inconsistentes: 0.

## Restricciones confirmadas

- No se mostró qSeries cruda.
- No se mostraron puntos tiempo-caudal.
- No se calcularon De, W50, W25, pendientes ni asimetría.
- El Bloque Q-5 permaneció visible e intacto.
- No se modificó hidroEngine.js.
- No se modificó HidroFlow.jsx.
- No se recalcularon hidrogramas.
- No se alteraron Qp, Tp, Volumen ni Q(t).

## Validación

- Panel visible en navegador.
- Build Vite aprobado.
- Working tree limpio.