### PR TITLE
OT-0086 — Síntesis ejecutiva temporal Q(t) no adoptiva

### DIFF
--- a/00_ADMIN/bitacora/OT-0086/OT-0086A_diseno_sintesis_ejecutiva_temporal_qt_no_adoptiva.md
+++ b/00_ADMIN/bitacora/OT-0086/OT-0086A_diseno_sintesis_ejecutiva_temporal_qt_no_adoptiva.md
@@ -1,0 +1,228 @@
+\# OT-0086A — Diseño de síntesis ejecutiva temporal Q(t) no adoptiva
+
+
+
+\## Contexto
+
+
+
+OT-0086 se abre después del cierre de OT-0085, donde se implementó una lectura comparativa de riesgo temporal Q(t) no adoptiva.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries reales.
+
+\- OT-0081 activó y validó qSeries reales en el comparador.
+
+\- OT-0082 implementó validación, métricas morfológicas y diagnóstico agregado.
+
+\- OT-0083 expuso métricas morfológicas compactas y no adoptivas.
+
+\- OT-0084 clasificó la forma Q(t) por método mediante un dictamen diagnóstico no adoptivo.
+
+\- OT-0085 tradujo la forma Q(t) a una lectura comparativa de riesgo temporal no adoptiva.
+
+
+
+Al cierre de OT-0085, el Panel diagnóstico qSeries permite identificar riesgos temporales por método, incluyendo nivel y factor dominante.
+
+
+
+\## Tesis técnica
+
+
+
+La lectura de riesgo temporal puede resumirse en una síntesis ejecutiva para facilitar interpretación técnica, pero dicha síntesis no equivale a adopción hidrológica.
+
+
+
+OT-0086 debe agrupar hallazgos temporales relevantes sin seleccionar método, sin modificar resultados y sin levantar el estado global `No coherente`.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una síntesis ejecutiva temporal Q(t) basada en los riesgos temporales ya calculados y visualizados.
+
+
+
+La síntesis debe presentar hallazgos agrupados, breves y trazables, manteniendo carácter diagnóstico y no adoptivo.
+
+
+
+\## Hallazgos ejecutivos candidatos
+
+
+
+La síntesis podrá agrupar información como:
+
+
+
+\- Métodos con riesgo alto por recesión prolongada.
+
+\- Método con riesgo alto por asimetría extrema o concentración abrupta.
+
+\- Métodos con persistencia temporal significativa de nivel medio.
+
+\- Métodos con factor dominante asociado a W50/W25.
+
+\- Métodos con duración efectiva alta y receso dominante.
+
+
+
+\## Fuentes permitidas
+
+
+
+La síntesis ejecutiva solo puede usar:
+
+
+
+\- Resultados del helper `evaluarRiesgoTemporalQt`.
+
+\- Filas de riesgo temporal ya generadas.
+
+\- Dictamen de forma Q(t) ya calculado.
+
+\- Métricas morfológicas ya calculadas desde qSeries reales.
+
+
+
+No se permite usar qSeries cruda directamente en esta OT.
+
+
+
+\## Fuentes no permitidas
+
+
+
+Durante OT-0086 no se permite:
+
+
+
+\- Leer qSeries cruda para producir la síntesis.
+
+\- Reconstruir Q(t).
+
+\- Interpolar.
+
+\- Recalcular métricas.
+
+\- Recalcular caudales.
+
+\- Usar Qpico, tPico o volTotal como sustitutos de qSeries.
+
+\- Seleccionar automáticamente un método.
+
+\- Levantar el estado global `No coherente`.
+
+
+
+\## Alcance visual propuesto
+
+
+
+La exposición visual debe ser breve y ejecutiva.
+
+
+
+Se propone agregar un bloque dentro del Panel diagnóstico qSeries con:
+
+
+
+\- Síntesis ejecutiva temporal Q(t).
+
+\- Grupos de hallazgos por nivel de riesgo.
+
+\- Factores dominantes principales.
+
+\- Advertencia explícita de no adopción.
+
+
+
+El bloque debe indicar explícitamente:
+
+
+
+> Síntesis diagnóstica no adoptiva.
+
+
+
+\## Restricciones
+
+
+
+Durante OT-0086:
+
+
+
+\- No se modifica `calcHidroCompleto`.
+
+\- No se modifica `uh`.
+
+\- No se modifica `hidroEngine.js`.
+
+\- No se reconstruye Q(t).
+
+\- No se interpola.
+
+\- No se recalculan métricas morfológicas.
+
+\- No se recalculan caudales.
+
+\- No se modifica la tabla Q-5.
+
+\- No se selecciona automáticamente ningún método.
+
+\- No se levanta el estado global `No coherente`.
+
+\- No se reemplaza revisión hidrológica profesional.
+
+\- No se convierte la síntesis ejecutiva en decisión hidráulica final.
+
+
+
+\## Criterio de aceptación de diseño
+
+
+
+OT-0086A se considera válida si deja definido:
+
+
+
+\- Qué significa síntesis ejecutiva temporal Q(t).
+
+\- Qué fuentes puede usar.
+
+\- Qué fuentes no puede usar.
+
+\- Qué hallazgos puede agrupar.
+
+\- Que la síntesis no adopta método.
+
+\- Que la síntesis no levanta `No coherente`.
+
+\- Que la síntesis es diagnóstica y no decisoria.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0086 no es una OT de adopción.
+
+
+
+OT-0086 es una OT de síntesis ejecutiva diagnóstica de riesgo temporal Q(t), basada en métricas, forma y riesgo temporal previamente calculados.
+

--- a/00_ADMIN/bitacora/OT-0086/OT-0086D_validacion_visual_sintesis_ejecutiva_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0086/OT-0086D_validacion_visual_sintesis_ejecutiva_temporal_qt.md
@@ -1,0 +1,102 @@
+\# OT-0086D — Validación visual de síntesis ejecutiva temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0086C, se validó visualmente la integración del bloque de síntesis ejecutiva temporal Q(t) en el Panel diagnóstico qSeries.
+
+
+
+La síntesis se deriva de las filas de riesgo temporal ya evaluadas mediante el helper puro `sintetizarRiesgoTemporalQt`.
+
+
+
+\## Evidencia visual
+
+
+
+El Panel diagnóstico qSeries muestra:
+
+
+
+\- Tabla diagnóstica morfológica Q(t).
+
+\- Dictamen diagnóstico de forma Q(t).
+
+\- Riesgo temporal Q(t).
+
+\- Síntesis ejecutiva temporal Q(t).
+
+\- Resumen estructural de hidrogramas.
+
+
+
+La síntesis ejecutiva presenta:
+
+
+
+\- Riesgo alto: 3.
+
+\- Riesgo medio: 2.
+
+\- Riesgo bajo: 0.
+
+\- No determinado: 0.
+
+
+
+La lectura agrupada visible es:
+
+
+
+\- Riesgo temporal alto: Snyder, Williams \& Hann, Clark IUH.
+
+\- Riesgo temporal medio: SCS, SCS Mod.
+
+\- Persistencia temporal significativa: SCS, SCS Mod. (Medio).
+
+\- Recesión prolongada dominante: Snyder, Clark IUH (Alto).
+
+\- Asimetría extrema con concentración abrupta: Williams \& Hann (Alto).
+
+
+
+\## Restricciones verificadas
+
+
+
+Durante la validación visual:
+
+
+
+\- No se seleccionó automáticamente ningún método.
+
+\- No se levantó el estado global `No coherente`.
+
+\- No se modificaron caudales.
+
+\- No se reconstruyó Q(t).
+
+\- No se interpolaron series.
+
+\- No se modificó el motor hidrológico.
+
+\- No se reemplazó la revisión hidrológica profesional.
+
+\- No se mostraron arrays crudos ni puntos tiempo-caudal masivos.
+
+
+
+\## Dictamen
+
+
+
+OT-0086C queda visualmente validada.
+
+
+
+La síntesis ejecutiva temporal Q(t) queda integrada como lectura diagnóstica agrupada, no adoptiva y no decisoria.
+

--- a/00_ADMIN/bitacora/OT-0086/OT-0086E_cierre_sintesis_ejecutiva_temporal_qt_no_adoptiva.md
+++ b/00_ADMIN/bitacora/OT-0086/OT-0086E_cierre_sintesis_ejecutiva_temporal_qt_no_adoptiva.md
@@ -1,0 +1,58 @@
+\# OT-0086E — Cierre técnico de síntesis ejecutiva temporal Q(t) no adoptiva
+
+
+
+\## Contexto
+
+
+
+OT-0086 se desarrolló después del cierre de OT-0085, donde se implementó una lectura comparativa de riesgo temporal Q(t) no adoptiva.
+
+
+
+El propósito de OT-0086 fue convertir la lectura de riesgo temporal en una síntesis ejecutiva agrupada, manteniendo separación estricta entre diagnóstico, interpretación técnica, decisión y adopción hidrológica.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0086A — Diseño documental
+
+
+
+Se documentó el diseño de la síntesis ejecutiva temporal Q(t) no adoptiva.
+
+
+
+Se estableció que la síntesis:
+
+
+
+\- proviene de riesgos temporales ya evaluados,
+
+\- no lee qSeries cruda,
+
+\- no recalcula métricas,
+
+\- no reconstruye Q(t),
+
+\- no selecciona método,
+
+\- no levanta el estado global No coherente.
+
+
+
+\### OT-0086B — Helper puro de síntesis
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+sintetizarRiesgoTemporalQt(filasRiesgoTemporalQt)
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -10,6 +10,7 @@ import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstruct
 import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
 import clasificarFormaQt from "../services/hidrogramas/clasificarFormaQt";
 import evaluarRiesgoTemporalQt from "../services/hidrogramas/evaluarRiesgoTemporalQt";
+import sintetizarRiesgoTemporalQt from "../services/hidrogramas/sintetizarRiesgoTemporalQt";
 
 import {
   resumenComparadorCatalogo,
@@ -346,6 +347,31 @@ const filasRiesgoTemporalQt = useMemo(() => {
     };
   });
 }, [filasDictamenFormaQt, filasMorfologiaQt]);
+
+// OT-0086C — Síntesis ejecutiva temporal Q(t) no adoptiva.
+// Resume riesgos temporales ya evaluados, sin seleccionar método ni levantar bloqueos.
+const sintesisRiesgoTemporalQt = useMemo(() => {
+  try {
+    return sintetizarRiesgoTemporalQt(filasRiesgoTemporalQt);
+  } catch (errorSintesisRiesgoTemporalQt) {
+    return {
+      ok: false,
+      resumen: [
+        "No fue posible generar la síntesis ejecutiva temporal Q(t)."
+      ],
+      niveles: {
+        alto: 0,
+        medio: 0,
+        bajo: 0,
+        noDeterminado: 0
+      },
+      riesgos: {},
+      advertencia:
+        "Síntesis diagnóstica no adoptiva; no selecciona método ni levanta No coherente.",
+      error: String(errorSintesisRiesgoTemporalQt?.message ?? errorSintesisRiesgoTemporalQt)
+    };
+  }
+}, [filasRiesgoTemporalQt]);
   
   const estilos = {
     pagina: {
@@ -2810,6 +2836,60 @@ const handleClickSeguro = (accion) => () => {
                         <div style={{ ...estilos.muted, marginTop: 8 }}>
                           Esta lectura compara riesgos temporales derivados de la forma Q(t). No selecciona método, no modifica caudales, no levanta el estado global No coherente y no reemplaza revisión hidrológica profesional.
                         </div>
+                        {sintesisRiesgoTemporalQt?.ok && Array.isArray(sintesisRiesgoTemporalQt.resumen) && (
+                          <div
+                            style={{
+                              marginTop: 10,
+                              padding: 10,
+                              borderRadius: 8,
+                              border: "1px solid rgba(56, 189, 248, 0.35)",
+                              background: "rgba(15, 23, 42, 0.35)"
+                            }}
+                          >
+                            <strong>Síntesis ejecutiva temporal Q(t):</strong>{" "}
+                            lectura agrupada de riesgos temporales. Diagnóstico no adoptivo.
+
+                            <div
+                              style={{
+                                display: "grid",
+                                gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+                                gap: 8,
+                                marginTop: 10,
+                                marginBottom: 10
+                              }}
+                            >
+                              <div>
+                                <strong>Riesgo alto:</strong>{" "}
+                                {sintesisRiesgoTemporalQt.niveles?.alto ?? 0}
+                              </div>
+                              <div>
+                                <strong>Riesgo medio:</strong>{" "}
+                                {sintesisRiesgoTemporalQt.niveles?.medio ?? 0}
+                              </div>
+                              <div>
+                                <strong>Riesgo bajo:</strong>{" "}
+                                {sintesisRiesgoTemporalQt.niveles?.bajo ?? 0}
+                              </div>
+                              <div>
+                                <strong>No determinado:</strong>{" "}
+                                {sintesisRiesgoTemporalQt.niveles?.noDeterminado ?? 0}
+                              </div>
+                            </div>
+
+                            <ul style={{ margin: "8px 0 0 18px", padding: 0 }}>
+                              {sintesisRiesgoTemporalQt.resumen.map((item, indice) => (
+                                <li key={`sintesis-riesgo-temporal-${indice}`} style={{ marginBottom: 4 }}>
+                                  {item}
+                                </li>
+                              ))}
+                            </ul>
+
+                            <div style={{ ...estilos.muted, marginTop: 8 }}>
+                              {sintesisRiesgoTemporalQt.advertencia ??
+                                "Síntesis diagnóstica no adoptiva; no selecciona método ni levanta No coherente."}
+                            </div>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/sintetizarRiesgoTemporalQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/sintetizarRiesgoTemporalQt.js
@@ -1,0 +1,174 @@
+// OT-0086B — Helper puro de síntesis ejecutiva temporal Q(t).
+// Recibe filas de riesgo temporal ya evaluadas.
+// No recibe qSeries cruda, no recalcula métricas, no reconstruye Q(t), no interpola y no adopta métodos.
+
+function normalizarTexto(valor) {
+  return String(valor ?? "").trim();
+}
+
+function agruparPorNivel(filas) {
+  return filas.reduce(
+    (grupos, fila) => {
+      const nivel = normalizarTexto(fila?.nivel);
+
+      if (nivel === "Alto") grupos.alto.push(fila);
+      else if (nivel === "Medio") grupos.medio.push(fila);
+      else if (nivel === "Bajo") grupos.bajo.push(fila);
+      else grupos.noDeterminado.push(fila);
+
+      return grupos;
+    },
+    {
+      alto: [],
+      medio: [],
+      bajo: [],
+      noDeterminado: []
+    }
+  );
+}
+
+function agruparPorRiesgo(filas) {
+  return filas.reduce((grupos, fila) => {
+    const riesgo = normalizarTexto(fila?.riesgo) || "Riesgo no determinado";
+
+    if (!grupos[riesgo]) grupos[riesgo] = [];
+    grupos[riesgo].push(fila);
+
+    return grupos;
+  }, {});
+}
+
+function nombresMetodos(filas) {
+  return filas
+    .map((fila) => normalizarTexto(fila?.metodo))
+    .filter(Boolean)
+    .join(", ");
+}
+
+function construirRespuesta({
+  ok = true,
+  resumen = [],
+  niveles = {
+    alto: 0,
+    medio: 0,
+    bajo: 0,
+    noDeterminado: 0
+  },
+  riesgos = {},
+  advertencia = "Síntesis diagnóstica no adoptiva.",
+  metodoCritico = null
+}) {
+  return {
+    ok,
+    resumen,
+    niveles,
+    riesgos,
+    advertencia,
+    metodoCritico
+  };
+}
+
+export default function sintetizarRiesgoTemporalQt(filasRiesgoTemporalQt = []) {
+  if (!Array.isArray(filasRiesgoTemporalQt)) {
+    return construirRespuesta({
+      ok: false,
+      resumen: [
+        "No fue posible generar síntesis ejecutiva temporal porque la entrada no es una lista de riesgos."
+      ],
+      advertencia:
+        "Síntesis diagnóstica no adoptiva; no selecciona método ni levanta No coherente."
+    });
+  }
+
+  const filasValidas = filasRiesgoTemporalQt.filter((fila) =>
+    Boolean(normalizarTexto(fila?.metodo))
+  );
+
+  if (filasValidas.length === 0) {
+    return construirRespuesta({
+      ok: false,
+      resumen: [
+        "No hay filas de riesgo temporal disponibles para síntesis ejecutiva."
+      ],
+      advertencia:
+        "Síntesis diagnóstica no adoptiva; no selecciona método ni levanta No coherente."
+    });
+  }
+
+  const gruposNivel = agruparPorNivel(filasValidas);
+  const gruposRiesgo = agruparPorRiesgo(filasValidas);
+
+  const resumen = [];
+
+  if (gruposNivel.alto.length > 0) {
+    resumen.push(
+      `Riesgo temporal alto: ${nombresMetodos(gruposNivel.alto)}.`
+    );
+  }
+
+  if (gruposNivel.medio.length > 0) {
+    resumen.push(
+      `Riesgo temporal medio: ${nombresMetodos(gruposNivel.medio)}.`
+    );
+  }
+
+  if (gruposNivel.bajo.length > 0) {
+    resumen.push(
+      `Riesgo temporal bajo: ${nombresMetodos(gruposNivel.bajo)}.`
+    );
+  }
+
+  Object.entries(gruposRiesgo).forEach(([riesgo, filas]) => {
+    if (!riesgo || filas.length === 0) return;
+
+    const metodos = nombresMetodos(filas);
+    const nivelDominante = normalizarTexto(filas[0]?.nivel) || "nivel no determinado";
+
+    resumen.push(
+      `${riesgo}: ${metodos} (${nivelDominante}).`
+    );
+  });
+
+  const altoConFactores = gruposNivel.alto.map((fila) => ({
+    metodo: normalizarTexto(fila?.metodo),
+    riesgo: normalizarTexto(fila?.riesgo),
+    factorDominante: normalizarTexto(fila?.factorDominante)
+  }));
+
+  const metodoCritico =
+    altoConFactores.length === 1
+      ? altoConFactores[0]
+      : null;
+
+  if (metodoCritico) {
+    resumen.push(
+      `Método con riesgo alto singular: ${metodoCritico.metodo}, asociado a ${metodoCritico.factorDominante || metodoCritico.riesgo}.`
+    );
+  }
+
+  if (resumen.length === 0) {
+    resumen.push(
+      "No se identificaron agrupaciones ejecutivas dominantes bajo los criterios disponibles."
+    );
+  }
+
+  return construirRespuesta({
+    ok: true,
+    resumen,
+    niveles: {
+      alto: gruposNivel.alto.length,
+      medio: gruposNivel.medio.length,
+      bajo: gruposNivel.bajo.length,
+      noDeterminado: gruposNivel.noDeterminado.length
+    },
+    riesgos: Object.fromEntries(
+      Object.entries(gruposRiesgo).map(([riesgo, filas]) => [
+        riesgo,
+        filas.map((fila) => normalizarTexto(fila?.metodo)).filter(Boolean)
+      ])
+    ),
+    advertencia:
+      "Síntesis diagnóstica no adoptiva; no selecciona método, no modifica caudales y no levanta el estado global No coherente.",
+    metodoCritico
+  });
+}


### PR DESCRIPTION
## Resumen

Esta OT implementa una síntesis ejecutiva temporal Q(t) no adoptiva, derivada de la lectura comparativa de riesgo temporal implementada en OT-0085.

La síntesis permite comunicar de forma breve los hallazgos temporales dominantes entre métodos, sin seleccionar método, sin modificar caudales y sin levantar el estado global `No coherente`.

## Secuencia técnica

- OT-0086A: diseño documental de síntesis ejecutiva temporal Q(t) no adoptiva.
- OT-0086B: creación del helper puro `sintetizarRiesgoTemporalQt(filasRiesgoTemporalQt)`.
- OT-0086C: integración visual del bloque de síntesis ejecutiva temporal Q(t).
- OT-0086D: validación visual documental.
- OT-0086E: cierre técnico documental.

## Cambios principales

Se agregó el helper puro:

```js
sintetizarRiesgoTemporalQt(filasRiesgoTemporalQt)