### PR TITLE
OT-0107 — Priorización de productos exportables HidroFlow

### DIFF
--- a/00_ADMIN/bitacora/OT-0107/OT-0107A_priorizacion_productos_exportables_hidroflow.md
+++ b/00_ADMIN/bitacora/OT-0107/OT-0107A_priorizacion_productos_exportables_hidroflow.md
@@ -1,0 +1,166 @@
+\# OT-0107A — Priorización de productos exportables HidroFlow
+
+
+
+\## Contexto
+
+
+
+OT-0107 se abre después del cierre de OT-0106, donde se clasificó el estado de madurez de los productos HidroFlow.
+
+
+
+OT-0105 identificó el catálogo inicial de productos.
+
+
+
+OT-0106 clasificó esos productos según madurez:
+
+
+
+\- operativo,
+
+\- visible,
+
+\- documentado,
+
+\- validado,
+
+\- exportable,
+
+\- en diagnóstico,
+
+\- futuro.
+
+
+
+El siguiente paso lógico es priorizar qué productos conviene fortalecer primero como salidas técnicas, exportables o institucionales.
+
+
+
+\## Objetivo
+
+
+
+Definir una priorización inicial de productos exportables HidroFlow.
+
+
+
+La priorización debe orientar el fortalecimiento de productos existentes antes de abrir nuevas arquitecturas grandes como:
+
+
+
+\- comparación multi-cuenca real,
+
+\- subcuencas tipo HEC-HMS,
+
+\- paquete hidráulico completo,
+
+\- exportación institucional integral.
+
+
+
+\## Criterios de priorización
+
+
+
+La priorización se basa en criterios técnicos y operativos:
+
+
+
+\### 1. Madurez actual
+
+
+
+Se priorizan productos ya operativos, visibles, documentados o validados.
+
+
+
+\### 2. Valor técnico
+
+
+
+Se priorizan productos que ayudan a explicar, justificar o auditar resultados hidrológicos.
+
+
+
+\### 3. Potencial exportable
+
+
+
+Se priorizan productos que pueden convertirse en reporte, anexo, expediente o insumo técnico formal.
+
+
+
+\### 4. Bajo coste de consolidación
+
+
+
+Se priorizan productos que pueden fortalecerse sin tocar motor, sin recalcular Q(t) y sin abrir grandes cambios de arquitectura.
+
+
+
+\### 5. Trazabilidad
+
+
+
+Se priorizan productos con bitácora, validadores, restricciones y evidencia acumulada.
+
+
+
+\### 6. Utilidad institucional
+
+
+
+Se priorizan productos que puedan apoyar revisión técnica, sustentación o comunicación profesional.
+
+
+
+\## Priorización inicial
+
+
+
+| Prioridad | Producto | Estado actual | Motivo |
+
+|---:|---|---|---|
+
+| 1 | Expediente hidrológico mínimo | Operativo, documentado, validado, parcialmente exportable | Es el producto con mayor potencial institucional porque consolida resultados técnicos en formato revisable. |
+
+| 2 | Diagnóstico Q(t) | Operativo, visible, documentado, validado | Aporta lectura técnica de forma temporal, plausibilidad y riesgo, clave para explicar hidrogramas. |
+
+| 3 | Matriz patrón La Iguaná PC\_80 | Operativa, visible, documentada, validada, comparable | Es el producto patrón más maduro y sirve como referencia técnica trazable. |
+
+| 4 | Gráficas Qp–tPico y velocidad efectiva | Operativas, visibles, documentadas, validadas | Traducen resultados complejos a lectura visual técnica. |
+
+| 5 | Lectura comparativa textual automática | Operativa, visible, documentada, validada | Aporta síntesis ejecutiva preliminar no adoptiva. |
+
+| 6 | Comparador Hidrológico Multi‑Método | Operativo, visible, documentado, validado, en diagnóstico | Producto técnico central, pero amplio y más costoso de convertir completo en salida institucional. |
+
+| 7 | Validadores de completitud y consistencia | Operativos, documentados, validados | Son productos internos críticos, pero no son salida final para usuario institucional. |
+
+| 8 | Índice Hidrológico de cuenca | Operativo, visible, parcialmente documentado | Producto central de navegación y síntesis, pero requiere más consolidación documental para exportación. |
+
+| 9 | Contrato de cuenca patrón futura | Documentado, validado, futuro | Importante arquitectónicamente, pero no es producto exportable inmediato. |
+
+| 10 | Paquete hidráulico futuro no adoptivo | Futuro | No debe priorizarse hasta consolidar hidrograma completo, expediente y trazabilidad. |
+
+| 11 | Comparación multi‑cuenca real | Futuro | No debe abrirse sin segunda matriz real trazable y validada. |
+
+| 12 | Subcuencas tipo HEC‑HMS | Futuro | Frente importante, pero reservado para otra fase del proyecto. |
+
+| 13 | Exportación institucional completa | Futuro | Depende de consolidar primero productos técnicos base. |
+
+
+
+\## Producto prioritario recomendado
+
+
+
+El primer producto a fortalecer debería ser:
+
+
+
+```text
+
+Expediente hidrológico mínimo
+

--- a/00_ADMIN/bitacora/OT-0107/OT-0107B_cierre_priorizacion_productos_exportables_hidroflow.md
+++ b/00_ADMIN/bitacora/OT-0107/OT-0107B_cierre_priorizacion_productos_exportables_hidroflow.md
@@ -1,0 +1,32 @@
+\# OT-0107B — Cierre técnico de priorización de productos exportables HidroFlow
+
+
+
+\## Contexto
+
+
+
+OT-0107 se abrió después del cierre de OT-0106, donde se clasificó la madurez de los productos HidroFlow.
+
+
+
+El objetivo de OT-0107 fue priorizar qué productos conviene fortalecer primero como salidas técnicas, exportables o institucionales.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0107A — Priorización de productos exportables HidroFlow
+
+
+
+Se creó el registro:
+
+
+
+```md
+
+00\_ADMIN/bitacora/OT-0107/OT-0107A\_priorizacion\_productos\_exportables\_hidroflow.md
+


### PR DESCRIPTION
## Resumen

Esta OT prioriza los productos HidroFlow con mayor potencial de salida técnica, exportable o institucional, usando como base el catálogo inicial de OT-0105 y la matriz de madurez de OT-0106.

No introduce cambios de código.

## Secuencia técnica

- OT-0107A: priorización inicial de productos exportables HidroFlow.
- OT-0107B: cierre técnico documental.

## Criterios de priorización

- Madurez actual.
- Valor técnico.
- Potencial exportable.
- Bajo coste de consolidación.
- Trazabilidad.
- Utilidad institucional.

## Priorización resultante

### Prioridad 1

Expediente hidrológico mínimo.

### Prioridad 2

Diagnóstico Q(t).

### Prioridad 3

Matriz patrón La Iguaná PC_80.

## Productos no priorizados todavía

- Comparación multi-cuenca real.
- Subcuencas tipo HEC-HMS.
- Paquete hidráulico completo.
- Exportación institucional integral.

## Resultado

OT-0107 deja una decisión estratégica inicial:

```text
Fortalecer primero el expediente hidrológico mínimo como producto exportable principal.