### PR TITLE
OT-0081 — Activación auditada de publicación qSeries

### DIFF
--- a/00_ADMIN/bitacora/OT-0081/OT-0081A_activacion_auditada_qseries.md
+++ b/00_ADMIN/bitacora/OT-0081/OT-0081A_activacion_auditada_qseries.md
@@ -1,0 +1,20 @@
+\# OT-0081A — Activación auditada de publicación qSeries
+
+
+
+\## Contexto
+
+
+
+OT-0081 se abre después del cierre y estabilización de OT-0080.
+
+
+
+OT-0080 dejó preparada la publicación controlada de qSeries reales mediante el flag local:
+
+
+
+```js
+
+const publicarQSeries = false;
+

--- a/00_ADMIN/bitacora/OT-0081/OT-0081C_validacion_estructural_qseries_publicadas.md
+++ b/00_ADMIN/bitacora/OT-0081/OT-0081C_validacion_estructural_qseries_publicadas.md
@@ -1,0 +1,116 @@
+\# OT-0081C — Validación estructural de qSeries publicadas
+
+
+
+\## Contexto
+
+
+
+Después de activar `publicarQSeries = true` en OT-0081B, se validó visualmente el panel diagnóstico qSeries y el resumen estructural de hidrogramas en el comparador.
+
+
+
+\## Evidencia visual observada
+
+
+
+El panel diagnóstico qSeries reportó:
+
+
+
+\- Estado: Disponible
+
+\- Total: 5
+
+\- Publicados: 5
+
+\- Parciales: 0
+
+\- No disponibles: 0
+
+\- Inconsistentes: 0
+
+
+
+El resumen estructural de hidrogramas reportó:
+
+
+
+\- Tipo entrada: object
+
+\- Contenedor: resultados
+
+\- Candidatos: 5
+
+\- Con serie: 5
+
+\- Sin serie: 0
+
+\- Con Qpico: 5
+
+\- Con tPico: 5
+
+\- Con volTotal: 5
+
+
+
+\## Dictamen técnico
+
+
+
+La publicación auditada de qSeries reales quedó estructuralmente validada.
+
+
+
+Las cinco series Q(t) fueron reconocidas por el diagnóstico del comparador, sin reconstruir Q(t), sin interpolar, sin usar `uh` como serie y sin modificar `calcHidroCompleto`.
+
+
+
+\## Restricciones verificadas
+
+
+
+Durante la validación visual:
+
+
+
+\- No se mostraron arrays crudos completos.
+
+\- No se listaron puntos tiempo-caudal de forma masiva.
+
+\- No se calcularon métricas morfológicas.
+
+\- No se modificó el Bloque Q-5.
+
+\- No se adoptó automáticamente ningún método.
+
+\- No se recalcularon hidrogramas.
+
+
+
+\## Hallazgo complementario
+
+
+
+Aunque los indicadores estructurales ya reportan series publicadas, permanecen visibles textos de dictamen heredados que indican que las series Q(t) no están publicadas.
+
+
+
+Este mensaje quedó desactualizado frente al nuevo estado:
+
+
+
+\- Publicados: 5
+
+\- Con serie: 5
+
+\- Sin serie: 0
+
+
+
+\## Recomendación
+
+
+
+Abrir un ajuste posterior mínimo para actualizar el texto diagnóstico del comparador, de manera que el dictamen textual sea condicional al estado real de publicación de qSeries.
+

--- a/00_ADMIN/bitacora/OT-0081/OT-0081E_cierre_activacion_auditada_qseries.md
+++ b/00_ADMIN/bitacora/OT-0081/OT-0081E_cierre_activacion_auditada_qseries.md
@@ -1,0 +1,40 @@
+\# OT-0081E — Cierre técnico de activación auditada qSeries
+
+
+
+\## Contexto
+
+
+
+OT-0081 se desarrolló después de OT-0080, que dejó preparada la publicación controlada de qSeries reales mediante el flag local `publicarQSeries`.
+
+
+
+La activación se realizó en una rama aislada para validar si las series Q(t) generadas por `calcHidroCompleto` podían ser reconocidas estructuralmente por el comparador sin recalcular hidrogramas ni alterar el motor.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0081A — Apertura documental
+
+
+
+Se abrió la OT para activar de forma auditada la publicación de qSeries reales.
+
+
+
+\### OT-0081B — Activación funcional
+
+
+
+Se cambió el flag local:
+
+
+
+```js
+
+const publicarQSeries = true;
+

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -2169,7 +2169,7 @@ const leerT = (punto, indice) => {
       : sumaLluviaEfectivaMm || null;
   // OT-0080B — Publicación controlada de qSeries reales.
   // Por defecto permanece desactivada para conservar el comportamiento actual.
-  const publicarQSeries = false;
+  const publicarQSeries = true;
 
   const hidrogramasQ5Exportables = (hidros || []).map((h) => ({
     metodo: h?.metodo ?? "Método Q-5",

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2326,7 +2326,10 @@ const handleClickSeguro = (accion) => () => {
                 background: "rgba(15, 23, 42, 0.45)"
               }}
             >
-              <strong>Dictamen operativo:</strong> las series Q(t) no están publicadas para los métodos evaluados. No procede calcular métricas morfológicas de forma hasta publicar qSeries reales o normalizadas por método.
+              <strong>Dictamen operativo:</strong>{" "}
+{(resumenEstructuraHidrogramas?.resumen?.conSerieTemporal ?? 0) > 0
+  ? "las series Q(t) están publicadas y reconocidas por el diagnóstico estructural. Las métricas morfológicas permanecen bloqueadas hasta una OT posterior de análisis de forma."
+  : "las series Q(t) no están publicadas para los métodos evaluados. No procede calcular métricas morfológicas de forma hasta publicar qSeries reales o normalizadas por método."}
             </div>
             {(() => {
               const resumenEstructural = resumenEstructuraHidrogramas?.resumen ?? {
@@ -2380,7 +2383,10 @@ const handleClickSeguro = (accion) => () => {
                       background: "rgba(15, 23, 42, 0.35)"
                     }}
                   >
-                    <strong>Dictamen de serie temporal:</strong> el objeto hidrogramas contiene resultados resumen para los 5 métodos evaluados, incluyendo Qpico, tPico y volTotal, pero no publica una serie temporal Q(t) reconocible. No procede calcular métricas morfológicas de forma hasta disponer de qSeries reales o normalizadas por método.
+                    <strong>Dictamen de serie temporal:</strong>{" "}
+{(resumenEstructural?.conSerieTemporal ?? 0) > 0
+  ? "el objeto hidrogramas contiene resultados resumen y series temporales Q(t) reconocibles para los métodos evaluados. La publicación de qSeries está activa y validada estructuralmente; las métricas morfológicas permanecen bloqueadas hasta una OT posterior."
+  : "el objeto hidrogramas contiene resultados resumen para los 5 métodos evaluados, incluyendo Qpico, tPico y volTotal, pero no publica una serie temporal Q(t) reconocible. No procede calcular métricas morfológicas de forma hasta disponer de qSeries reales o normalizadas por método."}
                   </div>
                   <div style={{ ...estilos.muted, marginTop: 8 }}>
                     Este bloque no muestra series crudas, no lista arrays completos y no calcula métricas morfológicas.


### PR DESCRIPTION
## Resumen

Esta OT activa de forma auditada la publicación de `qSeries` reales hacia `contextoBase.hidrogramas.resultados`, usando el contrato preparado en OT-0080.

## Secuencia técnica

- OT-0081A: apertura documental.
- OT-0081B: activación del flag `publicarQSeries = true`.
- OT-0081C: validación estructural visual de qSeries publicadas.
- OT-0081D: actualización condicional del dictamen textual del comparador.
- OT-0081E: cierre técnico documental.

## Cambios funcionales

Se activó la publicación controlada de qSeries reales:

```js
const publicarQSeries = true;