### PR TITLE
OT-0080 — Publicación controlada de qSeries reales

### DIFF
--- a/00_ADMIN/bitacora/OT-0080/OT-0080A_diseno_publicacion_controlada_qseries.md
+++ b/00_ADMIN/bitacora/OT-0080/OT-0080A_diseno_publicacion_controlada_qseries.md
@@ -1,0 +1,204 @@
+\# OT-0080A — Publicación controlada de qSeries real
+
+
+
+\## Contexto
+
+
+
+Las OT-0078 y OT-0079 demostraron que:
+
+
+
+\- El motor hidrológico sí genera qSeries real mediante calcHidroCompleto.
+
+\- qSeries contiene pares {t, Q} con unidades coherentes.
+
+\- Se calculan Qpico, tPico y volTotal a partir de qSeries.
+
+\- Sin embargo, qSeries no es publicado aguas arriba en contextoBase.hidrogramas.
+
+
+
+Esto genera una situación donde el sistema:
+
+
+
+\- Sí calcula la serie completa Q(t),
+
+\- Pero solo expone valores resumen.
+
+
+
+\## Hallazgo técnico
+
+
+
+Función auditada:
+
+
+
+calcHidroCompleto(lluvRows, uh\_struct, dt\_min)
+
+
+
+Salida real:
+
+
+
+{
+
+&#x20; qSeries,
+
+&#x20; Qpico,
+
+&#x20; tPico,
+
+&#x20; volTotal,
+
+&#x20; metodo,
+
+&#x20; color
+
+}
+
+
+
+Conclusión:
+
+
+
+\- qSeries existe, es físico y consistente.
+
+\- La no publicación es una decisión de arquitectura, no un error del motor.
+
+
+
+\## Problema
+
+
+
+El objeto publicado en contextoBase.hidrogramas:
+
+
+
+\- Incluye Qpico, tPico, volTotal
+
+\- NO incluye qSeries
+
+
+
+Esto impide:
+
+
+
+\- análisis temporal
+
+\- auditoría morfológica
+
+\- trazabilidad del hidrograma
+
+
+
+\## Objetivo de OT-0080
+
+
+
+Definir y ejecutar una publicación controlada de qSeries que:
+
+
+
+\- No modifique el motor
+
+\- No recalcula hidrogramas
+
+\- No reconstruya Q(t)
+
+\- Sea explícita y opcional
+
+
+
+\## Propuesta de contrato
+
+
+
+Estructura esperada:
+
+
+
+{
+
+&#x20; qSeries,
+
+&#x20; Qpico,
+
+&#x20; tPico,
+
+&#x20; volTotal,
+
+&#x20; metodo,
+
+&#x20; color
+
+}
+
+
+
+\## Control de publicación
+
+
+
+Incluir bandera de control:
+
+
+
+publicarQSeries: false (por defecto)
+
+
+
+Comportamiento:
+
+
+
+\- false → solo resumen (estado actual)
+
+\- true → incluye qSeries
+
+
+
+\## Restricciones
+
+
+
+\- No modificar hidroEngine.js
+
+\- No modificar fórmulas
+
+\- No recalcular hidrogramas
+
+\- No construir Q(t) desde resúmenes
+
+\- No usar uh como qSeries
+
+\- No calcular métricas morfológicas aún
+
+
+
+\## Dictamen
+
+
+
+La publicación de qSeries es:
+
+
+
+\- Técnicamente válida ✅
+
+\- Hidrológicamente consistente ✅
+
+\- Arquitectónicamente viable ✅
+
+
+
+La siguiente fase debe implementar la publicación mínima controlada.
+

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2167,6 +2167,10 @@ const leerT = (punto, indice) => {
     sumaLluviaEfectivaMm / maxLluviaEfectivaMm > 3
       ? maxLluviaEfectivaMm
       : sumaLluviaEfectivaMm || null;
+  // OT-0080B — Publicación controlada de qSeries reales.
+  // Por defecto permanece desactivada para conservar el comportamiento actual.
+  const publicarQSeries = false;
+
   const hidrogramasQ5Exportables = (hidros || []).map((h) => ({
     metodo: h?.metodo ?? "Método Q-5",
     Qpico: h?.Qpico,
@@ -2174,7 +2178,8 @@ const leerT = (punto, indice) => {
     volTotal: h?.volTotal,
     Qp: h?.Qpico,
     Tp: h?.tPico,
-    volumen: h?.volTotal
+    volumen: h?.volTotal,
+    ...(publicarQSeries && Array.isArray(h?.qSeries) ? { qSeries: h.qSeries } : {})
   }));
 
       onContextoComparador((previo) => {


### PR DESCRIPTION
## Resumen

Esta OT implementa la publicación controlada de `qSeries` reales generadas por el motor hidrológico, sin recalcular hidrogramas ni modificar fórmulas.

## Contexto técnico

OT-0078 y OT-0079 demostraron que:

- `calcHidroCompleto` genera `qSeries` real como serie `{t, Q}`.
- `qSeries` se usa internamente para calcular `Qpico`, `tPico` y `volTotal`.
- El contexto exportable hacia el comparador publicaba únicamente resumen.
- La ausencia de `qSeries` en `contextoBase.hidrogramas` era una decisión de publicación, no un fallo del motor.

## Cambios realizados

- Se documentó el diseño de publicación controlada en `OT-0080A`.
- Se agregó un flag local:

```js
const publicarQSeries = false;