### PR TITLE
OT-0084 — Dictamen técnico de forma Q(t) no adoptivo

### DIFF
--- a/00_ADMIN/bitacora/OT-0084/OT-0084A_diseno_dictamen_forma_qt_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0084/OT-0084A_diseno_dictamen_forma_qt_no_adoptivo.md
@@ -1,0 +1,244 @@
+\# OT-0084A — Diseño de dictamen técnico de forma Q(t) no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0084 se abre después del cierre de OT-0083, donde se implementó la exposición controlada de métricas morfológicas Q(t) en el Panel diagnóstico qSeries.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó la ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries.
+
+\- OT-0081 activó y validó qSeries reales.
+
+\- OT-0082 implementó validación y diagnóstico morfológico agregado.
+
+\- OT-0083 expuso una tabla compacta no adoptiva de métricas morfológicas Q(t).
+
+
+
+Al cierre de OT-0083, el comparador muestra métricas por método:
+
+
+
+\- Qp.
+
+\- tPico.
+
+\- De.
+
+\- Tiempo de ascenso.
+
+\- Tiempo de receso.
+
+\- W50.
+
+\- W25.
+
+\- Asimetría.
+
+
+
+\## Tesis técnica
+
+
+
+La disponibilidad de métricas morfológicas permite interpretar la forma temporal de los hidrogramas, pero no implica adopción hidrológica.
+
+
+
+OT-0084 debe producir un dictamen técnico de forma Q(t) de carácter diagnóstico, sin modificar resultados, sin recalcular caudales y sin levantar el estado global `No coherente`.
+
+
+
+\## Objetivo
+
+
+
+Diseñar un criterio de clasificación no adoptivo para la forma temporal de cada método Q(t), usando únicamente las métricas morfológicas ya calculadas desde qSeries reales validadas.
+
+
+
+\## Variables de lectura
+
+
+
+Las variables principales para el dictamen son:
+
+
+
+\- Duración efectiva `De`.
+
+\- Tiempo de ascenso.
+
+\- Tiempo de receso.
+
+\- Relación receso/ascenso o asimetría.
+
+\- W50.
+
+\- W25.
+
+\- tPico.
+
+\- Qp.
+
+
+
+\## Clasificaciones candidatas
+
+
+
+Las formas candidatas preliminares son:
+
+
+
+\- Forma concentrada.
+
+\- Forma prolongada.
+
+\- Forma recesiva.
+
+\- Forma altamente asimétrica.
+
+\- Forma abrupta.
+
+\- Forma temporalmente sensible.
+
+\- Forma moderada o equilibrada.
+
+
+
+\## Criterios cualitativos iniciales
+
+
+
+La clasificación deberá ser conservadora y diagnóstica.
+
+
+
+Ejemplos de lectura preliminar:
+
+
+
+\- Asimetría alta puede indicar recesión dominante.
+
+\- Ascenso muy corto frente al receso puede indicar respuesta abrupta y altamente asimétrica.
+
+\- Duración efectiva muy larga puede indicar hidrograma prolongado.
+
+\- W50 y W25 amplios pueden indicar persistencia de caudales significativos.
+
+\- tPico temprano con Qp alto puede indicar forma temporal crítica.
+
+
+
+Estos criterios no equivalen a adopción del método.
+
+
+
+\## Restricciones
+
+
+
+Durante OT-0084:
+
+
+
+\- No se modifica `calcHidroCompleto`.
+
+\- No se modifica `uh`.
+
+\- No se modifica `hidroEngine.js`.
+
+\- No se reconstruye Q(t).
+
+\- No se interpola.
+
+\- No se modifican métricas.
+
+\- No se recalculan caudales.
+
+\- No se adopta automáticamente ningún método.
+
+\- No se levanta el estado global `No coherente`.
+
+\- No se reemplaza el dictamen técnico del expediente.
+
+\- No se usa el dictamen de forma como decisión hidráulica final.
+
+
+
+\## Alcance visual propuesto
+
+
+
+La primera exposición visual deberá ser compacta.
+
+
+
+Se propone agregar una columna o bloque diagnóstico con:
+
+
+
+\- Método.
+
+\- Forma temporal preliminar.
+
+\- Alerta de forma.
+
+\- Comentario técnico breve.
+
+
+
+El dictamen debe quedar explícitamente marcado como:
+
+
+
+> Diagnóstico no adoptivo.
+
+
+
+\## Criterio de aceptación de diseño
+
+
+
+OT-0084A se considera válida si deja definido:
+
+
+
+\- Que el dictamen proviene solo de métricas ya calculadas desde qSeries.
+
+\- Que la clasificación es diagnóstica.
+
+\- Que no modifica cálculos.
+
+\- Que no adopta métodos.
+
+\- Que no levanta `No coherente`.
+
+\- Que la interpretación hidrológica final queda diferida a una OT posterior.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0084 no es una OT de adopción.
+
+
+
+OT-0084 es una OT de interpretación diagnóstica de forma temporal Q(t), basada en métricas morfológicas expuestas en OT-0083.
+

--- a/00_ADMIN/bitacora/OT-0084/OT-0084D_validacion_visual_dictamen_forma_qt.md
+++ b/00_ADMIN/bitacora/OT-0084/OT-0084D_validacion_visual_dictamen_forma_qt.md
@@ -1,0 +1,98 @@
+\# OT-0084D — Validación visual del dictamen de forma Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0084C, se validó visualmente la integración del dictamen diagnóstico de forma Q(t) en el Panel diagnóstico qSeries.
+
+
+
+El dictamen usa las métricas morfológicas ya expuestas en OT-0083 y las clasifica mediante el helper puro `clasificarFormaQt`.
+
+
+
+\## Evidencia visual
+
+
+
+El Panel diagnóstico qSeries muestra:
+
+
+
+\- Tabla diagnóstica morfológica Q(t).
+
+\- Dictamen diagnóstico de forma Q(t).
+
+\- Resumen estructural de hidrogramas.
+
+
+
+El dictamen de forma Q(t) presenta las columnas:
+
+
+
+\- Método.
+
+\- Forma.
+
+\- Alerta.
+
+\- Severidad.
+
+
+
+Los métodos aparecen clasificados así:
+
+
+
+\- SCS: Forma persistente; alerta de ancho temporal significativo; severidad media.
+
+\- SCS Mod.: Forma persistente; alerta de ancho temporal significativo; severidad media.
+
+\- Snyder: Forma prolongada con receso dominante; alerta de recesión extensa; severidad alta.
+
+\- Williams \& Hann: Forma abrupta altamente asimétrica; alerta de ascenso muy corto y receso extremo; severidad alta.
+
+\- Clark IUH: Forma prolongada con receso dominante; alerta de recesión extensa; severidad alta.
+
+
+
+\## Restricciones verificadas
+
+
+
+Durante la validación visual:
+
+
+
+\- No se adoptó automáticamente ningún método.
+
+\- No se levantó el estado global `No coherente`.
+
+\- No se modificaron caudales.
+
+\- No se reconstruyó Q(t).
+
+\- No se interpolaron series.
+
+\- No se modificó el motor hidrológico.
+
+\- No se reemplazó la revisión hidrológica profesional.
+
+\- No se mostraron arrays crudos ni puntos tiempo-caudal masivos.
+
+
+
+\## Dictamen
+
+
+
+OT-0084C queda visualmente validada.
+
+
+
+La clasificación de forma Q(t) queda integrada como diagnóstico preliminar no adoptivo.
+

--- a/00_ADMIN/bitacora/OT-0084/OT-0084E_cierre_dictamen_forma_qt_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0084/OT-0084E_cierre_dictamen_forma_qt_no_adoptivo.md
@@ -1,0 +1,56 @@
+\# OT-0084E — Cierre técnico del dictamen de forma Q(t) no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0084 se desarrolló después del cierre de OT-0083, donde se implementó la exposición controlada de métricas morfológicas Q(t).
+
+
+
+El propósito de OT-0084 fue avanzar desde la visualización de métricas hacia una clasificación diagnóstica de forma temporal Q(t), sin convertir dicha clasificación en adopción hidrológica ni en levantamiento del estado global No coherente.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0084A — Diseño documental
+
+
+
+Se documentó el diseño del dictamen técnico de forma Q(t) no adoptivo.
+
+
+
+Se estableció que la clasificación:
+
+
+
+\- proviene de métricas morfológicas ya calculadas,
+
+\- no modifica resultados,
+
+\- no recalcula Q(t),
+
+\- no adopta métodos,
+
+\- no levanta el estado global No coherente.
+
+
+
+\### OT-0084B — Helper puro de clasificación
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+clasificarFormaQt(metricas)
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -8,6 +8,7 @@ import adaptarExpedienteDocumental from "../services/documentos/adaptarExpedient
 import adaptarQSeriesHidrogramas from "../services/hidrogramas/adaptarQSeriesHidrogramas";
 import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstructuraHidrogramas";
 import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
+import clasificarFormaQt from "../services/hidrogramas/clasificarFormaQt";
 
 import {
   resumenComparadorCatalogo,
@@ -277,7 +278,34 @@ const filasMorfologiaQt = useMemo(() => {
   }
 }, [contextoBase?.hidrogramas, diagnosticoMorfologiaQt]);
 
+// OT-0084C — Filas de dictamen diagnóstico de forma Q(t).
+// Clasificación no adoptiva basada únicamente en métricas morfológicas ya calculadas.
+const filasDictamenFormaQt = useMemo(() => {
+  if (!Array.isArray(filasMorfologiaQt)) return [];
 
+  return filasMorfologiaQt.map((fila) => {
+    const dictamen = clasificarFormaQt({
+      duracionEfectivaMin: fila?.duracionEfectivaMin,
+      tiempoAscensoMin: fila?.tiempoAscensoMin,
+      tiempoRecesoMin: fila?.tiempoRecesoMin,
+      W50Min: fila?.W50Min,
+      W25Min: fila?.W25Min,
+      asimetriaAscensoReceso: fila?.asimetriaAscensoReceso,
+      Qp: fila?.Qp,
+      tPico: fila?.tPico
+    });
+
+    return {
+      metodo: fila?.metodo ?? "Método Q(t)",
+      estadoMetrico: fila?.estado ?? "No apta",
+      forma: dictamen?.forma ?? "No clasificable",
+      alerta: dictamen?.alerta ?? "Sin dictamen",
+      severidad: dictamen?.severidad ?? "No determinada",
+      comentario: dictamen?.comentario ?? "Diagnóstico no adoptivo.",
+      banderas: Array.isArray(dictamen?.banderas) ? dictamen.banderas : []
+    };
+  });
+}, [filasMorfologiaQt]);
   
   const estilos = {
     pagina: {
@@ -2546,6 +2574,107 @@ const handleClickSeguro = (accion) => () => {
                 <div style={{ ...estilos.muted, marginTop: 8 }}>
                   Lectura diagnóstica: las métricas se calculan desde qSeries reales validadas. No implican adopción hidrológica, no levantan el estado global No coherente y no reemplazan el dictamen técnico del expediente.
                 </div>
+                {Array.isArray(filasDictamenFormaQt) && filasDictamenFormaQt.length > 0 && (
+                  <div
+                    style={{
+                      marginTop: 10,
+                      padding: 10,
+                      borderRadius: 8,
+                      border: "1px solid rgba(251, 191, 36, 0.35)",
+                      background: "rgba(15, 23, 42, 0.35)",
+                      overflowX: "auto"
+                    }}
+                  >
+                    <strong>Dictamen diagnóstico de forma Q(t):</strong>{" "}
+                    clasificación preliminar no adoptiva basada en métricas morfológicas.
+
+                    <table
+                      style={{
+                        width: "100%",
+                        borderCollapse: "collapse",
+                        marginTop: 10,
+                        fontSize: 12
+                      }}
+                    >
+                      <thead>
+                        <tr>
+                          {["Método", "Forma", "Alerta", "Severidad"].map((encabezado) => (
+                            <th
+                              key={encabezado}
+                              style={{
+                                textAlign: "left",
+                                padding: "6px 8px",
+                                borderBottom: "1px solid rgba(148, 163, 184, 0.35)",
+                                color: "#fde68a",
+                                whiteSpace: "nowrap"
+                              }}
+                            >
+                              {encabezado}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+
+                      <tbody>
+                        {filasDictamenFormaQt.map((fila, indice) => (
+                          <tr key={`${fila.metodo}-dictamen-${indice}`}>
+                            <td
+                              style={{
+                                padding: "6px 8px",
+                                borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                                whiteSpace: "nowrap"
+                              }}
+                            >
+                              {fila.metodo}
+                            </td>
+
+                            <td
+                              style={{
+                                padding: "6px 8px",
+                                borderBottom: "1px solid rgba(51, 65, 85, 0.55)"
+                              }}
+                            >
+                              {fila.forma}
+                            </td>
+
+                            <td
+                              style={{
+                                padding: "6px 8px",
+                                borderBottom: "1px solid rgba(51, 65, 85, 0.55)"
+                              }}
+                            >
+                              {fila.alerta}
+                            </td>
+
+                            <td
+                              style={{
+                                padding: "6px 8px",
+                                borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                                color:
+                                  fila.severidad === "Alta"
+                                    ? "#fca5a5"
+                                    : fila.severidad === "Media"
+                                    ? "#fde68a"
+                                    : fila.severidad === "Baja"
+                                    ? "#86efac"
+                                    : "#cbd5e1",
+                                fontWeight: 700,
+                                whiteSpace: "nowrap"
+                              }}
+                            >
+                              {fila.severidad}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+
+                    <div style={{ ...estilos.muted, marginTop: 8 }}>
+                      Este dictamen clasifica la forma temporal Q(t) como diagnóstico preliminar. No adopta métodos, no modifica caudales, no levanta el estado global No coherente y no reemplaza revisión hidrológica profesional.
+                    </div>
+                  </div>
+                )}
+                
               </div>
             )}
 

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/clasificarFormaQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/clasificarFormaQt.js
@@ -1,0 +1,201 @@
+// OT-0084B — Helper puro de clasificación diagnóstica de forma Q(t).
+// Recibe métricas morfológicas ya calculadas.
+// No recibe qSeries cruda, no recalcula Q(t), no interpola y no adopta métodos.
+
+function numeroFinito(valor) {
+  const numero = Number(valor);
+  return Number.isFinite(numero) ? numero : null;
+}
+
+function construirRespuesta({
+  ok = true,
+  forma = "No clasificable",
+  alerta = "Sin dictamen",
+  severidad = "No determinada",
+  comentario = "Diagnóstico no adoptivo.",
+  banderas = []
+}) {
+  return {
+    ok,
+    forma,
+    alerta,
+    severidad,
+    comentario,
+    banderas
+  };
+}
+
+export default function clasificarFormaQt(metricas = {}) {
+  const duracionEfectivaMin = numeroFinito(metricas?.duracionEfectivaMin);
+  const tiempoAscensoMin = numeroFinito(metricas?.tiempoAscensoMin);
+  const tiempoRecesoMin = numeroFinito(metricas?.tiempoRecesoMin);
+  const W50Min = numeroFinito(metricas?.W50Min);
+  const W25Min = numeroFinito(metricas?.W25Min);
+  const asimetriaAscensoReceso = numeroFinito(metricas?.asimetriaAscensoReceso);
+  const Qp = numeroFinito(metricas?.Qp);
+  const tPico = numeroFinito(metricas?.tPico);
+
+  const camposMinimos = [
+    duracionEfectivaMin,
+    tiempoAscensoMin,
+    tiempoRecesoMin,
+    asimetriaAscensoReceso,
+    Qp,
+    tPico
+  ];
+
+  if (camposMinimos.some((valor) => valor === null)) {
+    return construirRespuesta({
+      ok: false,
+      forma: "No clasificable",
+      alerta: "Métricas insuficientes",
+      severidad: "No determinada",
+      comentario:
+        "No hay métricas morfológicas suficientes para clasificar la forma Q(t). Diagnóstico no adoptivo.",
+      banderas: ["metricas_insuficientes"]
+    });
+  }
+
+  if (
+    duracionEfectivaMin <= 0 ||
+    tiempoAscensoMin < 0 ||
+    tiempoRecesoMin < 0 ||
+    Qp <= 0 ||
+    tPico < 0
+  ) {
+    return construirRespuesta({
+      ok: false,
+      forma: "No clasificable",
+      alerta: "Métricas no físicas",
+      severidad: "Alta",
+      comentario:
+        "Las métricas disponibles no cumplen condiciones físicas mínimas para clasificar la forma Q(t). Diagnóstico no adoptivo.",
+      banderas: ["metricas_no_fisicas"]
+    });
+  }
+
+  const banderas = [];
+
+  const recesoDominante = asimetriaAscensoReceso >= 3;
+  const recesoMuyDominante = asimetriaAscensoReceso >= 6;
+  const recesoExtremo = asimetriaAscensoReceso >= 10;
+
+  const ascensoAbrupto =
+    tiempoAscensoMin > 0 &&
+    duracionEfectivaMin > 0 &&
+    tiempoAscensoMin / duracionEfectivaMin <= 0.12;
+
+  const duracionProlongada =
+    duracionEfectivaMin >= 1000 ||
+    (tiempoRecesoMin >= 800 && asimetriaAscensoReceso >= 4);
+
+  const persistenciaAlta =
+    W25Min !== null &&
+    duracionEfectivaMin > 0 &&
+    W25Min / duracionEfectivaMin >= 0.25;
+
+  const nucleoAncho =
+    W50Min !== null &&
+    duracionEfectivaMin > 0 &&
+    W50Min / duracionEfectivaMin >= 0.15;
+
+  const picoTemprano =
+    tPico >= 0 &&
+    duracionEfectivaMin > 0 &&
+    tPico / duracionEfectivaMin <= 0.15;
+
+  if (recesoDominante) banderas.push("receso_dominante");
+  if (recesoMuyDominante) banderas.push("receso_muy_dominante");
+  if (recesoExtremo) banderas.push("receso_extremo");
+  if (ascensoAbrupto) banderas.push("ascenso_abrupto");
+  if (duracionProlongada) banderas.push("duracion_prolongada");
+  if (persistenciaAlta) banderas.push("persistencia_alta");
+  if (nucleoAncho) banderas.push("nucleo_ancho");
+  if (picoTemprano) banderas.push("pico_temprano");
+
+  if (recesoExtremo && ascensoAbrupto) {
+    return construirRespuesta({
+      forma: "Forma abrupta altamente asimétrica",
+      alerta: "Ascenso muy corto y receso extremo",
+      severidad: "Alta",
+      comentario:
+        "La forma Q(t) presenta ascenso muy corto frente a una recesión dominante extrema. Diagnóstico no adoptivo; requiere interpretación hidrológica posterior.",
+      banderas
+    });
+  }
+
+  if (recesoMuyDominante && duracionProlongada) {
+    return construirRespuesta({
+      forma: "Forma prolongada con receso dominante",
+      alerta: "Recesión extensa",
+      severidad: "Alta",
+      comentario:
+        "La duración efectiva y la relación receso/ascenso indican una respuesta prolongada dominada por la recesión. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  if (recesoMuyDominante) {
+    return construirRespuesta({
+      forma: "Forma altamente asimétrica",
+      alerta: "Receso muy dominante",
+      severidad: "Alta",
+      comentario:
+        "El receso supera ampliamente el tiempo de ascenso. La forma temporal debe interpretarse con cautela antes de cualquier decisión técnica. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  if (duracionProlongada) {
+    return construirRespuesta({
+      forma: "Forma prolongada",
+      alerta: "Duración efectiva alta",
+      severidad: "Media",
+      comentario:
+        "La duración efectiva del hidrograma es alta frente al tiempo de respuesta principal. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  if (ascensoAbrupto && picoTemprano) {
+    return construirRespuesta({
+      forma: "Forma abrupta",
+      alerta: "Pico temprano",
+      severidad: "Media",
+      comentario:
+        "El hidrograma concentra la respuesta en un ascenso relativamente corto y un pico temprano. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  if (recesoDominante) {
+    return construirRespuesta({
+      forma: "Forma recesiva",
+      alerta: "Receso dominante",
+      severidad: "Media",
+      comentario:
+        "El receso domina sobre el ascenso, aunque sin alcanzar umbrales extremos. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  if (nucleoAncho || persistenciaAlta) {
+    return construirRespuesta({
+      forma: "Forma persistente",
+      alerta: "Ancho temporal significativo",
+      severidad: "Media",
+      comentario:
+        "Los anchos W50 o W25 sugieren persistencia temporal de caudales significativos. Diagnóstico no adoptivo.",
+      banderas
+    });
+  }
+
+  return construirRespuesta({
+    forma: "Forma moderada",
+    alerta: "Sin alerta morfológica dominante",
+    severidad: "Baja",
+    comentario:
+      "Las métricas no evidencian una alerta morfológica dominante bajo los criterios preliminares. Diagnóstico no adoptivo.",
+    banderas
+  });
+}


### PR DESCRIPTION
## Resumen

Esta OT implementa un dictamen diagnóstico de forma temporal Q(t) no adoptivo, basado en las métricas morfológicas expuestas previamente en OT-0083.

La clasificación permite interpretar diferencias temporales entre métodos sin adoptar resultados, sin modificar caudales y sin levantar el estado global `No coherente`.

## Secuencia técnica

- OT-0084A: diseño documental del dictamen forma Q(t) no adoptivo.
- OT-0084B: creación del helper puro `clasificarFormaQt(metricas)`.
- OT-0084C: integración visual del dictamen diagnóstico en el Panel diagnóstico qSeries.
- OT-0084D: validación visual documental.
- OT-0084E: cierre técnico documental.

## Cambios principales

Se agregó el helper puro:

```js
clasificarFormaQt(metricas)