### PR TITLE
OT-0088 — Validación del expediente con diagnóstico temporal Q(t)

### DIFF
--- a/00_ADMIN/bitacora/OT-0088/OT-0088A_diseno_validacion_expediente_diagnostico_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0088/OT-0088A_diseno_validacion_expediente_diagnostico_temporal_qt.md
@@ -1,0 +1,46 @@
+\# OT-0088A — Diseño de validación del expediente con diagnóstico temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0088 se abre después del cierre de OT-0087, donde se integró el diagnóstico temporal Q(t) como sección exportable del expediente hidrológico mínimo.
+
+
+
+La cadena técnica previa dejó establecido que:
+
+
+
+\- OT-0078 identificó ausencia de qSeries publicada.
+
+\- OT-0079 auditó `uh` y descartó tratarlo como qSeries.
+
+\- OT-0080 preparó la publicación controlada de qSeries reales.
+
+\- OT-0081 activó y validó qSeries reales en el comparador.
+
+\- OT-0082 implementó validación, métricas morfológicas y diagnóstico agregado.
+
+\- OT-0083 expuso métricas morfológicas compactas y no adoptivas.
+
+\- OT-0084 clasificó la forma Q(t) por método.
+
+\- OT-0085 tradujo la forma Q(t) a riesgo temporal comparativo.
+
+\- OT-0086 sintetizó ejecutivamente los hallazgos temporales.
+
+\- OT-0087 consolidó el diagnóstico temporal Q(t) como sección exportable del expediente.
+
+
+
+Al cierre de OT-0087, el expediente hidrológico mínimo debe incluir la sección:
+
+
+
+```markdown
+
+\## Diagnóstico temporal Q(t) no adoptivo
+

--- a/00_ADMIN/bitacora/OT-0088/OT-0088D_validacion_expediente_copiado_diagnostico_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0088/OT-0088D_validacion_expediente_copiado_diagnostico_temporal_qt.md
@@ -1,0 +1,20 @@
+\# OT-0088D — Validación del expediente copiado con diagnóstico temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+Después de OT-0088C, se validó funcionalmente el flujo de copiado del expediente hidrológico mínimo con la validación textual estricta de la sección Diagnóstico temporal Q(t) no adoptivo.
+
+
+
+La validación se ejecuta antes de enviar el texto final al portapapeles mediante el helper puro:
+
+
+
+```js
+
+validarSeccionDiagnosticoTemporalQt(textoExpediente)
+

--- a/00_ADMIN/bitacora/OT-0088/OT-0088E_cierre_validacion_expediente_diagnostico_temporal_qt.md
+++ b/00_ADMIN/bitacora/OT-0088/OT-0088E_cierre_validacion_expediente_diagnostico_temporal_qt.md
@@ -1,0 +1,52 @@
+\# OT-0088E — Cierre técnico de validación del expediente con diagnóstico temporal Q(t)
+
+
+
+\## Contexto
+
+
+
+OT-0088 se desarrolló después del cierre de OT-0087, donde se integró el diagnóstico temporal Q(t) como sección exportable del expediente hidrológico mínimo.
+
+
+
+El propósito de OT-0088 fue fortalecer la validación del texto final copiado al portapapeles, comprobando que la sección temporal exportable aparece completa, sin tokens inválidos y con sus subsecciones y advertencias no adoptivas esperadas.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0088A — Diseño documental
+
+
+
+Se documentó el diseño de validación del expediente con diagnóstico temporal Q(t), definiendo:
+
+
+
+\- sección temporal obligatoria,
+
+\- subsecciones esperadas,
+
+\- advertencias no adoptivas,
+
+\- tokens inválidos,
+
+\- validación sobre el texto final del expediente.
+
+
+
+\### OT-0088B — Helper puro de validación
+
+
+
+Se creó el helper puro:
+
+
+
+```js
+
+validarSeccionDiagnosticoTemporalQt(textoExpediente)
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -12,6 +12,7 @@ import clasificarFormaQt from "../services/hidrogramas/clasificarFormaQt";
 import evaluarRiesgoTemporalQt from "../services/hidrogramas/evaluarRiesgoTemporalQt";
 import sintetizarRiesgoTemporalQt from "../services/hidrogramas/sintetizarRiesgoTemporalQt";
 import construirSeccionDiagnosticoTemporalQt from "../services/hidrogramas/construirSeccionDiagnosticoTemporalQt";
+import validarSeccionDiagnosticoTemporalQt from "../services/hidrogramas/validarSeccionDiagnosticoTemporalQt";
 
 import {
   resumenComparadorCatalogo,
@@ -2172,12 +2173,20 @@ const handleClickSeguro = (accion) => () => {
                 !textoExpediente.includes(seccion)
               );
 
-              if (tokensDetectadosExpediente.length > 0 || seccionesFaltantesExpediente.length > 0) {
+              // OT-0088C — Validación textual estricta de diagnóstico temporal Q(t).
+              const validacionDiagnosticoTemporalQt =
+                validarSeccionDiagnosticoTemporalQt(textoExpediente);
+
+              if (
+                tokensDetectadosExpediente.length > 0 ||
+                seccionesFaltantesExpediente.length > 0 ||
+                !validacionDiagnosticoTemporalQt.ok
+              ) {
                 window.alert(
                   [
                     "Validación del expediente copiado fallida.",
                     "",
-                    "No se copió el expediente porque contiene tokens inválidos o perdió secciones obligatorias.",
+                    "No se copió el expediente porque contiene tokens inválidos, perdió secciones obligatorias o falló la validación del diagnóstico temporal Q(t).",
                     "",
                     ...(tokensDetectadosExpediente.length > 0
                       ? [
@@ -2189,7 +2198,31 @@ const handleClickSeguro = (accion) => () => {
                     ...(seccionesFaltantesExpediente.length > 0
                       ? [
                           "Secciones obligatorias faltantes:",
-                          ...seccionesFaltantesExpediente.map((seccion) => `- ${seccion}`)
+                          ...seccionesFaltantesExpediente.map((seccion) => `- ${seccion}`),
+                          ""
+                        ]
+                      : []),
+                    ...(!validacionDiagnosticoTemporalQt.ok
+                      ? [
+                          "Diagnóstico temporal Q(t) inválido:",
+                          ...(validacionDiagnosticoTemporalQt.faltantes.length > 0
+                            ? [
+                                "Subsecciones temporales faltantes:",
+                                ...validacionDiagnosticoTemporalQt.faltantes.map((item) => `- ${item}`)
+                              ]
+                            : []),
+                          ...(validacionDiagnosticoTemporalQt.advertenciasFaltantes.length > 0
+                            ? [
+                                "Advertencias temporales faltantes:",
+                                ...validacionDiagnosticoTemporalQt.advertenciasFaltantes.map((item) => `- ${item}`)
+                              ]
+                            : []),
+                          ...(validacionDiagnosticoTemporalQt.tokensInvalidos.length > 0
+                            ? [
+                                "Tokens inválidos en diagnóstico temporal:",
+                                ...validacionDiagnosticoTemporalQt.tokensInvalidos.map((item) => `- ${item}`)
+                              ]
+                            : [])
                         ]
                       : [])
                   ].join("\n")
@@ -2198,6 +2231,7 @@ const handleClickSeguro = (accion) => () => {
                 return;
               }
 
+               
           const areaTexto = document.createElement("textarea");
           areaTexto.value = textoExpediente;
           areaTexto.setAttribute("readonly", "");

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/validarSeccionDiagnosticoTemporalQt.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/validarSeccionDiagnosticoTemporalQt.js
@@ -1,0 +1,79 @@
+// OT-0088B — Helper puro para validar sección de diagnóstico temporal Q(t) en expediente.
+// Recibe texto final del expediente. No recibe qSeries, no recalcula métricas,
+// no reconstruye Q(t), no interpola y no adopta métodos.
+
+const SECCIONES_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT = [
+  "## Diagnóstico temporal Q(t) no adoptivo",
+  "### Alcance",
+  "### Síntesis ejecutiva temporal",
+  "### Lectura temporal por método",
+  "### Restricciones de interpretación",
+  "### Dictamen"
+];
+
+const ADVERTENCIAS_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT = [
+  "Diagnóstico temporal no adoptivo",
+  "No selecciona automáticamente ningún método",
+  "No levanta el estado global No coherente",
+  "No reemplaza revisión hidrológica profesional",
+  "No modifica Qp, Tp, Volumen ni Q(t)",
+  "No reconstruye Q(t) ni interpola series"
+];
+
+const TOKENS_INVALIDOS_DIAGNOSTICO_TEMPORAL_QT = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+function normalizarTexto(texto) {
+  return String(texto ?? "");
+}
+
+function buscarFaltantes(texto, elementos) {
+  return elementos.filter((elemento) => !texto.includes(elemento));
+}
+
+export default function validarSeccionDiagnosticoTemporalQt(textoExpediente) {
+  const texto = normalizarTexto(textoExpediente);
+
+  if (!texto.trim()) {
+    return {
+      ok: false,
+      faltantes: [...SECCIONES_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT],
+      advertenciasFaltantes: [...ADVERTENCIAS_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT],
+      tokensInvalidos: [],
+      mensaje: "El expediente está vacío o no es texto válido."
+    };
+  }
+
+  const faltantes = buscarFaltantes(
+    texto,
+    SECCIONES_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT
+  );
+
+  const advertenciasFaltantes = buscarFaltantes(
+    texto,
+    ADVERTENCIAS_OBLIGATORIAS_DIAGNOSTICO_TEMPORAL_QT
+  );
+
+  const tokensInvalidos = TOKENS_INVALIDOS_DIAGNOSTICO_TEMPORAL_QT.filter((token) =>
+    texto.includes(token)
+  );
+
+  const ok =
+    faltantes.length === 0 &&
+    advertenciasFaltantes.length === 0 &&
+    tokensInvalidos.length === 0;
+
+  return {
+    ok,
+    faltantes,
+    advertenciasFaltantes,
+    tokensInvalidos,
+    mensaje: ok
+      ? "Sección de diagnóstico temporal Q(t) válida en expediente exportable."
+      : "La sección de diagnóstico temporal Q(t) presenta faltantes o tokens inválidos."
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT fortalece la validación del expediente hidrológico mínimo copiado al portapapeles, comprobando que la sección de diagnóstico temporal Q(t) no adoptivo aparece completa, sin tokens inválidos y con las advertencias técnicas requeridas.

## Secuencia técnica

- OT-0088A: diseño documental de validación del expediente con diagnóstico temporal Q(t).
- OT-0088B: creación del helper puro `validarSeccionDiagnosticoTemporalQt(textoExpediente)`.
- OT-0088C: integración de la validación textual previa al portapapeles.
- OT-0088D: validación funcional/documental del copiado del expediente.
- OT-0088E: cierre técnico documental.

## Cambios principales

Se agregó el helper puro:

```js
validarSeccionDiagnosticoTemporalQt(textoExpediente)