### PR TITLE
OT-0087 — Diagnóstico temporal Q(t) exportable no adoptivo

### DIFF
--- a/00_ADMIN/bitacora/OT-0087/OT-0087A_diseno_diagnostico_temporal_expediente_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0087/OT-0087A_diseno_diagnostico_temporal_expediente_no_adoptivo.md
@@ -1,0 +1,280 @@
+\# OT-0087A — Diseño de diagnóstico temporal Q(t) para expediente no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0087 se abre después del cierre de OT-0086, donde se implementó una síntesis ejecutiva temporal Q(t) no adoptiva.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries reales.
+
+\- OT-0081 activó y validó qSeries reales en el comparador.
+
+\- OT-0082 implementó validación, métricas morfológicas y diagnóstico agregado.
+
+\- OT-0083 expuso métricas morfológicas compactas y no adoptivas.
+
+\- OT-0084 clasificó la forma Q(t) por método mediante dictamen no adoptivo.
+
+\- OT-0085 tradujo la forma Q(t) a riesgo temporal comparativo no adoptivo.
+
+\- OT-0086 sintetizó ejecutivamente los hallazgos temporales dominantes.
+
+
+
+Al cierre de OT-0086, el Panel diagnóstico qSeries contiene una lectura completa de métricas, forma, riesgo y síntesis temporal.
+
+
+
+\## Tesis técnica
+
+
+
+La cadena de diagnóstico temporal Q(t) puede consolidarse en el expediente como sección técnica exportable, siempre que se mantenga el carácter no adoptivo.
+
+
+
+La incorporación al expediente no debe seleccionar método, no debe modificar caudales, no debe levantar el estado global `No coherente` y no debe reemplazar revisión hidrológica profesional.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una sección exportable para el expediente hidrológico mínimo que consolide:
+
+
+
+\- métricas morfológicas Q(t),
+
+\- dictamen de forma Q(t),
+
+\- riesgo temporal Q(t),
+
+\- síntesis ejecutiva temporal Q(t),
+
+
+
+manteniendo advertencia explícita de diagnóstico no adoptivo.
+
+
+
+\## Alcance propuesto
+
+
+
+La sección exportable deberá contener:
+
+
+
+1\. Título de sección:
+
+&#x20;  - Diagnóstico temporal Q(t) no adoptivo.
+
+
+
+2\. Fuente de datos:
+
+&#x20;  - qSeries reales publicadas y validadas.
+
+&#x20;  - Métricas morfológicas calculadas desde qSeries.
+
+&#x20;  - Dictamen de forma Q(t).
+
+&#x20;  - Riesgo temporal Q(t).
+
+&#x20;  - Síntesis ejecutiva temporal Q(t).
+
+
+
+3\. Resumen ejecutivo:
+
+&#x20;  - Riesgo alto.
+
+&#x20;  - Riesgo medio.
+
+&#x20;  - Riesgo bajo.
+
+&#x20;  - No determinado.
+
+&#x20;  - Lectura agrupada de hallazgos temporales.
+
+
+
+4\. Tabla o listado por método:
+
+&#x20;  - Método.
+
+&#x20;  - Forma.
+
+&#x20;  - Riesgo temporal.
+
+&#x20;  - Nivel.
+
+&#x20;  - Factor dominante.
+
+
+
+5\. Advertencia técnica:
+
+&#x20;  - Diagnóstico no adoptivo.
+
+&#x20;  - No selecciona método.
+
+&#x20;  - No levanta `No coherente`.
+
+&#x20;  - No reemplaza revisión hidrológica profesional.
+
+
+
+\## Fuentes permitidas
+
+
+
+La sección del expediente solo puede usar:
+
+
+
+\- `filasMorfologiaQt`.
+
+\- `filasDictamenFormaQt`.
+
+\- `filasRiesgoTemporalQt`.
+
+\- `sintesisRiesgoTemporalQt`.
+
+\- Resultados derivados de helpers puros ya integrados.
+
+
+
+No se permite leer qSeries cruda directamente en la generación del texto del expediente.
+
+
+
+\## Fuentes no permitidas
+
+
+
+Durante OT-0087 no se permite:
+
+
+
+\- Reconstruir Q(t).
+
+\- Interpolar series.
+
+\- Recalcular métricas morfológicas.
+
+\- Recalcular riesgos fuera de los helpers existentes.
+
+\- Recalcular caudales.
+
+\- Usar `uh` como qSeries.
+
+\- Usar Qpico, tPico o volTotal como sustitutos de qSeries.
+
+\- Seleccionar automáticamente un método.
+
+\- Levantar el estado global `No coherente`.
+
+
+
+\## Restricciones
+
+
+
+Durante OT-0087:
+
+
+
+\- No se modifica `calcHidroCompleto`.
+
+\- No se modifica `uh`.
+
+\- No se modifica `hidroEngine.js`.
+
+\- No se modifica la lógica de convolución.
+
+\- No se alteran Qp, Tp, Volumen ni Q(t).
+
+\- No se modifica la tabla Q-5.
+
+\- No se adopta automáticamente ningún método.
+
+\- No se convierte el diagnóstico temporal en decisión hidráulica final.
+
+
+
+\## Alcance visual/exportable propuesto
+
+
+
+La primera integración debe ser textual y controlada dentro del expediente copiado.
+
+
+
+No debe incluir arrays crudos ni puntos tiempo-caudal completos.
+
+
+
+Debe ser una sección breve, trazable y defendible, por ejemplo:
+
+
+
+\- `## Diagnóstico temporal Q(t) no adoptivo`
+
+\- `### Síntesis ejecutiva temporal`
+
+\- `### Lectura por método`
+
+\- `### Restricciones de interpretación`
+
+
+
+\## Criterio de aceptación de diseño
+
+
+
+OT-0087A se considera válida si deja definido:
+
+
+
+\- Qué información temporal puede exportarse.
+
+\- Qué fuentes puede usar.
+
+\- Qué fuentes no puede usar.
+
+\- Qué advertencias deben acompañar la sección.
+
+\- Que la sección no adopta método.
+
+\- Que la sección no levanta `No coherente`.
+
+\- Que la sección no reemplaza revisión hidrológica profesional.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0087 no es una OT de adopción.
+
+
+
+OT-0087 es una OT de consolidación exportable del diagnóstico temporal Q(t), con carácter no adoptivo y trazabilidad explícita hacia métricas, forma, riesgo y síntesis ejecutiva.
+

--- a/00_ADMIN/bitacora/OT-0087/OT-0087D_validacion_expediente_diagnostico_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0087/OT-0087D_validacion_expediente_diagnostico_temporal_qt.md
@@ -1,0 +1,38 @@
+\# OT-0087D — Validación del expediente con diagnóstico temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0087C, se validó la integración de la sección exportable de diagnóstico temporal Q(t) no adoptivo dentro del expediente hidrológico mínimo copiado.
+
+
+
+La sección fue construida mediante el helper puro `construirSeccionDiagnosticoTemporalQt`, usando estructuras ya preparadas:
+
+
+
+\- filasMorfologiaQt
+
+\- filasDictamenFormaQt
+
+\- filasRiesgoTemporalQt
+
+\- sintesisRiesgoTemporalQt
+
+
+
+\## Evidencia validada
+
+
+
+La sección obligatoria fue incorporada en la lista interna de control:
+
+
+
+```js
+
+"## Diagnóstico temporal Q(t) no adoptivo"
+

--- a/00_ADMIN/bitacora/OT-0087/OT-0087E_cierre_diagnostico_temporal_expediente_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0087/OT-0087E_cierre_diagnostico_temporal_expediente_no_adoptivo.md
@@ -1,0 +1,68 @@
+\# OT-0087E — Cierre técnico del diagnóstico temporal Q(t) para expediente no adoptivo
+
+
+
+\## Contexto
+
+
+
+OT-0087 se desarrolló después del cierre de OT-0086, donde se implementó una síntesis ejecutiva temporal Q(t) no adoptiva.
+
+
+
+El propósito de OT-0087 fue consolidar la cadena de diagnóstico temporal Q(t) dentro del expediente hidrológico mínimo, manteniendo separación estricta entre diagnóstico, exportación textual, decisión técnica y adopción hidrológica.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0087A — Diseño documental
+
+
+
+Se documentó el diseño de una sección exportable de diagnóstico temporal Q(t) no adoptivo para el expediente.
+
+
+
+Se estableció que la sección debía consolidar:
+
+
+
+\- métricas morfológicas Q(t),
+
+\- dictamen de forma Q(t),
+
+\- riesgo temporal Q(t),
+
+\- síntesis ejecutiva temporal Q(t),
+
+
+
+sin seleccionar método ni levantar el estado global No coherente.
+
+
+
+\### OT-0087B — Helper puro de sección exportable
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+construirSeccionDiagnosticoTemporalQt({
+
+&#x20; filasMorfologiaQt,
+
+&#x20; filasDictamenFormaQt,
+
+&#x20; filasRiesgoTemporalQt,
+
+&#x20; sintesisRiesgoTemporalQt
+
+})
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -11,6 +11,7 @@ import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetric
 import clasificarFormaQt from "../services/hidrogramas/clasificarFormaQt";
 import evaluarRiesgoTemporalQt from "../services/hidrogramas/evaluarRiesgoTemporalQt";
 import sintetizarRiesgoTemporalQt from "../services/hidrogramas/sintetizarRiesgoTemporalQt";
+import construirSeccionDiagnosticoTemporalQt from "../services/hidrogramas/construirSeccionDiagnosticoTemporalQt";
 
 import {
   resumenComparadorCatalogo,
@@ -1981,6 +1982,14 @@ const handleClickSeguro = (accion) => () => {
                   ? "requiere revisión menor"
                   : "requiere revisión técnica";
 
+          // OT-0087C — Sección exportable de diagnóstico temporal Q(t) no adoptivo.
+          const seccionDiagnosticoTemporalQt = construirSeccionDiagnosticoTemporalQt({
+            filasMorfologiaQt,
+            filasDictamenFormaQt,
+            filasRiesgoTemporalQt,
+            sintesisRiesgoTemporalQt
+          });
+
           const textoExpediente = [
             "# Expediente hidrológico mínimo — Cuenca activa",
             "Estado técnico del expediente: CONSISTENTE CON ADVERTENCIAS.",
@@ -2091,10 +2100,18 @@ const handleClickSeguro = (accion) => () => {
             "Método Racional: presente como contraste global independiente.",
             "Lectura técnica: control interno preliminar; no reemplaza revisión hidrológica profesional.",
             "",
+            seccionDiagnosticoTemporalQt?.texto ?? [
+              "## Diagnóstico temporal Q(t) no adoptivo",
+              "",
+              "No fue posible construir la sección de diagnóstico temporal Q(t).",
+              "",
+              "Restricción: diagnóstico no adoptivo; no selecciona método ni levanta No coherente."
+            ].join("\n"),
+            "",
             "## 10. Validación interna del expediente exportado",
             "Estado de validación estructural: control previo al portapapeles aplicado.",
             "Control de tokens inválidos: activo mediante validador interno del expediente copiado.",
-            "Secciones obligatorias controladas: Q-Tr activo, Q-5 auditado, Método Racional, contraste, restricciones y sello técnico.",
+            "Secciones obligatorias controladas: Q-Tr activo, Q-5 auditado, Método Racional, contraste, diagnóstico temporal Q(t), restricciones y sello técnico.",
             "Q-Tr activo: trazado desde q_tr_activo_estado y verificado como sección exportable.",
             "Q-5 auditado: presente como bloque de hidrogramas no adoptivo.",
             "Método Racional: presente como contraste global independiente.",
@@ -2146,6 +2163,7 @@ const handleClickSeguro = (accion) => () => {
                 "## 7. Método Racional — contraste global independiente",
                 "## 8. Contraste Q-5 vs Método Racional",
                 "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+                "## Diagnóstico temporal Q(t) no adoptivo",
                 "## 10. Validación interna del expediente exportado",
                 "## 11. Sello técnico de generación",
                 "## 12. Restricciones y advertencias técnicas"

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/construirSeccionDiagnosticoTemporalQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/construirSeccionDiagnosticoTemporalQt.js
@@ -1,0 +1,160 @@
+// OT-0087B — Helper puro para construir sección exportable de diagnóstico temporal Q(t).
+// No recibe qSeries cruda, no recalcula métricas, no reconstruye Q(t), no interpola y no adopta métodos.
+
+function textoSeguro(valor, fallback = "—") {
+  const texto = String(valor ?? "").trim();
+  return texto || fallback;
+}
+
+function numeroSeguro(valor, decimales = 2, unidad = "") {
+  const numero = Number(valor);
+
+  if (!Number.isFinite(numero)) return "—";
+
+  return `${numero.toLocaleString("es-CO", {
+    maximumFractionDigits: decimales
+  })}${unidad}`;
+}
+
+function listaLineas(items = []) {
+  return Array.isArray(items) && items.length > 0
+    ? items.map((item) => `- ${item}`).join("\n")
+    : "- Sin información disponible.";
+}
+
+function buscarPorMetodo(filas = [], metodo) {
+  return Array.isArray(filas)
+    ? filas.find((fila) => fila?.metodo === metodo) ?? null
+    : null;
+}
+
+export default function construirSeccionDiagnosticoTemporalQt({
+  filasMorfologiaQt = [],
+  filasDictamenFormaQt = [],
+  filasRiesgoTemporalQt = [],
+  sintesisRiesgoTemporalQt = null
+} = {}) {
+  const tieneMorfologia = Array.isArray(filasMorfologiaQt) && filasMorfologiaQt.length > 0;
+  const tieneForma = Array.isArray(filasDictamenFormaQt) && filasDictamenFormaQt.length > 0;
+  const tieneRiesgo = Array.isArray(filasRiesgoTemporalQt) && filasRiesgoTemporalQt.length > 0;
+  const tieneSintesis =
+    sintesisRiesgoTemporalQt &&
+    Array.isArray(sintesisRiesgoTemporalQt?.resumen) &&
+    sintesisRiesgoTemporalQt.resumen.length > 0;
+
+  if (!tieneMorfologia && !tieneForma && !tieneRiesgo && !tieneSintesis) {
+    return {
+      ok: false,
+      texto: [
+        "## Diagnóstico temporal Q(t) no adoptivo",
+        "",
+        "No hay información temporal suficiente para construir la sección exportable.",
+        "",
+        "Restricción: esta sección no reconstruye Q(t), no interpola, no adopta métodos y no levanta el estado global No coherente."
+      ].join("\n"),
+      advertencias: [
+        "Diagnóstico temporal no adoptivo.",
+        "No hay filas temporales suficientes.",
+        "No selecciona método.",
+        "No levanta No coherente."
+      ]
+    };
+  }
+
+  const resumenSintesis = tieneSintesis
+    ? sintesisRiesgoTemporalQt.resumen
+    : ["No hay síntesis ejecutiva temporal disponible."];
+
+  const niveles = sintesisRiesgoTemporalQt?.niveles ?? {
+    alto: 0,
+    medio: 0,
+    bajo: 0,
+    noDeterminado: 0
+  };
+
+  const metodos = Array.from(
+    new Set([
+      ...filasMorfologiaQt.map((fila) => fila?.metodo).filter(Boolean),
+      ...filasDictamenFormaQt.map((fila) => fila?.metodo).filter(Boolean),
+      ...filasRiesgoTemporalQt.map((fila) => fila?.metodo).filter(Boolean)
+    ])
+  );
+
+  const lecturaPorMetodo = metodos.map((metodo) => {
+    const morfologia = buscarPorMetodo(filasMorfologiaQt, metodo);
+    const forma = buscarPorMetodo(filasDictamenFormaQt, metodo);
+    const riesgo = buscarPorMetodo(filasRiesgoTemporalQt, metodo);
+
+    return [
+      `### ${textoSeguro(metodo, "Método Q(t)")}`,
+      "",
+      `- Estado métrico: ${textoSeguro(morfologia?.estado)}.`,
+      `- Qp desde qSeries: ${numeroSeguro(morfologia?.Qp, 2, " m³/s")}.`,
+      `- tPico desde qSeries: ${numeroSeguro(morfologia?.tPico, 2, " min")}.`,
+      `- Duración efectiva De: ${numeroSeguro(morfologia?.duracionEfectivaMin, 2, " min")}.`,
+      `- Ascenso: ${numeroSeguro(morfologia?.tiempoAscensoMin, 2, " min")}.`,
+      `- Receso: ${numeroSeguro(morfologia?.tiempoRecesoMin, 2, " min")}.`,
+      `- W50 observado: ${numeroSeguro(morfologia?.W50Min, 2, " min")}.`,
+      `- W25 observado: ${numeroSeguro(morfologia?.W25Min, 2, " min")}.`,
+      `- Asimetría receso/ascenso: ${numeroSeguro(morfologia?.asimetriaAscensoReceso, 3)}.`,
+      `- Forma temporal: ${textoSeguro(forma?.forma)}.`,
+      `- Alerta de forma: ${textoSeguro(forma?.alerta)}.`,
+      `- Severidad de forma: ${textoSeguro(forma?.severidad)}.`,
+      `- Riesgo temporal: ${textoSeguro(riesgo?.riesgo)}.`,
+      `- Nivel de riesgo: ${textoSeguro(riesgo?.nivel)}.`,
+      `- Factor dominante: ${textoSeguro(riesgo?.factorDominante)}.`,
+      "",
+      "Lectura: diagnóstico temporal no adoptivo; no constituye selección de método ni decisión hidráulica final."
+    ].join("\n");
+  });
+
+  const texto = [
+    "## Diagnóstico temporal Q(t) no adoptivo",
+    "",
+    "### Alcance",
+    "",
+    "Esta sección consolida métricas morfológicas, dictamen de forma, riesgo temporal y síntesis ejecutiva derivados de qSeries reales publicadas y validadas.",
+    "",
+    "La sección es diagnóstica y no adoptiva. No selecciona método, no modifica caudales, no reconstruye Q(t), no interpola y no levanta el estado global No coherente.",
+    "",
+    "### Síntesis ejecutiva temporal",
+    "",
+    `- Riesgo alto: ${Number(niveles?.alto ?? 0)}.`,
+    `- Riesgo medio: ${Number(niveles?.medio ?? 0)}.`,
+    `- Riesgo bajo: ${Number(niveles?.bajo ?? 0)}.`,
+    `- No determinado: ${Number(niveles?.noDeterminado ?? 0)}.`,
+    "",
+    listaLineas(resumenSintesis),
+    "",
+    "### Lectura temporal por método",
+    "",
+    lecturaPorMetodo.length > 0
+      ? lecturaPorMetodo.join("\n\n")
+      : "No hay lectura temporal por método disponible.",
+    "",
+    "### Restricciones de interpretación",
+    "",
+    "- Diagnóstico temporal no adoptivo.",
+    "- No selecciona automáticamente ningún método.",
+    "- No levanta el estado global No coherente.",
+    "- No reemplaza revisión hidrológica profesional.",
+    "- No modifica Qp, Tp, Volumen ni Q(t).",
+    "- No usa qSeries cruda en la construcción textual de esta sección.",
+    "- No reconstruye Q(t) ni interpola series.",
+    "",
+    "### Dictamen",
+    "",
+    "La información anterior permite consolidar una lectura temporal ejecutiva y trazable, pero no constituye adopción hidrológica ni decisión hidráulica final."
+  ].join("\n");
+
+  return {
+    ok: true,
+    texto,
+    advertencias: [
+      "Diagnóstico temporal no adoptivo.",
+      "No selecciona método.",
+      "No levanta No coherente.",
+      "No reemplaza revisión hidrológica profesional."
+    ]
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT integra el diagnóstico temporal Q(t) como sección exportable del expediente hidrológico mínimo, consolidando métricas morfológicas, dictamen de forma, riesgo temporal y síntesis ejecutiva temporal.

La sección mantiene carácter no adoptivo: no selecciona método, no modifica caudales y no levanta el estado global `No coherente`.

## Secuencia técnica

- OT-0087A: diseño documental de diagnóstico temporal Q(t) para expediente.
- OT-0087B: creación del helper puro `construirSeccionDiagnosticoTemporalQt`.
- OT-0087C: integración de la sección en `textoExpediente`.
- OT-0087D: validación documental del expediente exportable.
- OT-0087E: cierre técnico documental.

## Cambios principales

Se agregó el helper puro:

```js
construirSeccionDiagnosticoTemporalQt({
  filasMorfologiaQt,
  filasDictamenFormaQt,
  filasRiesgoTemporalQt,
  sintesisRiesgoTemporalQt
})