### PR TITLE
OT-0100 — Validador de completitud de matriz de cuenca patrón

### DIFF
--- a/00_ADMIN/bitacora/OT-0100/OT-0100A_diseno_validador_completitud_matriz_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0100/OT-0100A_diseno_validador_completitud_matriz_cuenca_patron.md
@@ -1,0 +1,20 @@
+\# OT-0100A — Diseño de validador de completitud de matriz de cuenca patrón
+
+
+
+\## Contexto
+
+
+
+OT-0100 se abre después del cierre de OT-0099, donde se preparó el contrato mínimo para una futura segunda cuenca patrón y se creó una plantilla estructural no operativa.
+
+
+
+La plantilla vive en:
+
+
+
+```js
+
+src/data/plantillaMatrizCuencaPatron.js
+

--- a/00_ADMIN/bitacora/OT-0100/OT-0100C_validacion_helper_completitud_matriz_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0100/OT-0100C_validacion_helper_completitud_matriz_cuenca_patron.md
@@ -1,0 +1,16 @@
+\# OT-0100C — Validación del helper de completitud de matriz de cuenca patrón
+
+
+
+\## Contexto
+
+
+
+Después de OT-0100B, se creó el helper:
+
+
+
+```js
+
+src/services/hidrogramas/validarCompletitudMatrizCuencaPatron.js
+

--- a/00_ADMIN/bitacora/OT-0100/OT-0100D_cierre_validador_completitud_matriz_cuenca_patron.md
+++ b/00_ADMIN/bitacora/OT-0100/OT-0100D_cierre_validador_completitud_matriz_cuenca_patron.md
@@ -1,0 +1,44 @@
+\# OT-0100D — Cierre técnico de validador de completitud de matriz de cuenca patrón
+
+
+
+\## Contexto
+
+
+
+OT-0100 se abrió después del cierre de OT-0099, donde se preparó el contrato mínimo para una futura segunda cuenca patrón y se creó una plantilla estructural no operativa.
+
+
+
+El propósito de OT-0100 fue crear un helper puro que valide si una matriz candidata cumple el contrato mínimo antes de permitir comparación futura.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0100A — Diseño documental
+
+
+
+Se documentó el diseño del validador de completitud de matriz de cuenca patrón.
+
+
+
+La validación se definió como una revisión de campos mínimos, trazabilidad y restricciones no adoptivas, sin comparar cuencas ni completar datos faltantes.
+
+
+
+\### OT-0100B — Helper puro
+
+
+
+Se creó el helper:
+
+
+
+```js
+
+src/services/hidrogramas/validarCompletitudMatrizCuencaPatron.js
+

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/validarCompletitudMatrizCuencaPatron.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/validarCompletitudMatrizCuencaPatron.js
@@ -1,0 +1,126 @@
+// OT-0100B — Helper puro para validar completitud de matriz de cuenca patrón.
+// No compara cuencas, no inventa datos, no recalcula hidrogramas y no toca motor.
+
+function textoValido(valor) {
+  return typeof valor === "string" && valor.trim().length > 0;
+}
+
+function numeroFinito(valor) {
+  const numero = Number(valor);
+  return Number.isFinite(numero) ? numero : null;
+}
+
+function arregloConContenido(valor) {
+  return Array.isArray(valor) && valor.length > 0;
+}
+
+function incluirRestriccion(textoRestricciones, fragmento) {
+  return textoRestricciones.toLowerCase().includes(fragmento.toLowerCase());
+}
+
+function validarCampoTexto(objeto, ruta, etiqueta, errores) {
+  const valor = ruta.reduce((actual, clave) => actual?.[clave], objeto);
+  if (!textoValido(valor)) errores.push(`Falta ${etiqueta}.`);
+}
+
+function validarCampoNumero(objeto, ruta, etiqueta, errores) {
+  const valor = ruta.reduce((actual, clave) => actual?.[clave], objeto);
+  if (numeroFinito(valor) === null) errores.push(`Falta valor numérico válido para ${etiqueta}.`);
+}
+
+export default function validarCompletitudMatrizCuencaPatron(matriz = {}) {
+  const errores = [];
+  const advertencias = [];
+
+  validarCampoTexto(matriz, ["id"], "id de matriz", errores);
+  validarCampoTexto(matriz, ["cuenca", "nombre"], "nombre de cuenca", errores);
+  validarCampoTexto(matriz, ["cuenca", "puntoControl"], "punto de control", errores);
+  validarCampoTexto(matriz, ["cuenca", "estado"], "estado de cuenca", errores);
+  validarCampoTexto(matriz, ["cuenca", "uso"], "uso diagnóstico", errores);
+
+  validarCampoNumero(matriz, ["morfometria", "areaKm2"], "área de cuenca", errores);
+  validarCampoNumero(matriz, ["morfometria", "longitudHidraulicaKm"], "longitud hidráulica", errores);
+  validarCampoNumero(matriz, ["morfometria", "cotaMaxMsnm"], "cota máxima", errores);
+  validarCampoNumero(matriz, ["morfometria", "cotaMinMsnm"], "cota mínima", errores);
+  validarCampoNumero(matriz, ["morfometria", "desnivelM"], "desnivel", errores);
+  validarCampoNumero(matriz, ["morfometria", "pendienteCaucePct"], "pendiente del cauce", errores);
+  validarCampoNumero(matriz, ["morfometria", "pendienteMediaCuencaPct"], "pendiente media de cuenca", errores);
+  validarCampoTexto(matriz, ["morfometria", "fuente"], "fuente morfométrica", errores);
+
+  validarCampoNumero(matriz, ["tiemposConcentracion", "tcSugeridoMin"], "Tc sugerido", errores);
+  validarCampoNumero(matriz, ["tiemposConcentracion", "metodosValidos"], "métodos válidos Tc", errores);
+  validarCampoNumero(matriz, ["tiemposConcentracion", "rangoBrutoMin"], "rango bruto mínimo Tc", errores);
+  validarCampoNumero(matriz, ["tiemposConcentracion", "rangoBrutoMax"], "rango bruto máximo Tc", errores);
+  validarCampoNumero(matriz, ["tiemposConcentracion", "rangoCompetenteMin"], "rango competente mínimo Tc", errores);
+  validarCampoNumero(matriz, ["tiemposConcentracion", "rangoCompetenteMax"], "rango competente máximo Tc", errores);
+  validarCampoTexto(matriz, ["tiemposConcentracion", "estado"], "estado Tc", errores);
+
+  validarCampoNumero(matriz, ["lluviaEscorrentia", "lluviaEfectivaTotalMm"], "lluvia efectiva total", errores);
+  validarCampoNumero(matriz, ["lluviaEscorrentia", "volumenEsperadoM3"], "volumen esperado", errores);
+  validarCampoNumero(matriz, ["lluviaEscorrentia", "relacionMasaPeAreaVolumen"], "relación masa Pe–Área–Volumen", errores);
+  validarCampoTexto(matriz, ["lluviaEscorrentia", "estado"], "estado lluvia-escorrentía", errores);
+
+  validarCampoTexto(matriz, ["escenarioReferencia", "nombre"], "nombre de escenario de referencia", errores);
+  validarCampoNumero(matriz, ["escenarioReferencia", "periodoRetornoAnios"], "periodo de retorno", errores);
+  validarCampoTexto(matriz, ["escenarioReferencia", "estado"], "estado de escenario de referencia", errores);
+
+  const diagnosticoQt = Array.isArray(matriz?.diagnosticoQt) ? matriz.diagnosticoQt : [];
+
+  if (!arregloConContenido(diagnosticoQt)) {
+    errores.push("Falta diagnóstico Q(t) con al menos una fila.");
+  }
+
+  diagnosticoQt.forEach((fila, indice) => {
+    const prefijo = `diagnosticoQt[${indice}]`;
+
+    if (!textoValido(fila?.metodo)) errores.push(`${prefijo}: falta método.`);
+    if (!textoValido(fila?.estadoSerie)) errores.push(`${prefijo}: falta estado de serie.`);
+    if (numeroFinito(fila?.QpM3s) === null) errores.push(`${prefijo}: falta QpM3s.`);
+    if (numeroFinito(fila?.tPicoMin) === null) errores.push(`${prefijo}: falta tPicoMin.`);
+    if (numeroFinito(fila?.duracionEfectivaMin) === null) errores.push(`${prefijo}: falta duración efectiva.`);
+    if (numeroFinito(fila?.ascensoMin) === null) errores.push(`${prefijo}: falta ascenso.`);
+    if (numeroFinito(fila?.recesoMin) === null) errores.push(`${prefijo}: falta receso.`);
+    if (!textoValido(fila?.formaTemporal)) errores.push(`${prefijo}: falta forma temporal.`);
+    if (!textoValido(fila?.riesgoTemporal)) errores.push(`${prefijo}: falta riesgo temporal.`);
+    if (!textoValido(fila?.nivelRiesgo)) errores.push(`${prefijo}: falta nivel de riesgo.`);
+    if (numeroFinito(fila?.velocidadEfectivaTPicoKmh) === null) errores.push(`${prefijo}: falta velocidad efectiva tPico.`);
+    if (numeroFinito(fila?.velocidadEfectivaAscensoKmh) === null) errores.push(`${prefijo}: falta velocidad efectiva ascenso.`);
+    if (!textoValido(fila?.plausibilidadTemporal)) errores.push(`${prefijo}: falta plausibilidad temporal.`);
+  });
+
+  if (!Array.isArray(matriz?.restricciones) || matriz.restricciones.length === 0) {
+    errores.push("Faltan restricciones no adoptivas.");
+  }
+
+  const textoRestricciones = Array.isArray(matriz?.restricciones)
+    ? matriz.restricciones.join(" ")
+    : "";
+
+  [
+    "No adopta",
+    "No descarta",
+    "No levanta",
+    "No reemplaza"
+  ].forEach((fragmento) => {
+    if (!incluirRestriccion(textoRestricciones, fragmento)) {
+      advertencias.push(`Restricción no adoptiva posiblemente faltante: ${fragmento}`);
+    }
+  });
+
+  const comparable = errores.length === 0;
+
+  return {
+    ok: comparable,
+    comparable,
+    errores,
+    advertencias,
+    resumen: {
+      id: matriz?.id ?? null,
+      cuenca: matriz?.cuenca?.nombre ?? null,
+      puntoControl: matriz?.cuenca?.puntoControl ?? null,
+      metodosQt: diagnosticoQt.length,
+      restricciones: Array.isArray(matriz?.restricciones) ? matriz.restricciones.length : 0,
+      camposCriticosCompletos: comparable
+    }
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT agrega un helper puro para validar la completitud de matrices candidatas de cuenca patrón antes de permitir una comparación futura multi-cuenca.

El validador actúa como portero: una matriz candidata solo puede considerarse comparable si cumple campos mínimos de identificación, morfometría, tiempos de concentración, lluvia-escorrentía, escenario de referencia, diagnóstico Q(t), velocidades efectivas, plausibilidad temporal y restricciones no adoptivas.

## Secuencia técnica

- OT-0100A: diseño documental del validador de completitud.
- OT-0100B: creación del helper puro `validarCompletitudMatrizCuencaPatron.js`.
- OT-0100C: validación documental/técnica del helper.
- OT-0100D: cierre técnico documental.

## Cambios principales

Se agrega el helper:

```js
src/services/hidrogramas/validarCompletitudMatrizCuencaPatron.js