### PR TITLE
OT-0085 — Riesgo temporal Q(t) no adoptivo

### DIFF
--- a/00_ADMIN/bitacora/OT-0085/OT-0085A_diseno_riesgo_temporal_qt_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0085/OT-0085A_diseno_riesgo_temporal_qt_no_adoptivo.md
@@ -1,0 +1,238 @@
+\# OT-0085A — Diseño de criterio comparativo de riesgo temporal Q(t) no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0085 se abre después del cierre de OT-0084, donde se implementó un dictamen diagnóstico de forma temporal Q(t) no adoptivo.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries reales.
+
+\- OT-0081 activó y validó qSeries reales en el comparador.
+
+\- OT-0082 implementó validación, métricas morfológicas y diagnóstico agregado.
+
+\- OT-0083 expuso métricas morfológicas compactas y no adoptivas.
+
+\- OT-0084 clasificó la forma Q(t) por método mediante un dictamen diagnóstico no adoptivo.
+
+
+
+Al cierre de OT-0084, el Panel diagnóstico qSeries muestra una clasificación de forma temporal para cada método, incluyendo forma, alerta y severidad.
+
+
+
+\## Tesis técnica
+
+
+
+La clasificación de forma Q(t) permite construir una lectura comparativa de riesgo temporal, pero dicha lectura no equivale a adopción hidrológica.
+
+
+
+OT-0085 debe convertir la clasificación de forma en un criterio diagnóstico de riesgo temporal, sin seleccionar método, sin modificar resultados y sin levantar el estado global `No coherente`.
+
+
+
+\## Objetivo
+
+
+
+Diseñar un criterio comparativo de riesgo temporal Q(t) basado en las métricas morfológicas y la clasificación de forma ya generadas.
+
+
+
+El criterio debe servir para orientar la lectura técnica de la respuesta temporal de cada método, manteniendo carácter diagnóstico y no adoptivo.
+
+
+
+\## Riesgos temporales candidatos
+
+
+
+Los riesgos temporales preliminares son:
+
+
+
+\- Riesgo por pico temprano.
+
+\- Riesgo por ascenso abrupto.
+
+\- Riesgo por recesión prolongada.
+
+\- Riesgo por asimetría extrema.
+
+\- Riesgo por persistencia temporal.
+
+\- Riesgo por núcleo ancho.
+
+\- Riesgo por duración efectiva prolongada.
+
+
+
+\## Fuentes permitidas
+
+
+
+El criterio de riesgo temporal solo puede usar:
+
+
+
+\- Métricas morfológicas ya calculadas desde qSeries reales.
+
+\- Clasificación generada por `clasificarFormaQt`.
+
+\- Banderas diagnósticas devueltas por el helper de clasificación.
+
+\- Severidad ya calculada como parte del dictamen de forma.
+
+
+
+No se permite usar qSeries cruda directamente en esta OT.
+
+
+
+\## Variables candidatas
+
+
+
+Las variables candidatas son:
+
+
+
+\- forma.
+
+\- alerta.
+
+\- severidad.
+
+\- banderas.
+
+\- duración efectiva.
+
+\- tiempo de ascenso.
+
+\- tiempo de receso.
+
+\- W50.
+
+\- W25.
+
+\- asimetría.
+
+\- Qp.
+
+\- tPico.
+
+
+
+\## Restricciones
+
+
+
+Durante OT-0085:
+
+
+
+\- No se modifica `calcHidroCompleto`.
+
+\- No se modifica `uh`.
+
+\- No se modifica `hidroEngine.js`.
+
+\- No se reconstruye Q(t).
+
+\- No se interpola.
+
+\- No se recalculan métricas morfológicas.
+
+\- No se recalculan caudales.
+
+\- No se modifica la tabla Q-5.
+
+\- No se adopta automáticamente ningún método.
+
+\- No se levanta el estado global `No coherente`.
+
+\- No se reemplaza revisión hidrológica profesional.
+
+\- No se convierte el riesgo temporal en decisión hidráulica final.
+
+
+
+\## Alcance visual propuesto
+
+
+
+La exposición visual debe ser compacta y diagnóstica.
+
+
+
+Se propone agregar un bloque o tabla con:
+
+
+
+\- Método.
+
+\- Riesgo temporal principal.
+
+\- Nivel de riesgo.
+
+\- Factor dominante.
+
+\- Comentario breve no adoptivo.
+
+
+
+El bloque debe indicar explícitamente:
+
+
+
+> Diagnóstico comparativo no adoptivo.
+
+
+
+\## Criterio de aceptación de diseño
+
+
+
+OT-0085A se considera válida si deja definido:
+
+
+
+\- Qué significa riesgo temporal Q(t).
+
+\- Qué fuentes puede usar.
+
+\- Qué fuentes no puede usar.
+
+\- Qué riesgos temporales se pueden clasificar.
+
+\- Que el riesgo temporal no adopta método.
+
+\- Que el riesgo temporal no levanta `No coherente`.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0085 no es una OT de adopción.
+
+
+
+OT-0085 es una OT de lectura comparativa de riesgo temporal Q(t), basada en métricas y dictámenes previos, con carácter diagnóstico y no adoptivo.
+

--- a/00_ADMIN/bitacora/OT-0085/OT-0085D_validacion_visual_riesgo_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0085/OT-0085D_validacion_visual_riesgo_temporal_qt.md
@@ -1,0 +1,100 @@
+\# OT-0085D — Validación visual de riesgo temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0085C, se validó visualmente la integración del bloque de riesgo temporal Q(t) en el Panel diagnóstico qSeries.
+
+
+
+El riesgo temporal se deriva de las métricas morfológicas y del dictamen de forma Q(t), mediante el helper puro `evaluarRiesgoTemporalQt`.
+
+
+
+\## Evidencia visual
+
+
+
+El Panel diagnóstico qSeries muestra:
+
+
+
+\- Tabla diagnóstica morfológica Q(t).
+
+\- Dictamen diagnóstico de forma Q(t).
+
+\- Riesgo temporal Q(t).
+
+\- Resumen estructural de hidrogramas.
+
+
+
+La tabla de riesgo temporal presenta las columnas:
+
+
+
+\- Método.
+
+\- Riesgo.
+
+\- Nivel.
+
+\- Factor dominante.
+
+
+
+Los métodos aparecen con la siguiente lectura:
+
+
+
+\- SCS: persistencia temporal significativa; nivel medio; factor dominante: anchos W50/W25 relevantes.
+
+\- SCS Mod.: persistencia temporal significativa; nivel medio; factor dominante: anchos W50/W25 relevantes.
+
+\- Snyder: recesión prolongada dominante; nivel alto; factor dominante: duración efectiva alta y receso dominante.
+
+\- Williams \& Hann: asimetría extrema con concentración abrupta; nivel alto; factor dominante: receso extremo y ascenso abrupto.
+
+\- Clark IUH: recesión prolongada dominante; nivel alto; factor dominante: duración efectiva alta y receso dominante.
+
+
+
+\## Restricciones verificadas
+
+
+
+Durante la validación visual:
+
+
+
+\- No se seleccionó automáticamente ningún método.
+
+\- No se levantó el estado global `No coherente`.
+
+\- No se modificaron caudales.
+
+\- No se reconstruyó Q(t).
+
+\- No se interpolaron series.
+
+\- No se modificó el motor hidrológico.
+
+\- No se reemplazó la revisión hidrológica profesional.
+
+\- No se mostraron arrays crudos ni puntos tiempo-caudal masivos.
+
+
+
+\## Dictamen
+
+
+
+OT-0085C queda visualmente validada.
+
+
+
+La lectura de riesgo temporal Q(t) queda integrada como diagnóstico comparativo no adoptivo.
+

--- a/00_ADMIN/bitacora/OT-0085/OT-0085E_cierre_riesgo_temporal_qt_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0085/OT-0085E_cierre_riesgo_temporal_qt_no_adoptivo.md
@@ -1,0 +1,56 @@
+\# OT-0085E — Cierre técnico de riesgo temporal Q(t) no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0085 se desarrolló después del cierre de OT-0084, donde se implementó un dictamen diagnóstico de forma temporal Q(t) no adoptivo.
+
+
+
+El propósito de OT-0085 fue convertir la clasificación de forma Q(t) en una lectura comparativa de riesgo temporal, manteniendo separación estricta entre diagnóstico, comparación, decisión técnica y adopción hidrológica.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0085A — Diseño documental
+
+
+
+Se documentó el diseño del criterio comparativo de riesgo temporal Q(t) no adoptivo.
+
+
+
+Se estableció que el riesgo temporal:
+
+
+
+\- proviene de métricas morfológicas y dictámenes previos,
+
+\- no modifica resultados,
+
+\- no recalcula Q(t),
+
+\- no adopta métodos,
+
+\- no levanta el estado global No coherente.
+
+
+
+\### OT-0085B — Helper puro de riesgo temporal
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+evaluarRiesgoTemporalQt(entrada)
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -9,6 +9,7 @@ import adaptarQSeriesHidrogramas from "../services/hidrogramas/adaptarQSeriesHid
 import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstructuraHidrogramas";
 import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
 import clasificarFormaQt from "../services/hidrogramas/clasificarFormaQt";
+import evaluarRiesgoTemporalQt from "../services/hidrogramas/evaluarRiesgoTemporalQt";
 
 import {
   resumenComparadorCatalogo,
@@ -306,6 +307,45 @@ const filasDictamenFormaQt = useMemo(() => {
     };
   });
 }, [filasMorfologiaQt]);
+
+// OT-0085C — Filas de riesgo temporal Q(t) no adoptivo.
+// Lectura comparativa basada en el dictamen de forma y métricas morfológicas ya calculadas.
+const filasRiesgoTemporalQt = useMemo(() => {
+  if (!Array.isArray(filasDictamenFormaQt)) return [];
+
+  return filasDictamenFormaQt.map((filaDictamen) => {
+    const filaMorfologia =
+      Array.isArray(filasMorfologiaQt)
+        ? filasMorfologiaQt.find((fila) => fila?.metodo === filaDictamen?.metodo)
+        : null;
+
+    const riesgoTemporal = evaluarRiesgoTemporalQt({
+      forma: filaDictamen?.forma,
+      alerta: filaDictamen?.alerta,
+      severidad: filaDictamen?.severidad,
+      banderas: filaDictamen?.banderas,
+      duracionEfectivaMin: filaMorfologia?.duracionEfectivaMin,
+      tiempoAscensoMin: filaMorfologia?.tiempoAscensoMin,
+      tiempoRecesoMin: filaMorfologia?.tiempoRecesoMin,
+      W50Min: filaMorfologia?.W50Min,
+      W25Min: filaMorfologia?.W25Min,
+      asimetriaAscensoReceso: filaMorfologia?.asimetriaAscensoReceso,
+      Qp: filaMorfologia?.Qp,
+      tPico: filaMorfologia?.tPico
+    });
+
+    return {
+      metodo: filaDictamen?.metodo ?? "Método Q(t)",
+      riesgo: riesgoTemporal?.riesgo ?? "No determinado",
+      nivel: riesgoTemporal?.nivel ?? "No determinado",
+      factorDominante: riesgoTemporal?.factorDominante ?? "Sin factor dominante",
+      comentario: riesgoTemporal?.comentario ?? "Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo: Array.isArray(riesgoTemporal?.banderasRiesgo)
+        ? riesgoTemporal.banderasRiesgo
+        : []
+    };
+  });
+}, [filasDictamenFormaQt, filasMorfologiaQt]);
   
   const estilos = {
     pagina: {
@@ -2672,6 +2712,106 @@ const handleClickSeguro = (accion) => () => {
                     <div style={{ ...estilos.muted, marginTop: 8 }}>
                       Este dictamen clasifica la forma temporal Q(t) como diagnóstico preliminar. No adopta métodos, no modifica caudales, no levanta el estado global No coherente y no reemplaza revisión hidrológica profesional.
                     </div>
+                    {Array.isArray(filasRiesgoTemporalQt) && filasRiesgoTemporalQt.length > 0 && (
+                      <div
+                        style={{
+                          marginTop: 10,
+                          padding: 10,
+                          borderRadius: 8,
+                          border: "1px solid rgba(248, 113, 113, 0.35)",
+                          background: "rgba(15, 23, 42, 0.35)",
+                          overflowX: "auto"
+                        }}
+                      >
+                        <strong>Riesgo temporal Q(t):</strong>{" "}
+                        lectura comparativa no adoptiva de factores temporales dominantes.
+
+                        <table
+                          style={{
+                            width: "100%",
+                            borderCollapse: "collapse",
+                            marginTop: 10,
+                            fontSize: 12
+                          }}
+                        >
+                          <thead>
+                            <tr>
+                              {["Método", "Riesgo", "Nivel", "Factor dominante"].map((encabezado) => (
+                                <th
+                                  key={encabezado}
+                                  style={{
+                                    textAlign: "left",
+                                    padding: "6px 8px",
+                                    borderBottom: "1px solid rgba(148, 163, 184, 0.35)",
+                                    color: "#fecaca",
+                                    whiteSpace: "nowrap"
+                                  }}
+                                >
+                                  {encabezado}
+                                </th>
+                              ))}
+                            </tr>
+                          </thead>
+
+                          <tbody>
+                            {filasRiesgoTemporalQt.map((fila, indice) => (
+                              <tr key={`${fila.metodo}-riesgo-${indice}`}>
+                                <td
+                                  style={{
+                                    padding: "6px 8px",
+                                    borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                                    whiteSpace: "nowrap"
+                                  }}
+                                >
+                                  {fila.metodo}
+                                </td>
+
+                                <td
+                                  style={{
+                                    padding: "6px 8px",
+                                    borderBottom: "1px solid rgba(51, 65, 85, 0.55)"
+                                  }}
+                                >
+                                  {fila.riesgo}
+                                </td>
+
+                                <td
+                                  style={{
+                                    padding: "6px 8px",
+                                    borderBottom: "1px solid rgba(51, 65, 85, 0.55)",
+                                    color:
+                                      fila.nivel === "Alto"
+                                        ? "#fca5a5"
+                                        : fila.nivel === "Medio"
+                                        ? "#fde68a"
+                                        : fila.nivel === "Bajo"
+                                        ? "#86efac"
+                                        : "#cbd5e1",
+                                    fontWeight: 700,
+                                    whiteSpace: "nowrap"
+                                  }}
+                                >
+                                  {fila.nivel}
+                                </td>
+
+                                <td
+                                  style={{
+                                    padding: "6px 8px",
+                                    borderBottom: "1px solid rgba(51, 65, 85, 0.55)"
+                                  }}
+                                >
+                                  {fila.factorDominante}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+
+                        <div style={{ ...estilos.muted, marginTop: 8 }}>
+                          Esta lectura compara riesgos temporales derivados de la forma Q(t). No selecciona método, no modifica caudales, no levanta el estado global No coherente y no reemplaza revisión hidrológica profesional.
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
                 

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/evaluarRiesgoTemporalQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/evaluarRiesgoTemporalQt.js
@@ -1,0 +1,194 @@
+// OT-0085B — Helper puro de riesgo temporal Q(t).
+// Recibe métricas y dictamen de forma ya calculados.
+// No recibe qSeries cruda, no reconstruye Q(t), no interpola y no adopta métodos.
+
+function numeroFinito(valor) {
+  const numero = Number(valor);
+  return Number.isFinite(numero) ? numero : null;
+}
+
+function listaBanderas(banderas) {
+  return Array.isArray(banderas) ? banderas.filter(Boolean) : [];
+}
+
+function tieneBandera(banderas, nombre) {
+  return listaBanderas(banderas).includes(nombre);
+}
+
+function construirRespuesta({
+  ok = true,
+  riesgo = "No determinado",
+  nivel = "No determinado",
+  factorDominante = "Sin factor dominante",
+  comentario = "Diagnóstico comparativo no adoptivo.",
+  banderasRiesgo = []
+}) {
+  return {
+    ok,
+    riesgo,
+    nivel,
+    factorDominante,
+    comentario,
+    banderasRiesgo
+  };
+}
+
+export default function evaluarRiesgoTemporalQt(entrada = {}) {
+  const forma = String(entrada?.forma ?? "");
+  const alerta = String(entrada?.alerta ?? "");
+  const severidad = String(entrada?.severidad ?? "");
+  const banderas = listaBanderas(entrada?.banderas);
+
+  const duracionEfectivaMin = numeroFinito(entrada?.duracionEfectivaMin);
+  const tiempoAscensoMin = numeroFinito(entrada?.tiempoAscensoMin);
+  const tiempoRecesoMin = numeroFinito(entrada?.tiempoRecesoMin);
+  const W50Min = numeroFinito(entrada?.W50Min);
+  const W25Min = numeroFinito(entrada?.W25Min);
+  const asimetriaAscensoReceso = numeroFinito(entrada?.asimetriaAscensoReceso);
+  const Qp = numeroFinito(entrada?.Qp);
+  const tPico = numeroFinito(entrada?.tPico);
+
+  if (!forma || !alerta || !severidad) {
+    return construirRespuesta({
+      ok: false,
+      riesgo: "No clasificable",
+      nivel: "No determinado",
+      factorDominante: "Dictamen de forma insuficiente",
+      comentario:
+        "No existe dictamen de forma suficiente para evaluar riesgo temporal. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo: ["dictamen_forma_insuficiente"]
+    });
+  }
+
+  const recesoDominante = tieneBandera(banderas, "receso_dominante");
+  const recesoMuyDominante = tieneBandera(banderas, "receso_muy_dominante");
+  const recesoExtremo = tieneBandera(banderas, "receso_extremo");
+  const ascensoAbrupto = tieneBandera(banderas, "ascenso_abrupto");
+  const duracionProlongada = tieneBandera(banderas, "duracion_prolongada");
+  const persistenciaAlta = tieneBandera(banderas, "persistencia_alta");
+  const nucleoAncho = tieneBandera(banderas, "nucleo_ancho");
+  const picoTemprano = tieneBandera(banderas, "pico_temprano");
+
+  const banderasRiesgo = [];
+
+  if (recesoExtremo) banderasRiesgo.push("riesgo_asimetria_extrema");
+  if (recesoMuyDominante || duracionProlongada) banderasRiesgo.push("riesgo_recesion_prolongada");
+  if (ascensoAbrupto) banderasRiesgo.push("riesgo_ascenso_abrupto");
+  if (picoTemprano) banderasRiesgo.push("riesgo_pico_temprano");
+  if (persistenciaAlta || nucleoAncho) banderasRiesgo.push("riesgo_persistencia_temporal");
+
+  if (recesoExtremo && ascensoAbrupto) {
+    return construirRespuesta({
+      riesgo: "Asimetría extrema con concentración abrupta",
+      nivel: "Alto",
+      factorDominante: "Receso extremo y ascenso abrupto",
+      comentario:
+        "La forma temporal combina ascenso muy corto con receso extremo. Este riesgo es comparativo y no adopta método ni levanta el estado global No coherente.",
+      banderasRiesgo
+    });
+  }
+
+  if (recesoMuyDominante && duracionProlongada) {
+    return construirRespuesta({
+      riesgo: "Recesión prolongada dominante",
+      nivel: "Alto",
+      factorDominante: "Duración efectiva alta y receso dominante",
+      comentario:
+        "La respuesta temporal se prolonga por una recesión dominante. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (recesoExtremo) {
+    return construirRespuesta({
+      riesgo: "Asimetría extrema",
+      nivel: "Alto",
+      factorDominante: "Relación receso/ascenso extrema",
+      comentario:
+        "La asimetría temporal alcanza un nivel extremo bajo los criterios preliminares. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (recesoMuyDominante) {
+    return construirRespuesta({
+      riesgo: "Recesión muy dominante",
+      nivel: "Alto",
+      factorDominante: "Receso muy superior al ascenso",
+      comentario:
+        "El tiempo de receso domina ampliamente la respuesta temporal. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (ascensoAbrupto && picoTemprano) {
+    return construirRespuesta({
+      riesgo: "Pico temprano con ascenso abrupto",
+      nivel: "Medio",
+      factorDominante: "Concentración temprana de la respuesta",
+      comentario:
+        "La respuesta concentra el ascenso y el pico en una fase temprana. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (duracionProlongada) {
+    return construirRespuesta({
+      riesgo: "Duración efectiva prolongada",
+      nivel: "Medio",
+      factorDominante: "Extensión temporal del hidrograma",
+      comentario:
+        "La duración efectiva sugiere persistencia temporal relevante. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (persistenciaAlta || nucleoAncho) {
+    return construirRespuesta({
+      riesgo: "Persistencia temporal significativa",
+      nivel: "Medio",
+      factorDominante: "Anchos W50/W25 relevantes",
+      comentario:
+        "Los anchos temporales sugieren permanencia de caudales significativos. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (recesoDominante) {
+    return construirRespuesta({
+      riesgo: "Receso dominante moderado",
+      nivel: "Medio",
+      factorDominante: "Receso mayor que ascenso",
+      comentario:
+        "La recesión domina la forma temporal, sin alcanzar umbrales extremos. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  if (
+    severidad === "Baja" &&
+    asimetriaAscensoReceso !== null &&
+    asimetriaAscensoReceso < 3 &&
+    duracionEfectivaMin !== null &&
+    Qp !== null &&
+    tPico !== null
+  ) {
+    return construirRespuesta({
+      riesgo: "Riesgo temporal bajo",
+      nivel: "Bajo",
+      factorDominante: "Sin alerta temporal dominante",
+      comentario:
+        "No se identifica un factor temporal dominante bajo los criterios preliminares. Diagnóstico comparativo no adoptivo.",
+      banderasRiesgo
+    });
+  }
+
+  return construirRespuesta({
+    riesgo: "Riesgo temporal moderado no específico",
+    nivel: severidad === "Alta" ? "Alto" : severidad === "Media" ? "Medio" : "Bajo",
+    factorDominante: alerta || "Forma temporal sin factor dominante",
+    comentario:
+      "El riesgo temporal se deriva del dictamen de forma disponible. Diagnóstico comparativo no adoptivo.",
+    banderasRiesgo
+  });
+}


### PR DESCRIPTION
## Resumen

Esta OT implementa una lectura comparativa de riesgo temporal Q(t) no adoptiva, derivada de las métricas morfológicas y del dictamen de forma Q(t) implementados en las OT previas.

El riesgo temporal permite identificar factores dominantes entre métodos sin seleccionar método, sin modificar caudales y sin levantar el estado global `No coherente`.

## Secuencia técnica

- OT-0085A: diseño documental del criterio comparativo de riesgo temporal Q(t) no adoptivo.
- OT-0085B: creación del helper puro `evaluarRiesgoTemporalQt(entrada)`.
- OT-0085C: integración visual del bloque de riesgo temporal Q(t) en el Panel diagnóstico qSeries.
- OT-0085D: validación visual documental.
- OT-0085E: cierre técnico documental.

## Cambios principales

Se agregó el helper puro:

```js
evaluarRiesgoTemporalQt(entrada)