### PR TITLE
Diagnóstico morfológico Q(t): series aptas 5/5; no aptas 0.

### DIFF
--- a/00_ADMIN/bitacora/OT-0082/OT-0082A_diseno_metricas_morfologicas_qt.md
+++ b/00_ADMIN/bitacora/OT-0082/OT-0082A_diseno_metricas_morfologicas_qt.md
@@ -1,0 +1,202 @@
+\# OT-0082A — Diseño de métricas morfológicas preliminares de Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0082 se abre después del cierre de OT-0081, donde se activó y validó la publicación auditada de qSeries reales.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó ausencia de qSeries publicadas.
+
+\- OT-0079 auditó `uh` y determinó que no debe confundirse con qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries reales.
+
+\- OT-0081 activó `publicarQSeries = true`, validó la publicación estructural y corrigió el dictamen textual del comparador.
+
+
+
+Al cierre de OT-0081, el panel diagnóstico qSeries reportó:
+
+
+
+\- Estado: Disponible
+
+\- Total: 5
+
+\- Publicados: 5
+
+\- Parciales: 0
+
+\- No disponibles: 0
+
+\- Inconsistentes: 0
+
+
+
+El resumen estructural reportó:
+
+
+
+\- Candidatos: 5
+
+\- Con serie: 5
+
+\- Sin serie: 0
+
+\- Con Qpico: 5
+
+\- Con tPico: 5
+
+\- Con volTotal: 5
+
+
+
+\## Tesis técnica
+
+
+
+Las métricas morfológicas de Q(t) solo pueden calcularse si existe qSeries real, reconocida estructuralmente, no parcial y consistente.
+
+
+
+No se permite calcular métricas desde Qpico, tPico o volTotal aislados.
+
+
+
+No se permite reconstruir Q(t).
+
+
+
+No se permite interpolar sin justificación técnica posterior.
+
+
+
+\## Objetivo
+
+
+
+Diseñar un conjunto mínimo de métricas morfológicas preliminares sobre qSeries reales publicadas, manteniendo bloqueo de adopción hidrológica y sin alterar el motor.
+
+
+
+\## Métricas candidatas
+
+
+
+Las métricas preliminares candidatas son:
+
+
+
+\- Duración efectiva del hidrograma.
+
+\- Tiempo de ascenso.
+
+\- Tiempo de receso.
+
+\- Ancho temporal al 50 % de Qp.
+
+\- Ancho temporal al 25 % de Qp.
+
+\- Pendiente media de ascenso.
+
+\- Pendiente media de receso.
+
+\- Asimetría temporal ascenso/receso.
+
+
+
+\## Condiciones mínimas de cálculo
+
+
+
+Antes de calcular cualquier métrica, cada qSeries debe cumplir:
+
+
+
+\- Ser un array.
+
+\- Tener longitud mayor que cero.
+
+\- Contener puntos con tiempo y caudal numéricos.
+
+\- Tener valores `t` crecientes o no decrecientes.
+
+\- Tener valores `Q` finitos.
+
+\- Tener Qp mayor que cero.
+
+\- No contener `undefined`, `null`, `NaN` ni objetos inválidos.
+
+\- No estar marcada como parcial o inconsistente por el diagnóstico estructural.
+
+
+
+\## Restricciones
+
+
+
+Durante OT-0082:
+
+
+
+\- No se modifica `calcHidroCompleto`.
+
+\- No se modifica `uh`.
+
+\- No se modifica `hidroEngine.js`.
+
+\- No se reconstruye Q(t).
+
+\- No se interpola la serie.
+
+\- No se calculan métricas si qSeries no existe.
+
+\- No se calculan métricas si la serie es parcial.
+
+\- No se adopta automáticamente ningún método.
+
+\- No se levanta el bloqueo global de coherencia física.
+
+\- No se cambia el Bloque Q-5 salvo para mostrar diagnóstico controlado si procede.
+
+
+
+\## Criterio de aceptación de diseño
+
+
+
+OT-0082A se considera válida si deja documentado:
+
+
+
+\- Qué métricas pueden calcularse.
+
+\- Qué condiciones deben cumplirse antes del cálculo.
+
+\- Qué restricciones impiden el cálculo.
+
+\- Que qSeries es la única fuente válida para métricas morfológicas.
+
+\- Que la disponibilidad de qSeries no implica adopción hidrológica.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0082 no es una OT de adopción.
+
+
+
+OT-0082 inicia como una OT de diseño y control de elegibilidad para métricas morfológicas preliminares de Q(t).
+

--- a/00_ADMIN/bitacora/OT-0082/OT-0082F_cierre_metricas_morfologicas_qt.md
+++ b/00_ADMIN/bitacora/OT-0082/OT-0082F_cierre_metricas_morfologicas_qt.md
@@ -1,0 +1,40 @@
+\# OT-0082F — Cierre técnico de métricas morfológicas preliminares Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0082 se desarrolló después del cierre de OT-0081, donde las qSeries reales quedaron publicadas y reconocidas estructuralmente por el comparador.
+
+
+
+El propósito de OT-0082 fue avanzar desde la disponibilidad de qSeries hacia un diagnóstico morfológico preliminar, manteniendo separación estricta entre publicación de serie, validación, cálculo morfológico, visualización y adopción hidrológica.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0082A — Diseño documental
+
+
+
+Se documentó el diseño de métricas morfológicas preliminares de Q(t), sus condiciones de elegibilidad y restricciones.
+
+
+
+\### OT-0082B — Validador qSeries
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+validarQSeriesMorfologia(qSeries)
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -7,6 +7,7 @@ import { derivarRangoCompetenteTc } from "../services/tc/derivarRangoCompetenteT
 import adaptarExpedienteDocumental from "../services/documentos/adaptarExpedienteDocumental";
 import adaptarQSeriesHidrogramas from "../services/hidrogramas/adaptarQSeriesHidrogramas";
 import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstructuraHidrogramas";
+import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
 
 import {
   resumenComparadorCatalogo,
@@ -183,6 +184,46 @@ const resumenEstructuraHidrogramas = useMemo(() => {
       },
       candidatos: [],
       error: String(errorResumenHidrogramas?.message ?? errorResumenHidrogramas)
+    };
+  }
+}, [contextoBase?.hidrogramas]);
+
+// OT-0082D — Diagnóstico interno controlado de métricas morfológicas Q(t).
+// Calcula elegibilidad agregada sobre qSeries publicadas, sin mostrar métricas detalladas.
+const diagnosticoMorfologiaQt = useMemo(() => {
+  try {
+    const bruto = contextoBase?.hidrogramas;
+
+    const candidatos = Array.isArray(bruto)
+      ? bruto
+      : Array.isArray(bruto?.resultados)
+      ? bruto.resultados
+      : Array.isArray(bruto?.metodos)
+      ? bruto.metodos
+      : [];
+
+    const evaluaciones = candidatos.map((candidato) =>
+      calcularMetricasMorfologiaQt(candidato?.qSeries)
+    );
+
+    const aptas = evaluaciones.filter((evaluacion) => evaluacion?.ok).length;
+    const noAptas = evaluaciones.length - aptas;
+
+    return {
+      ok: true,
+      total: evaluaciones.length,
+      aptas,
+      noAptas,
+      evaluaciones
+    };
+  } catch (errorMorfologiaQt) {
+    return {
+      ok: false,
+      total: 0,
+      aptas: 0,
+      noAptas: 0,
+      evaluaciones: [],
+      error: String(errorMorfologiaQt?.message ?? errorMorfologiaQt)
     };
   }
 }, [contextoBase?.hidrogramas]);
@@ -2158,8 +2199,23 @@ const handleClickSeguro = (accion) => () => {
                 </h3>
 
                 <div style={{ ...estilos.muted, marginBottom: 10 }}>
-                  Control Pe–Área–Volumen/Q-5 visible antes de copiar el expediente. No recalcula hidrogramas, no modifica Q-5 y no adopta resultados.
-                </div>
+  Lectura no invasiva de disponibilidad de series Q(t). Las métricas morfológicas se evalúan solo como diagnóstico agregado y no se exponen en detalle.
+</div>
+
+<div
+  style={{
+    marginBottom: 10,
+    padding: "8px 10px",
+    borderRadius: 8,
+    border: "1px solid rgba(34, 197, 94, 0.35)",
+    background: "rgba(15, 23, 42, 0.35)"
+  }}
+>
+  <strong>Diagnóstico morfológico Q(t):</strong>{" "}
+  {diagnosticoMorfologiaQt?.ok
+    ? `series aptas ${diagnosticoMorfologiaQt.aptas}/${diagnosticoMorfologiaQt.total}; no aptas ${diagnosticoMorfologiaQt.noAptas}. No se muestran métricas detalladas ni se adopta ningún método.`
+    : "no disponible. No se calculan métricas morfológicas."}
+</div>
 
                 <div
                   style={{

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2199,22 +2199,7 @@ const handleClickSeguro = (accion) => () => {
                 </h3>
 
                 <div style={{ ...estilos.muted, marginBottom: 10 }}>
-  Lectura no invasiva de disponibilidad de series Q(t). Las métricas morfológicas se evalúan solo como diagnóstico agregado y no se exponen en detalle.
-</div>
-
-<div
-  style={{
-    marginBottom: 10,
-    padding: "8px 10px",
-    borderRadius: 8,
-    border: "1px solid rgba(34, 197, 94, 0.35)",
-    background: "rgba(15, 23, 42, 0.35)"
-  }}
->
-  <strong>Diagnóstico morfológico Q(t):</strong>{" "}
-  {diagnosticoMorfologiaQt?.ok
-    ? `series aptas ${diagnosticoMorfologiaQt.aptas}/${diagnosticoMorfologiaQt.total}; no aptas ${diagnosticoMorfologiaQt.noAptas}. No se muestran métricas detalladas ni se adopta ningún método.`
-    : "no disponible. No se calculan métricas morfológicas."}
+  Control Pe–Área–Volumen/Q-5 visible antes de copiar el expediente. No recalcula hidrogramas, no modifica Q-5 y no adopta resultados.
 </div>
 
                 <div
@@ -2355,8 +2340,23 @@ const handleClickSeguro = (accion) => () => {
             </h3>
 
             <div style={{ ...estilos.muted, marginBottom: 10 }}>
-              Lectura no invasiva de disponibilidad de series Q(t). No calcula De, W50, W25, pendientes ni asimetría.
-            </div>
+  Lectura no invasiva de disponibilidad de series Q(t). Las métricas morfológicas se evalúan solo como diagnóstico agregado y no se exponen en detalle.
+</div>
+
+<div
+  style={{
+    marginBottom: 10,
+    padding: "8px 10px",
+    borderRadius: 8,
+    border: "1px solid rgba(34, 197, 94, 0.35)",
+    background: "rgba(15, 23, 42, 0.35)"
+  }}
+>
+  <strong>Diagnóstico morfológico Q(t):</strong>{" "}
+  {diagnosticoMorfologiaQt?.ok
+    ? `series aptas ${diagnosticoMorfologiaQt.aptas}/${diagnosticoMorfologiaQt.total}; no aptas ${diagnosticoMorfologiaQt.noAptas}. No se muestran métricas detalladas ni se adopta ningún método.`
+    : "no disponible. No se calculan métricas morfológicas."}
+</div>
 
             <div
               style={{

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/calcularMetricasMorfologiaQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/calcularMetricasMorfologiaQt.js
@@ -1,0 +1,163 @@
+// OT-0082C — Helper puro de métricas morfológicas preliminares Q(t).
+// Calcula métricas solo sobre qSeries real validada.
+// No interpola, no reconstruye Q(t), no usa Qpico/tPico/volTotal como sustitutos.
+
+import validarQSeriesMorfologia from "./validarQSeriesMorfologia";
+
+function buscarPrimerIndiceSobreUmbral(qSeries, umbral) {
+  return qSeries.findIndex((punto) => Number(punto?.Q) >= umbral);
+}
+
+function buscarUltimoIndiceSobreUmbral(qSeries, umbral) {
+  for (let i = qSeries.length - 1; i >= 0; i -= 1) {
+    if (Number(qSeries[i]?.Q) >= umbral) return i;
+  }
+
+  return -1;
+}
+
+function buscarIndicePico(qSeries) {
+  let indicePico = -1;
+  let qMax = -Infinity;
+
+  for (let i = 0; i < qSeries.length; i += 1) {
+    const Q = Number(qSeries[i]?.Q);
+
+    if (Number.isFinite(Q) && Q > qMax) {
+      qMax = Q;
+      indicePico = i;
+    }
+  }
+
+  return indicePico;
+}
+
+export default function calcularMetricasMorfologiaQt(qSeries) {
+  const validacion = validarQSeriesMorfologia(qSeries);
+
+  if (!validacion.ok) {
+    return {
+      ok: false,
+      motivo: validacion.motivo,
+      validacion,
+      Qp: null,
+      tPico: null,
+      duracionEfectivaMin: null,
+      tiempoAscensoMin: null,
+      tiempoRecesoMin: null,
+      W50Min: null,
+      W25Min: null,
+      pendienteAscenso: null,
+      pendienteReceso: null,
+      asimetriaAscensoReceso: null
+    };
+  }
+
+  const indicePico = buscarIndicePico(qSeries);
+
+  if (indicePico < 0) {
+    return {
+      ok: false,
+      motivo: "No fue posible identificar el pico de qSeries",
+      validacion,
+      Qp: null,
+      tPico: null,
+      duracionEfectivaMin: null,
+      tiempoAscensoMin: null,
+      tiempoRecesoMin: null,
+      W50Min: null,
+      W25Min: null,
+      pendienteAscenso: null,
+      pendienteReceso: null,
+      asimetriaAscensoReceso: null
+    };
+  }
+
+  const puntoPico = qSeries[indicePico];
+  const Qp = Number(puntoPico.Q);
+  const tPico = Number(puntoPico.t);
+
+  const indiceInicioEfectivo = qSeries.findIndex((punto) => Number(punto?.Q) > 0);
+  const indiceFinEfectivo = (() => {
+    for (let i = qSeries.length - 1; i >= 0; i -= 1) {
+      if (Number(qSeries[i]?.Q) > 0) return i;
+    }
+
+    return -1;
+  })();
+
+  if (indiceInicioEfectivo < 0 || indiceFinEfectivo < 0) {
+    return {
+      ok: false,
+      motivo: "No se identificó tramo efectivo con caudales positivos",
+      validacion,
+      Qp,
+      tPico,
+      duracionEfectivaMin: null,
+      tiempoAscensoMin: null,
+      tiempoRecesoMin: null,
+      W50Min: null,
+      W25Min: null,
+      pendienteAscenso: null,
+      pendienteReceso: null,
+      asimetriaAscensoReceso: null
+    };
+  }
+
+  const tInicio = Number(qSeries[indiceInicioEfectivo].t);
+  const tFin = Number(qSeries[indiceFinEfectivo].t);
+
+  const duracionEfectivaMin = +(tFin - tInicio).toFixed(6);
+  const tiempoAscensoMin = +(tPico - tInicio).toFixed(6);
+  const tiempoRecesoMin = +(tFin - tPico).toFixed(6);
+
+  const umbral50 = Qp * 0.5;
+  const umbral25 = Qp * 0.25;
+
+  const i50Inicio = buscarPrimerIndiceSobreUmbral(qSeries, umbral50);
+  const i50Fin = buscarUltimoIndiceSobreUmbral(qSeries, umbral50);
+
+  const i25Inicio = buscarPrimerIndiceSobreUmbral(qSeries, umbral25);
+  const i25Fin = buscarUltimoIndiceSobreUmbral(qSeries, umbral25);
+
+  const W50Min =
+    i50Inicio >= 0 && i50Fin >= 0 && i50Fin >= i50Inicio
+      ? +(Number(qSeries[i50Fin].t) - Number(qSeries[i50Inicio].t)).toFixed(6)
+      : null;
+
+  const W25Min =
+    i25Inicio >= 0 && i25Fin >= 0 && i25Fin >= i25Inicio
+      ? +(Number(qSeries[i25Fin].t) - Number(qSeries[i25Inicio].t)).toFixed(6)
+      : null;
+
+  const pendienteAscenso =
+    tiempoAscensoMin > 0
+      ? +(Qp / tiempoAscensoMin).toFixed(9)
+      : null;
+
+  const pendienteReceso =
+    tiempoRecesoMin > 0
+      ? +(Qp / tiempoRecesoMin).toFixed(9)
+      : null;
+
+  const asimetriaAscensoReceso =
+    tiempoAscensoMin > 0 && tiempoRecesoMin > 0
+      ? +(tiempoRecesoMin / tiempoAscensoMin).toFixed(9)
+      : null;
+
+  return {
+    ok: true,
+    motivo: null,
+    validacion,
+    Qp: +Qp.toFixed(6),
+    tPico: +tPico.toFixed(6),
+    duracionEfectivaMin,
+    tiempoAscensoMin,
+    tiempoRecesoMin,
+    W50Min,
+    W25Min,
+    pendienteAscenso,
+    pendienteReceso,
+    asimetriaAscensoReceso
+  };
+}

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/validarQSeriesMorfologia.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/validarQSeriesMorfologia.js
@@ -1,0 +1,107 @@
+// OT-0082B — Validador puro de qSeries para métricas morfológicas.
+// No calcula métricas de forma. Solo determina elegibilidad estructural.
+
+export default function validarQSeriesMorfologia(qSeries) {
+  if (!Array.isArray(qSeries)) {
+    return {
+      ok: false,
+      motivo: "qSeries no es un array",
+      totalPuntos: 0,
+      qMax: null,
+      tMin: null,
+      tMax: null
+    };
+  }
+
+  if (qSeries.length === 0) {
+    return {
+      ok: false,
+      motivo: "qSeries está vacía",
+      totalPuntos: 0,
+      qMax: null,
+      tMin: null,
+      tMax: null
+    };
+  }
+
+  let tAnterior = null;
+  let qMax = 0;
+  let tMin = null;
+  let tMax = null;
+
+  for (let i = 0; i < qSeries.length; i += 1) {
+    const punto = qSeries[i];
+
+    if (!punto || typeof punto !== "object") {
+      return {
+        ok: false,
+        motivo: `Punto inválido en índice ${i}`,
+        totalPuntos: qSeries.length,
+        qMax: null,
+        tMin: null,
+        tMax: null
+      };
+    }
+
+    const t = Number(punto.t);
+    const Q = Number(punto.Q);
+
+    if (!Number.isFinite(t) || !Number.isFinite(Q)) {
+      return {
+        ok: false,
+        motivo: `Tiempo o caudal no finito en índice ${i}`,
+        totalPuntos: qSeries.length,
+        qMax: null,
+        tMin: null,
+        tMax: null
+      };
+    }
+
+    if (Q < 0) {
+      return {
+        ok: false,
+        motivo: `Caudal negativo en índice ${i}`,
+        totalPuntos: qSeries.length,
+        qMax: null,
+        tMin: null,
+        tMax: null
+      };
+    }
+
+    if (tAnterior !== null && t < tAnterior) {
+      return {
+        ok: false,
+        motivo: `Tiempo decreciente en índice ${i}`,
+        totalPuntos: qSeries.length,
+        qMax: null,
+        tMin: null,
+        tMax: null
+      };
+    }
+
+    if (tMin === null) tMin = t;
+    tMax = t;
+    qMax = Math.max(qMax, Q);
+    tAnterior = t;
+  }
+
+  if (!(qMax > 0)) {
+    return {
+      ok: false,
+      motivo: "qSeries no contiene caudales positivos",
+      totalPuntos: qSeries.length,
+      qMax,
+      tMin,
+      tMax
+    };
+  }
+
+  return {
+    ok: true,
+    motivo: null,
+    totalPuntos: qSeries.length,
+    qMax,
+    tMin,
+    tMax
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT implementa una ruta segura para métricas morfológicas preliminares de Q(t) sobre qSeries reales publicadas y reconocidas estructuralmente por el comparador.

La OT no expone métricas detalladas todavía; solo habilita validación, cálculo puro aislado y diagnóstico agregado.

## Secuencia técnica

- OT-0082A: diseño documental de métricas morfológicas Q(t).
- OT-0082B: creación del validador puro `validarQSeriesMorfologia(qSeries)`.
- OT-0082C: creación del helper puro `calcularMetricasMorfologiaQt(qSeries)`.
- OT-0082D: integración del diagnóstico morfológico agregado en el comparador.
- OT-0082E: reubicación del diagnóstico morfológico en el Panel diagnóstico qSeries.
- OT-0082F: cierre técnico documental.

## Cambios principales

Se agregó el helper puro de validación:

```js
validarQSeriesMorfologia(qSeries)