### PR TITLE
OT-0105 — Catálogo inicial de productos HidroFlow

### DIFF
--- a/00_ADMIN/bitacora/OT-0105/OT-0105A_catalogo_inicial_productos_hidroflow.md
+++ b/00_ADMIN/bitacora/OT-0105/OT-0105A_catalogo_inicial_productos_hidroflow.md
@@ -1,0 +1,24 @@
+\# OT-0105A — Catálogo inicial de productos HidroFlow
+
+
+
+\## Contexto
+
+
+
+OT-0105 abre un nuevo bloque de trabajo después del cierre del bloque multi-cuenca inicial OT-0099 a OT-0104.
+
+
+
+El frente multi-cuenca queda reservado para una etapa posterior, especialmente cuando se aborde configuración de cuenca principal en subcuencas, lógica tipo HEC-HMS y comparación con una segunda matriz real trazable.
+
+
+
+El foco actual vuelve al tema principal del proyecto:
+
+
+
+```text
+
+HidroFlow como plataforma y sus productos técnicos.
+

--- a/00_ADMIN/bitacora/OT-0105/OT-0105B_cierre_catalogo_inicial_productos_hidroflow.md
+++ b/00_ADMIN/bitacora/OT-0105/OT-0105B_cierre_catalogo_inicial_productos_hidroflow.md
@@ -1,0 +1,24 @@
+\# OT-0105B — Cierre técnico de catálogo inicial de productos HidroFlow
+
+
+
+\## Contexto
+
+
+
+OT-0105 se abrió después del cierre del bloque multi-cuenca inicial OT-0099 a OT-0104.
+
+
+
+El frente de segunda cuenca patrón, subcuencas tipo HEC-HMS y comparación multi-cuenca real queda reservado para una etapa posterior.
+
+
+
+El foco de OT-0105 fue volver al eje principal del proyecto:
+
+
+
+```text
+
+HidroFlow como plataforma y sus productos técnicos.
+


### PR DESCRIPTION
## Resumen

Esta OT abre el catálogo inicial de productos HidroFlow, retomando el eje principal del proyecto después del cierre del bloque multi-cuenca inicial.

No introduce cambios de código.

## Secuencia técnica

- OT-0105A: registro del catálogo inicial de productos HidroFlow.
- OT-0105B: cierre técnico documental del catálogo inicial.

## Productos identificados

- Índice Hidrológico de cuenca.
- Comparador Hidrológico Multi-Método.
- Diagnóstico Q(t).
- Matriz patrón La Iguaná PC_80.
- Gráfica Qp–tPico.
- Gráfica de velocidad efectiva.
- Lectura comparativa textual automática.
- Expediente hidrológico mínimo.
- Validadores de completitud y consistencia.
- Contrato de cuenca patrón futura.
- Paquete hidráulico futuro no adoptivo.

## Resultado

OT-0105 deja registrado que HidroFlow debe entenderse como una plataforma de productos técnicos, no solo como una calculadora hidrológica.

La plataforma produce o prepara cálculo, diagnóstico, visualización, validación, trazabilidad, expediente, comparación futura y soporte para revisión profesional.

## Restricciones

- No se modifica código de aplicación.
- No se agregan productos funcionales nuevos.
- No se activa comparación multi-cuenca.
- No se implementan subcuencas.
- No se toca motor.
- No se recalcula Q(t).
- No se modifica expediente.
- No se adopta ni descarta método.
- No se implementa hidráulica.

## Dictamen

OT-0105 inicia el catálogo de productos HidroFlow y reorganiza el proyecto alrededor de sus salidas técnicas, visuales, documentales y de control.