### PR TITLE
OT-0099 — Contrato para segunda cuenca patrón

### DIFF
--- a/00_ADMIN/bitacora/OT-0099/OT-0099A_diseno_contrato_segunda_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0099/OT-0099A_diseno_contrato_segunda_cuenca_patron.md
@@ -1,0 +1,406 @@
+\# OT-0099A — Diseño de contrato mínimo para segunda cuenca patrón
+
+
+
+\## Contexto
+
+
+
+OT-0099 se abre después del cierre de OT-0098, donde se dejó registrado el estado consolidado de la tarjeta matriz patrón La Iguaná PC\_80.
+
+
+
+Entre OT-0091 y OT-0098 HidroFlow consolidó un bloque completo:
+
+
+
+\- matriz patrón como dato estructurado,
+
+\- tarjeta visual,
+
+\- gráfica Qp–tPico,
+
+\- gráfica de velocidad efectiva,
+
+\- lectura comparativa textual,
+
+\- validación de consistencia,
+
+\- control de densidad visual,
+
+\- registro consolidado del bloque.
+
+
+
+El siguiente crecimiento lógico no debe ser seguir agregando información a la tarjeta de La Iguaná PC\_80, sino preparar el contrato mínimo para una futura segunda cuenca patrón.
+
+
+
+\## Objetivo
+
+
+
+Definir el contrato mínimo que debe cumplir una segunda cuenca patrón para poder compararse contra La Iguaná PC\_80.
+
+
+
+Esta OT no implementa una segunda cuenca.
+
+
+
+Esta OT no inventa datos.
+
+
+
+Esta OT no simula resultados.
+
+
+
+\## Tesis técnica
+
+
+
+La comparación multi-cuenca solo es defendible si ambas cuencas tienen una estructura mínima equivalente.
+
+
+
+La segunda cuenca patrón debe entregar campos comparables de:
+
+
+
+\- identificación,
+
+\- morfometría,
+
+\- tiempos de concentración,
+
+\- lluvia efectiva,
+
+\- escenario de referencia,
+
+\- diagnóstico Q(t),
+
+\- forma temporal,
+
+\- riesgo temporal,
+
+\- plausibilidad,
+
+\- restricciones,
+
+\- salida hidráulica futura.
+
+
+
+\## Contrato mínimo propuesto
+
+
+
+Una futura segunda cuenca patrón debe contener, como mínimo:
+
+
+
+\### 1. Identificación
+
+
+
+\- id,
+
+\- nombre de cuenca,
+
+\- punto de control,
+
+\- estado,
+
+\- uso diagnóstico.
+
+
+
+\### 2. Morfometría
+
+
+
+\- área en km²,
+
+\- longitud hidráulica en km,
+
+\- perímetro,
+
+\- cotas máxima y mínima,
+
+\- desnivel,
+
+\- pendiente del cauce,
+
+\- pendiente media de cuenca,
+
+\- fuente de datos.
+
+
+
+\### 3. Tiempo de concentración
+
+
+
+\- Tc sugerido,
+
+\- número de métodos válidos,
+
+\- rango bruto,
+
+\- rango competente,
+
+\- estado adoptivo o no adoptivo.
+
+
+
+\### 4. Lluvia y escorrentía
+
+
+
+\- lluvia efectiva total,
+
+\- volumen esperado,
+
+\- relación de masa Pe–Área–Volumen,
+
+\- estado de consistencia.
+
+
+
+\### 5. Escenario de referencia
+
+
+
+\- nombre del escenario,
+
+\- periodo de retorno,
+
+\- volumen asociado,
+
+\- estado diagnóstico.
+
+
+
+\### 6. Diagnóstico Q(t)
+
+
+
+Por cada método:
+
+
+
+\- método,
+
+\- estado de serie,
+
+\- Qp,
+
+\- tPico,
+
+\- duración efectiva,
+
+\- ascenso,
+
+\- receso,
+
+\- W50,
+
+\- W25,
+
+\- asimetría,
+
+\- forma temporal,
+
+\- alerta de forma,
+
+\- severidad,
+
+\- riesgo temporal,
+
+\- nivel de riesgo,
+
+\- factor dominante,
+
+\- velocidad efectiva al tPico,
+
+\- velocidad efectiva de ascenso,
+
+\- plausibilidad temporal.
+
+
+
+\### 7. Síntesis temporal
+
+
+
+\- métodos con riesgo alto,
+
+\- métodos con riesgo medio,
+
+\- métodos con riesgo bajo,
+
+\- métodos no determinados,
+
+\- lectura textual.
+
+
+
+\### 8. Salida hidráulica futura
+
+
+
+\- requiere hidrograma completo,
+
+\- no usar solo Qp,
+
+\- incluir volumen,
+
+\- incluir tPico,
+
+\- incluir duración efectiva,
+
+\- incluir riesgo temporal,
+
+\- estado no adoptivo.
+
+
+
+\### 9. Restricciones
+
+
+
+Debe declarar explícitamente:
+
+
+
+\- no adopta automáticamente ningún método,
+
+\- no descarta automáticamente ningún método,
+
+\- no levanta No coherente,
+
+\- no reemplaza revisión hidrológica profesional,
+
+\- no recalcula Q(t),
+
+\- no interpola series,
+
+\- no modifica Qp, tPico, volumen ni métricas existentes,
+
+\- debe validarse antes de comparación institucional.
+
+
+
+\## Reglas de no invención
+
+
+
+Si una futura cuenca no tiene datos completos, HidroFlow debe marcar el campo como ausente o no determinado.
+
+
+
+No se deben fabricar:
+
+
+
+\- Qp,
+
+\- tPico,
+
+\- volumen,
+
+\- métricas morfológicas Q(t),
+
+\- velocidades efectivas,
+
+\- plausibilidad temporal,
+
+\- riesgo temporal,
+
+\- lectura comparativa.
+
+
+
+\## Comparación permitida
+
+
+
+La comparación contra La Iguaná PC\_80 solo debe activarse si la segunda cuenca tiene:
+
+
+
+\- identificación completa,
+
+\- morfometría mínima,
+
+\- al menos un escenario hidrológico,
+
+\- diagnóstico Q(t) con series válidas,
+
+\- métricas temporales suficientes,
+
+\- restricciones no adoptivas explícitas.
+
+
+
+\## Comparación no permitida
+
+
+
+No debe compararse una segunda cuenca si solo tiene:
+
+
+
+\- coordenadas,
+
+\- área,
+
+\- Qp aislado,
+
+\- un único valor de Tc,
+
+\- resultados sin qSeries,
+
+\- resultados sin volumen,
+
+\- resultados sin trazabilidad.
+
+
+
+\## Fuera de alcance
+
+
+
+Durante OT-0099 no se debe:
+
+
+
+\- implementar una segunda cuenca,
+
+\- inventar datos,
+
+\- modificar la matriz de La Iguaná PC\_80,
+
+\- modificar el motor hidrológico,
+
+\- modificar el expediente,
+
+\- recalcular hidrogramas,
+
+\- adoptar métodos,
+
+\- descartar métodos automáticamente,
+
+\- levantar No coherente,
+
+\- implementar hidráulica.
+
+
+
+\## Dictamen inicial
+
+
+
+OT-0099 debe preparar el contrato mínimo para comparación futura multi-cuenca, manteniendo a La Iguaná PC\_80 como primera cuenca patrón y evitando cualquier simulación o invención de datos.
+

--- a/00_ADMIN/bitacora/OT-0099/OT-0099C_validacion_no_invencion_plantilla_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0099/OT-0099C_validacion_no_invencion_plantilla_cuenca_patron.md
@@ -1,0 +1,20 @@
+\# OT-0099C — Validación de no invención en plantilla de cuenca patrón
+
+
+
+\## Contexto
+
+
+
+Después de OT-0099B, se creó una plantilla estructural para futuras matrices de cuenca patrón.
+
+
+
+La plantilla vive en:
+
+
+
+```js
+
+src/data/plantillaMatrizCuencaPatron.js
+

--- a/00_ADMIN/bitacora/OT-0099/OT-0099D_cierre_contrato_segunda_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0099/OT-0099D_cierre_contrato_segunda_cuenca_patron.md
@@ -1,0 +1,64 @@
+\# OT-0099D — Cierre técnico de contrato para segunda cuenca patrón
+
+
+
+\## Contexto
+
+
+
+OT-0099 se abrió después del cierre de OT-0098, donde se dejó registrado el estado consolidado de la tarjeta matriz patrón La Iguaná PC\_80.
+
+
+
+El propósito de OT-0099 fue preparar el contrato mínimo para una futura segunda cuenca patrón comparable contra La Iguaná PC\_80, sin implementarla ni inventar datos.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0099A — Diseño documental del contrato
+
+
+
+Se documentó el contrato mínimo que debe cumplir una futura segunda cuenca patrón para poder compararse contra La Iguaná PC\_80.
+
+
+
+El contrato exige campos mínimos de:
+
+
+
+\- identificación,
+
+\- morfometría,
+
+\- tiempos de concentración,
+
+\- lluvia y escorrentía,
+
+\- escenario de referencia,
+
+\- diagnóstico Q(t),
+
+\- síntesis temporal,
+
+\- salida hidráulica futura,
+
+\- restricciones no adoptivas.
+
+
+
+\### OT-0099B — Plantilla estructural no operativa
+
+
+
+Se creó la plantilla:
+
+
+
+```js
+
+src/data/plantillaMatrizCuencaPatron.js
+

--- a/01_APP/HIDROFLOW/src/data/plantillaMatrizCuencaPatron.js
+++ b/01_APP/HIDROFLOW/src/data/plantillaMatrizCuencaPatron.js
@@ -1,0 +1,107 @@
+// OT-0099B — Plantilla controlada de matriz de cuenca patrón.
+// Esta plantilla NO representa una cuenca real.
+// No contiene datos inventados.
+// No debe importarse en UI ni usarse para comparación directa.
+// Sirve únicamente como contrato estructural para futuras cuencas patrón.
+
+export const plantillaMatrizCuencaPatron = Object.freeze({
+  id: null,
+
+  cuenca: {
+    nombre: null,
+    puntoControl: null,
+    estado: "plantilla_no_operativa",
+    uso: "contrato_estructural_no_comparable"
+  },
+
+  morfometria: {
+    areaKm2: null,
+    perimetroKm: null,
+    longitudHidraulicaKm: null,
+    cotaMaxMsnm: null,
+    cotaMinMsnm: null,
+    desnivelM: null,
+    pendienteCaucePct: null,
+    pendienteMediaCuencaPct: null,
+    fuente: null
+  },
+
+  tiemposConcentracion: {
+    tcSugeridoMin: null,
+    metodosValidos: null,
+    rangoBrutoMin: null,
+    rangoBrutoMax: null,
+    rangoCompetenteMin: null,
+    rangoCompetenteMax: null,
+    estado: "no_determinado"
+  },
+
+  lluviaEscorrentia: {
+    lluviaEfectivaTotalMm: null,
+    volumenEsperadoM3: null,
+    relacionMasaPeAreaVolumen: null,
+    estado: "no_determinado"
+  },
+
+  escenarioReferencia: {
+    nombre: null,
+    periodoRetornoAnios: null,
+    volumenQ5M3: null,
+    estado: "no_determinado"
+  },
+
+  diagnosticoQt: [
+    {
+      metodo: null,
+      estadoSerie: "no_determinado",
+      QpM3s: null,
+      tPicoMin: null,
+      duracionEfectivaMin: null,
+      ascensoMin: null,
+      recesoMin: null,
+      W50Min: null,
+      W25Min: null,
+      asimetriaRecesoAscenso: null,
+      formaTemporal: null,
+      alertaForma: null,
+      severidadForma: null,
+      riesgoTemporal: null,
+      nivelRiesgo: null,
+      factorDominante: null,
+      velocidadEfectivaTPicoKmh: null,
+      velocidadEfectivaAscensoKmh: null,
+      plausibilidadTemporal: null
+    }
+  ],
+
+  sintesisTemporal: {
+    riesgoAlto: [],
+    riesgoMedio: [],
+    riesgoBajo: [],
+    noDeterminado: [],
+    lectura: []
+  },
+
+  salidaHidraulicaFutura: {
+    requiereHidrogramaCompleto: true,
+    noUsarSoloQp: true,
+    incluirVolumen: true,
+    incluirTPico: true,
+    incluirDuracionEfectiva: true,
+    incluirRiesgoTemporal: true,
+    estado: "plantilla_no_adoptiva"
+  },
+
+  restricciones: [
+    "Esta plantilla no representa una cuenca real.",
+    "No contiene datos hidrológicos inventados.",
+    "No debe usarse para comparación directa.",
+    "No adopta automáticamente ningún método.",
+    "No descarta automáticamente ningún método.",
+    "No levanta el estado global No coherente.",
+    "No reemplaza revisión hidrológica profesional.",
+    "Debe completarse únicamente con datos reales, trazables y validados."
+  ]
+});
+
+export default plantillaMatrizCuencaPatron;


### PR DESCRIPTION
## Resumen

Esta OT prepara el contrato mínimo para una futura segunda cuenca patrón comparable contra La Iguaná PC_80.

No implementa una segunda cuenca real, no inventa datos y no activa comparación multi-cuenca.

## Secuencia técnica

- OT-0099A: diseño documental del contrato mínimo para segunda cuenca patrón.
- OT-0099B: creación de plantilla estructural no operativa `plantillaMatrizCuencaPatron.js`.
- OT-0099C: validación documental de no invención.
- OT-0099D: cierre técnico documental.

## Cambios principales

Se agrega la plantilla:

```js
src/data/plantillaMatrizCuencaPatron.js