### PR TITLE
OT-0103 — Explicitación de restricción No descarta en La Iguaná

### DIFF
--- a/00_ADMIN/bitacora/OT-0103/OT-0103A_diseno_explicitacion_no_descarta_matriz_la_iguana.md
+++ b/00_ADMIN/bitacora/OT-0103/OT-0103A_diseno_explicitacion_no_descarta_matriz_la_iguana.md
@@ -1,0 +1,40 @@
+\# OT-0103A — Diseño de explicitación “No descarta” en matriz La Iguaná PC\_80
+
+
+
+\## Contexto
+
+
+
+OT-0103 se abre después del cierre de OT-0102, donde se validó la matriz real La Iguaná PC\_80 contra el validador de completitud de matriz de cuenca patrón.
+
+
+
+La validación de OT-0102 confirmó:
+
+
+
+```json
+
+{
+
+&#x20; "ok": true,
+
+&#x20; "comparable": true,
+
+&#x20; "errores": 0,
+
+&#x20; "advertencias": 1,
+
+&#x20; "camposCriticosCompletos": true,
+
+&#x20; "cuenca": "La Iguaná PC\_80",
+
+&#x20; "puntoControl": "PC\_80",
+
+&#x20; "metodosQt": 5,
+
+&#x20; "restricciones": 7
+
+}
+

--- a/00_ADMIN/bitacora/OT-0103/OT-0103C_validacion_advertencia_no_descarta_resuelta.md
+++ b/00_ADMIN/bitacora/OT-0103/OT-0103C_validacion_advertencia_no_descarta_resuelta.md
@@ -1,0 +1,16 @@
+\# OT-0103C — Validación de advertencia “No descarta” resuelta
+
+
+
+\## Contexto
+
+
+
+Después de OT-0103B, se agregó una restricción textual explícita en la matriz La Iguaná PC\_80:
+
+
+
+```text
+
+No descarta automáticamente ningún método.
+

--- a/00_ADMIN/bitacora/OT-0103/OT-0103D_cierre_explicitacion_no_descarta_la_iguana.md
+++ b/00_ADMIN/bitacora/OT-0103/OT-0103D_cierre_explicitacion_no_descarta_la_iguana.md
@@ -1,0 +1,16 @@
+\# OT-0103D — Cierre técnico de explicitación “No descarta” en La Iguaná PC\_80
+
+
+
+\## Contexto
+
+
+
+OT-0103 se abrió después del cierre de OT-0102, donde la matriz real La Iguaná PC\_80 pasó el validador de completitud como matriz comparable, pero con una advertencia no bloqueante:
+
+
+
+```text
+
+Restricción no adoptiva posiblemente faltante: No descarta
+

--- a/01_APP/HIDROFLOW/src/data/matrizPatronLaIguanaPC80.js
+++ b/01_APP/HIDROFLOW/src/data/matrizPatronLaIguanaPC80.js
@@ -179,6 +179,7 @@ export const matrizPatronLaIguanaPC80 = Object.freeze({
 
   restricciones: [
     "No adopta automáticamente ningún método.",
+    "No descarta automáticamente ningún método.",
     "No levanta el estado global No coherente.",
     "No reemplaza revisión hidrológica profesional.",
     "No recalcula Q(t).",


### PR DESCRIPTION
## Resumen

Esta OT resuelve la única advertencia no bloqueante detectada en OT-0102 por el validador de completitud de matriz de cuenca patrón.

La advertencia era:

```text
Restricción no adoptiva posiblemente faltante: No descarta