### PR TITLE
OT-0083 — Exposición controlada de métricas morfológicas Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0083/OT-0083A_diseno_exposicion_controlada_metricas_qt.md
+++ b/00_ADMIN/bitacora/OT-0083/OT-0083A_diseno_exposicion_controlada_metricas_qt.md
@@ -1,0 +1,70 @@
+\# OT-0083A — Diseño de exposición controlada de métricas morfológicas Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0083 se abre después del cierre de OT-0082, donde se implementó una ruta segura para diagnóstico morfológico preliminar sobre qSeries reales publicadas.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó la ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries.
+
+\- OT-0081 activó y validó qSeries reales en el comparador.
+
+\- OT-0082 creó un validador puro de qSeries, un helper puro de métricas morfológicas y un diagnóstico agregado que reporta series aptas y no aptas.
+
+
+
+Al cierre de OT-0082, el Panel diagnóstico qSeries muestra un diagnóstico agregado equivalente a:
+
+
+
+\- Series aptas: 5/5.
+
+\- No aptas: 0.
+
+\- No se muestran métricas detalladas.
+
+\- No se adopta ningún método.
+
+
+
+\## Tesis técnica
+
+
+
+La disponibilidad de qSeries y de métricas morfológicas preliminares no implica adopción hidrológica.
+
+
+
+OT-0083 solo puede exponer métricas detalladas como diagnóstico técnico de forma temporal.
+
+
+
+La exposición debe preservar el estado global `No coherente` mientras no exista una OT posterior específica de dictamen hidrológico de forma y adopción.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una exposición controlada de métricas morfológicas Q(t) en el comparador, usando únicamente resultados del helper puro:
+
+
+
+```js
+
+calcularMetricasMorfologiaQt(qSeries)
+

--- a/00_ADMIN/bitacora/OT-0083/OT-0083D_validacion_visual_tabla_metricas_qt.md
+++ b/00_ADMIN/bitacora/OT-0083/OT-0083D_validacion_visual_tabla_metricas_qt.md
@@ -1,0 +1,74 @@
+\# OT-0083D — Validación visual de tabla compacta de métricas Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0083B, donde se prepararon las filas tabulares de métricas morfológicas Q(t), se implementó en OT-0083C una tabla compacta no adoptiva dentro del Panel diagnóstico qSeries.
+
+
+
+\## Evidencia visual
+
+
+
+La tabla quedó ubicada en el Panel diagnóstico qSeries, después del diagnóstico agregado de disponibilidad morfológica y antes del resumen estructural de hidrogramas.
+
+
+
+La UI muestra:
+
+
+
+\- Diagnóstico morfológico Q(t): series aptas 5/5.
+
+\- No aptas: 0.
+
+\- Tabla diagnóstica morfológica Q(t).
+
+\- Cinco métodos listados: SCS, SCS Mod., Snyder, Williams \& Hann y Clark IUH.
+
+\- Estado Apta para los cinco métodos.
+
+\- Columnas visibles: Método, Estado, Qp, tPico, De, Ascenso, Receso, W50, W25 y Asim.
+
+
+
+\## Restricciones verificadas
+
+
+
+Durante la validación visual:
+
+
+
+\- No se mostraron arrays crudos.
+
+\- No se listaron puntos tiempo-caudal de forma masiva.
+
+\- No se adoptó automáticamente ningún método.
+
+\- No se levantó el estado global No coherente.
+
+\- No se modificó el motor hidrológico.
+
+\- No se reconstruyó Q(t).
+
+\- No se interpolaron series.
+
+\- La tabla se presentó como diagnóstico, no como decisión.
+
+
+
+\## Dictamen
+
+
+
+OT-0083C queda validada visualmente.
+
+
+
+La exposición de métricas morfológicas Q(t) es compacta, diagnóstica y no adoptiva.
+

--- a/00_ADMIN/bitacora/OT-0083/OT-0083E_cierre_exposicion_controlada_metricas_qt.md
+++ b/00_ADMIN/bitacora/OT-0083/OT-0083E_cierre_exposicion_controlada_metricas_qt.md
@@ -1,0 +1,150 @@
+\# OT-0083E — Cierre técnico de exposición controlada de métricas Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0083 se desarrolló después del cierre de OT-0082, donde se implementó una ruta segura para diagnóstico morfológico preliminar sobre qSeries reales publicadas.
+
+
+
+El propósito de OT-0083 fue avanzar desde el diagnóstico agregado hacia una exposición controlada y compacta de métricas morfológicas Q(t), manteniendo separación estricta entre diagnóstico, decisión técnica y adopción hidrológica.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0083A — Diseño documental
+
+
+
+Se documentó el diseño de exposición controlada de métricas morfológicas Q(t), estableciendo que la exposición sería diagnóstica y no adoptiva.
+
+
+
+\### OT-0083B — Preparación de filas tabulares
+
+
+
+Se preparó la estructura `filasMorfologiaQt` a partir de las evaluaciones generadas por el diagnóstico morfológico Q(t).
+
+
+
+Las filas incluyen únicamente valores derivados del helper puro validado:
+
+
+
+\- método,
+
+\- estado,
+
+\- Qp,
+
+\- tPico,
+
+\- duración efectiva,
+
+\- tiempo de ascenso,
+
+\- tiempo de receso,
+
+\- W50,
+
+\- W25,
+
+\- asimetría.
+
+
+
+\### OT-0083C — Tabla compacta no adoptiva
+
+
+
+Se incorporó una tabla compacta dentro del Panel diagnóstico qSeries.
+
+
+
+La tabla muestra métricas morfológicas Q(t) por método, pero no adopta resultados ni modifica el estado global del modelo.
+
+
+
+\### OT-0083D — Validación visual
+
+
+
+Se validó visualmente que la tabla quedó ubicada en el Panel diagnóstico qSeries, con los cinco métodos listados y estado Apta para las cinco series.
+
+
+
+\## Resultado visual validado
+
+
+
+La UI muestra:
+
+
+
+\- Diagnóstico morfológico Q(t): series aptas 5/5.
+
+\- No aptas: 0.
+
+\- Tabla diagnóstica morfológica Q(t).
+
+\- Métodos listados: SCS, SCS Mod., Snyder, Williams \& Hann y Clark IUH.
+
+\- Columnas visibles: Método, Estado, Qp, tPico, De, Ascenso, Receso, W50, W25 y Asim.
+
+\- Estado global del modelo: No coherente.
+
+
+
+\## Restricciones mantenidas
+
+
+
+Durante OT-0083:
+
+
+
+\- No se modificó `calcHidroCompleto`.
+
+\- No se modificó `uh`.
+
+\- No se modificó `hidroEngine.js`.
+
+\- No se reconstruyó Q(t).
+
+\- No se interpolaron series.
+
+\- No se usaron Qpico, tPico ni volTotal como sustitutos de qSeries.
+
+\- No se mostraron arrays crudos.
+
+\- No se listaron puntos tiempo-caudal de forma masiva.
+
+\- No se adoptó automáticamente ningún método.
+
+\- No se levantó el estado global `No coherente`.
+
+\- No se reemplazó el dictamen técnico del expediente.
+
+
+
+\## Validación
+
+
+
+Build aprobado con Vite:
+
+
+
+```text
+
+✓ 854 modules transformed.
+
+✓ built
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -228,7 +228,54 @@ const diagnosticoMorfologiaQt = useMemo(() => {
   }
 }, [contextoBase?.hidrogramas]);
 
+// OT-0083B — Filas tabulares controladas de métricas morfológicas Q(t).
+// Prepara datos para exposición diagnóstica, sin adoptar métodos ni levantar bloqueos.
+const filasMorfologiaQt = useMemo(() => {
+  try {
+    const bruto = contextoBase?.hidrogramas;
 
+    const candidatos = Array.isArray(bruto)
+      ? bruto
+      : Array.isArray(bruto?.resultados)
+      ? bruto.resultados
+      : Array.isArray(bruto?.metodos)
+      ? bruto.metodos
+      : [];
+
+    const evaluaciones = Array.isArray(diagnosticoMorfologiaQt?.evaluaciones)
+      ? diagnosticoMorfologiaQt.evaluaciones
+      : [];
+
+    return candidatos.map((candidato, indice) => {
+      const evaluacion = evaluaciones[indice] ?? {};
+
+      return {
+        metodo: candidato?.metodo ?? candidato?.nombre ?? `Método ${indice + 1}`,
+        estado: evaluacion?.ok ? "Apta" : "No apta",
+        motivo: evaluacion?.motivo ?? null,
+        Qp: Number.isFinite(Number(evaluacion?.Qp)) ? Number(evaluacion.Qp) : null,
+        tPico: Number.isFinite(Number(evaluacion?.tPico)) ? Number(evaluacion.tPico) : null,
+        duracionEfectivaMin: Number.isFinite(Number(evaluacion?.duracionEfectivaMin))
+          ? Number(evaluacion.duracionEfectivaMin)
+          : null,
+        tiempoAscensoMin: Number.isFinite(Number(evaluacion?.tiempoAscensoMin))
+          ? Number(evaluacion.tiempoAscensoMin)
+          : null,
+        tiempoRecesoMin: Number.isFinite(Number(evaluacion?.tiempoRecesoMin))
+          ? Number(evaluacion.tiempoRecesoMin)
+          : null,
+        W50Min: Number.isFinite(Number(evaluacion?.W50Min)) ? Number(evaluacion.W50Min) : null,
+        W25Min: Number.isFinite(Number(evaluacion?.W25Min)) ? Number(evaluacion.W25Min) : null,
+        asimetriaAscensoReceso: Number.isFinite(Number(evaluacion?.asimetriaAscensoReceso))
+          ? Number(evaluacion.asimetriaAscensoReceso)
+          : null
+      };
+    });
+  } catch (errorFilasMorfologiaQt) {
+    console.warn("Filas morfológicas Q(t) no generadas:", errorFilasMorfologiaQt);
+    return [];
+  }
+}, [contextoBase?.hidrogramas, diagnosticoMorfologiaQt]);
 
 
   

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2420,6 +2420,135 @@ const handleClickSeguro = (accion) => () => {
               <div><strong>Inconsistentes:</strong> {resumenQSeries.inconsistentes}</div>
             </div>
 
+            {/* OT-0083C — Tabla compacta no adoptiva de métricas morfológicas Q(t). */}
+            {Array.isArray(filasMorfologiaQt) && filasMorfologiaQt.length > 0 && (
+              <div
+                style={{
+                  marginTop: 10,
+                  padding: 10,
+                  borderRadius: 8,
+                  border: "1px solid rgba(34, 197, 94, 0.35)",
+                  background: "rgba(15, 23, 42, 0.35)",
+                  overflowX: "auto"
+                }}
+              >
+                <strong>Tabla diagnóstica morfológica Q(t):</strong>{" "}
+                exposición compacta no adoptiva basada exclusivamente en qSeries validadas.
+
+                <table
+                  style={{
+                    width: "100%",
+                    borderCollapse: "collapse",
+                    marginTop: 10,
+                    fontSize: 12
+                  }}
+                >
+                  <thead>
+                    <tr>
+                      {[
+                        "Método",
+                        "Estado",
+                        "Qp",
+                        "tPico",
+                        "De",
+                        "Ascenso",
+                        "Receso",
+                        "W50",
+                        "W25",
+                        "Asim."
+                      ].map((encabezado) => (
+                        <th
+                          key={encabezado}
+                          style={{
+                            textAlign: "left",
+                            padding: "6px 8px",
+                            borderBottom: "1px solid rgba(148, 163, 184, 0.35)",
+                            color: "#bae6fd",
+                            whiteSpace: "nowrap"
+                          }}
+                        >
+                          {encabezado}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    {filasMorfologiaQt.map((fila, indice) => {
+                      const formatear = (valor, decimales = 2, unidad = "") =>
+                        Number.isFinite(Number(valor))
+                          ? `${Number(valor).toLocaleString("es-CO", {
+                              maximumFractionDigits: decimales
+                            })}${unidad}`
+                          : "—";
+
+                      return (
+                        <tr key={`${fila.metodo}-${indice}`}>
+                          <td
+                            style={{
+                              padding: "6px 8px",
+                              borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                              whiteSpace: "nowrap"
+                            }}
+                          >
+                            {fila.metodo}
+                          </td>
+
+                          <td
+                            style={{
+                              padding: "6px 8px",
+                              borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                              color: fila.estado === "Apta" ? "#86efac" : "#fca5a5",
+                              fontWeight: 700,
+                              whiteSpace: "nowrap"
+                            }}
+                          >
+                            {fila.estado}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.Qp, 2, " m³/s")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.tPico, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.duracionEfectivaMin, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.tiempoAscensoMin, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.tiempoRecesoMin, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.W50Min, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.W25Min, 2, " min")}
+                          </td>
+
+                          <td style={{ padding: "6px 8px", borderBottom: "1px solid rgba(51, 65, 85, 0.55)" }}>
+                            {formatear(fila.asimetriaAscensoReceso, 3, "")}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+
+                <div style={{ ...estilos.muted, marginTop: 8 }}>
+                  Lectura diagnóstica: las métricas se calculan desde qSeries reales validadas. No implican adopción hidrológica, no levantan el estado global No coherente y no reemplazan el dictamen técnico del expediente.
+                </div>
+              </div>
+            )}
+
             <div
               style={{
                 marginTop: 10,


### PR DESCRIPTION
## Resumen

Esta OT implementa la exposición controlada de métricas morfológicas Q(t) en el Panel diagnóstico qSeries, usando únicamente qSeries reales publicadas y métricas derivadas del helper puro validado previamente.

La exposición es diagnóstica y no adoptiva.

## Secuencia técnica

- OT-0083A: diseño documental de exposición controlada.
- OT-0083B: preparación de filas tabulares morfológicas.
- OT-0083C: tabla compacta no adoptiva en Panel diagnóstico qSeries.
- OT-0083D: validación visual documental.
- OT-0083E: cierre técnico documental.

## Cambios principales

Se preparó la estructura `filasMorfologiaQt` a partir de las evaluaciones de `diagnosticoMorfologiaQt`.

Se incorporó una tabla compacta dentro del Panel diagnóstico qSeries con las columnas:

- Método
- Estado
- Qp
- tPico
- De
- Ascenso
- Receso
- W50
- W25
- Asim.

## Validación visual

La tabla quedó ubicada correctamente dentro del Panel diagnóstico qSeries, después del diagnóstico agregado y antes del resumen estructural de hidrogramas.

La UI muestra:

- Diagnóstico morfológico Q(t): series aptas 5/5.
- No aptas: 0.
- Cinco métodos listados: SCS, SCS Mod., Snyder, Williams & Hann y Clark IUH.
- Estado Apta para las cinco series.
- Estado global del modelo: No coherente.

## Restricciones mantenidas

- No se modifica `calcHidroCompleto`.
- No se modifica `uh`.
- No se modifica `hidroEngine.js`.
- No se reconstruye Q(t).
- No se interpolan series.
- No se usan Qpico, tPico ni volTotal como sustitutos de qSeries.
- No se muestran arrays crudos.
- No se listan puntos tiempo-caudal de forma masiva.
- No se adopta automáticamente ningún método.
- No se levanta el estado global `No coherente`.
- No se reemplaza el dictamen técnico del expediente.

## Validación

Build aprobado con Vite:

```text
✓ 854 modules transformed.
✓ built