### PR TITLE
OT-0095 — Lectura comparativa textual desde matriz patrón

### DIFF
--- a/00_ADMIN/bitacora/OT-0095/OT-0095A_diseno_lectura_comparativa_textual_matriz_patron.md
+++ b/00_ADMIN/bitacora/OT-0095/OT-0095A_diseno_lectura_comparativa_textual_matriz_patron.md
@@ -1,0 +1,68 @@
+\# OT-0095A — Diseño de lectura comparativa textual automática desde matriz patrón
+
+
+
+\## Contexto
+
+
+
+OT-0095 se abre después del cierre de OT-0094, donde se integró una gráfica de velocidad efectiva y plausibilidad temporal desde la matriz patrón La Iguaná PC\_80.
+
+
+
+La plataforma ya cuenta con:
+
+
+
+\- matriz patrón estructurada,
+
+\- tarjeta visual,
+
+\- gráfica Qp–tPico,
+
+\- gráfica de velocidad efectiva,
+
+\- lectura de riesgo temporal,
+
+\- plausibilidad temporal por método.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una lectura comparativa textual automática, breve y no adoptiva, derivada exclusivamente de la matriz patrón La Iguaná PC\_80.
+
+
+
+La lectura debe resumir, en lenguaje técnico claro, los patrones dominantes observados en la matriz.
+
+
+
+\## Tesis técnica
+
+
+
+Las gráficas permiten ver relaciones visuales, pero una síntesis textual compacta ayuda a convertir la matriz patrón en criterio técnico legible.
+
+
+
+La lectura textual debe interpretar patrones ya existentes, no calcular resultados nuevos.
+
+
+
+\## Fuente permitida
+
+
+
+La lectura solo puede usar:
+
+
+
+```js
+
+matrizPatronLaIguanaPC80.diagnosticoQt
+
+matrizPatronLaIguanaPC80.sintesisTemporal
+

--- a/00_ADMIN/bitacora/OT-0095/OT-0095D_validacion_lectura_comparativa_textual_matriz_patron.md
+++ b/00_ADMIN/bitacora/OT-0095/OT-0095D_validacion_lectura_comparativa_textual_matriz_patron.md
@@ -1,0 +1,20 @@
+\# OT-0095D — Validación de lectura comparativa textual desde matriz patrón
+
+
+
+\## Contexto
+
+
+
+Después de OT-0095C, se integró una lectura comparativa textual automática dentro de la tarjeta de matriz patrón La Iguaná PC\_80.
+
+
+
+La lectura usa datos sintetizados por:
+
+
+
+```js
+
+src/services/hidrogramas/sintetizarLecturaComparativaMatrizPatron.js
+

--- a/00_ADMIN/bitacora/OT-0095/OT-0095E_cierre_lectura_comparativa_textual_matriz_patron.md
+++ b/00_ADMIN/bitacora/OT-0095/OT-0095E_cierre_lectura_comparativa_textual_matriz_patron.md
@@ -1,0 +1,44 @@
+\# OT-0095E — Cierre técnico de lectura comparativa textual desde matriz patrón
+
+
+
+\## Contexto
+
+
+
+OT-0095 se abrió después del cierre de OT-0094, donde se integró una gráfica de velocidad efectiva y plausibilidad temporal desde la matriz patrón La Iguaná PC\_80.
+
+
+
+El propósito de OT-0095 fue convertir las gráficas y la matriz patrón en una lectura textual comparativa breve, automática y no adoptiva.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0095A — Diseño documental
+
+
+
+Se documentó el diseño de una lectura comparativa textual automática derivada exclusivamente de la matriz patrón La Iguaná PC\_80.
+
+
+
+La lectura se definió como compacta, no adoptiva y sin recálculo hidrológico.
+
+
+
+\### OT-0095B — Helper puro
+
+
+
+Se creó el helper:
+
+
+
+```js
+
+src/services/hidrogramas/sintetizarLecturaComparativaMatrizPatron.js
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -15,6 +15,7 @@ import construirSeccionDiagnosticoTemporalQt from "../services/hidrogramas/const
 import validarSeccionDiagnosticoTemporalQt from "../services/hidrogramas/validarSeccionDiagnosticoTemporalQt";
 import prepararGraficaQpTPicoMatrizPatron from "../services/hidrogramas/prepararGraficaQpTPicoMatrizPatron";
 import prepararGraficaVelocidadEfectivaMatrizPatron from "../services/hidrogramas/prepararGraficaVelocidadEfectivaMatrizPatron";
+import sintetizarLecturaComparativaMatrizPatron from "../services/hidrogramas/sintetizarLecturaComparativaMatrizPatron";
 
 import {
   resumenComparadorCatalogo,
@@ -388,6 +389,7 @@ const sintesisMatrizPatron = matrizPatronVisual?.sintesisTemporal ?? {};
 const salidaHidraulicaMatrizPatron = matrizPatronVisual?.salidaHidraulicaFutura ?? {};
 const graficaQpTPicoMatrizPatron = prepararGraficaQpTPicoMatrizPatron(matrizPatronVisual);
 const graficaVelocidadEfectivaMatrizPatron = prepararGraficaVelocidadEfectivaMatrizPatron(matrizPatronVisual);
+const lecturaComparativaMatrizPatron = sintetizarLecturaComparativaMatrizPatron(matrizPatronVisual);
   
   const estilos = {
     pagina: {
@@ -3327,6 +3329,36 @@ const handleClickSeguro = (accion) => () => {
                           </div>
                         );
                       })()}
+                      {lecturaComparativaMatrizPatron?.ok && Array.isArray(lecturaComparativaMatrizPatron.frases) && (
+                        <div
+                          style={{
+                            marginTop: 12,
+                            padding: 10,
+                            borderRadius: 8,
+                            border: "1px solid rgba(251, 191, 36, 0.35)",
+                            background: "rgba(2, 6, 23, 0.28)"
+                          }}
+                        >
+                          <strong>Lectura comparativa automática:</strong>{" "}
+                          síntesis textual no adoptiva desde matriz patrón.
+
+                          <ul style={{ margin: "8px 0 0 18px", padding: 0 }}>
+                            {lecturaComparativaMatrizPatron.frases.map((frase, indice) => (
+                              <li
+                                key={`lectura-comparativa-matriz-${indice}`}
+                                style={{ marginBottom: 4 }}
+                              >
+                                {frase}
+                              </li>
+                            ))}
+                          </ul>
+
+                          <div style={{ ...estilos.muted, marginTop: 8 }}>
+                            {lecturaComparativaMatrizPatron.advertencia ??
+                              "Lectura comparativa no adoptiva; no selecciona ni descarta métodos."}
+                          </div>
+                        </div>
+                      )}
                       <div style={{ ...estilos.muted, marginTop: 8 }}>
                         Riesgo alto: {(sintesisMatrizPatron.riesgoAlto ?? []).join(", ") || "—"}.{" "}
                         Riesgo medio: {(sintesisMatrizPatron.riesgoMedio ?? []).join(", ") || "—"}.
@@ -3397,6 +3429,7 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/sintetizarLecturaComparativaMatrizPatron.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/sintetizarLecturaComparativaMatrizPatron.js
@@ -1,0 +1,101 @@
+// OT-0095B — Helper puro para sintetizar lectura comparativa textual desde matriz patrón.
+// No recalcula hidrogramas, no modifica Q(t), no adopta ni descarta métodos y no toca motor.
+
+function textoSeguro(valor, fallback = "—") {
+  const texto = String(valor ?? "").trim();
+  return texto || fallback;
+}
+
+function esAlertaFuerte(fila = {}) {
+  const plausibilidad = String(fila?.plausibilidadTemporal ?? "").toLowerCase();
+  const riesgo = String(fila?.riesgoTemporal ?? "").toLowerCase();
+  const forma = String(fila?.formaTemporal ?? "").toLowerCase();
+
+  return (
+    plausibilidad.includes("alerta") ||
+    riesgo.includes("concentración abrupta") ||
+    forma.includes("abrupta")
+  );
+}
+
+function esPlausiblePreliminar(fila = {}) {
+  return String(fila?.plausibilidadTemporal ?? "")
+    .toLowerCase()
+    .includes("plausible");
+}
+
+function esProlongadaOAtenuada(fila = {}) {
+  const plausibilidad = String(fila?.plausibilidadTemporal ?? "").toLowerCase();
+  const forma = String(fila?.formaTemporal ?? "").toLowerCase();
+  const riesgo = String(fila?.riesgoTemporal ?? "").toLowerCase();
+
+  return (
+    plausibilidad.includes("prolongada") ||
+    plausibilidad.includes("atenuada") ||
+    plausibilidad.includes("recesiva") ||
+    forma.includes("prolongada") ||
+    riesgo.includes("recesión prolongada")
+  );
+}
+
+function listarMetodos(filas = []) {
+  return filas.map((fila) => textoSeguro(fila?.metodo)).join(", ");
+}
+
+export default function sintetizarLecturaComparativaMatrizPatron(matriz = {}) {
+  const diagnosticoQt = Array.isArray(matriz?.diagnosticoQt)
+    ? matriz.diagnosticoQt
+    : [];
+
+  if (diagnosticoQt.length === 0) {
+    return {
+      ok: false,
+      frases: [
+        "No hay diagnóstico Q(t) suficiente para generar lectura comparativa de matriz patrón."
+      ],
+      advertencia:
+        "Lectura comparativa no adoptiva; no selecciona ni descarta métodos."
+    };
+  }
+
+  const alertasFuertes = diagnosticoQt.filter(esAlertaFuerte);
+  const plausibles = diagnosticoQt.filter(esPlausiblePreliminar);
+  const prolongadas = diagnosticoQt.filter(esProlongadaOAtenuada);
+
+  const frases = [];
+
+  if (alertasFuertes.length > 0) {
+    frases.push(
+      `${listarMetodos(alertasFuertes)} presenta(n) la mayor alerta temporal por concentración abrupta o asimetría extrema.`
+    );
+  }
+
+  if (plausibles.length > 0) {
+    frases.push(
+      `${listarMetodos(plausibles)} se mantiene(n) como respuesta temporalmente plausible preliminar.`
+    );
+  }
+
+  if (prolongadas.length > 0) {
+    frases.push(
+      `${listarMetodos(prolongadas)} muestra(n) comportamiento prolongado, atenuado o con recesión dominante.`
+    );
+  }
+
+  frases.push(
+    "Esta lectura compara patrones temporales de la matriz patrón; no adopta ni descarta métodos automáticamente."
+  );
+
+  return {
+    ok: true,
+    frases,
+    resumen: {
+      totalMetodos: diagnosticoQt.length,
+      alertasFuertes: alertasFuertes.map((fila) => textoSeguro(fila?.metodo)),
+      plausibles: plausibles.map((fila) => textoSeguro(fila?.metodo)),
+      prolongadas: prolongadas.map((fila) => textoSeguro(fila?.metodo))
+    },
+    advertencia:
+      "Lectura comparativa no adoptiva; no recalcula hidrogramas, no modifica Q(t), no selecciona método y no levanta No coherente."
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT agrega una lectura comparativa textual automática desde la matriz patrón La Iguaná PC_80.

La lectura sintetiza, en frases breves, los patrones observados en la matriz y en las gráficas asociadas, sin recalcular hidrogramas, sin adoptar métodos y sin descartar métodos automáticamente.

## Secuencia técnica

- OT-0095A: diseño documental de lectura comparativa textual.
- OT-0095B: creación del helper puro `sintetizarLecturaComparativaMatrizPatron.js`.
- OT-0095C: integración visual de la lectura comparativa en `ComparadorMultiMetodo.jsx`.
- OT-0095D: validación documental/técnica.
- OT-0095E: cierre técnico documental.

## Cambios principales

Se agregó el helper:

```js
src/services/hidrogramas/sintetizarLecturaComparativaMatrizPatron.js