### PR TITLE
OT‑0110 — Helper puro inicial del expediente hidrológico mínimo

### DIFF
--- a/00_ADMIN/bitacora/OT-0110/OT-0110A_apertura_helper_puro_inicial_expediente.md
+++ b/00_ADMIN/bitacora/OT-0110/OT-0110A_apertura_helper_puro_inicial_expediente.md
@@ -1,0 +1,32 @@
+\# OT-0110A — Apertura de helper puro inicial del expediente hidrológico mínimo
+
+
+
+\## Contexto
+
+
+
+OT-0110 se abre después del cierre de OT-0109, donde se diseñó el helper puro para el expediente hidrológico mínimo.
+
+
+
+OT-0109 confirmó que `textoExpediente` no es una plantilla simple, sino una composición documental con datos, funciones locales, tablas derivadas, validadores, secciones obligatorias y salida por portapapeles.
+
+
+
+\## Objetivo
+
+
+
+Crear el helper puro inicial del expediente hidrológico mínimo sin integrarlo todavía al botón ni al flujo de copiado.
+
+
+
+\## Archivo objetivo
+
+
+
+```js
+
+src/services/documentos/construirExpedienteHidrologicoMinimo.js
+

--- a/00_ADMIN/bitacora/OT-0110/OT-0110C_validacion_helper_puro_inicial_expediente.md
+++ b/00_ADMIN/bitacora/OT-0110/OT-0110C_validacion_helper_puro_inicial_expediente.md
@@ -1,0 +1,16 @@
+\# OT-0110C — Validación del helper puro inicial del expediente hidrológico mínimo
+
+
+
+\## Contexto
+
+
+
+Después de OT-0110B, se creó el helper puro inicial del expediente hidrológico mínimo en:
+
+
+
+```js
+
+src/services/documentos/construirExpedienteHidrologicoMinimo.js
+

--- a/00_ADMIN/bitacora/OT-0110/OT-0110D_cierre_helper_puro_inicial_expediente.md
+++ b/00_ADMIN/bitacora/OT-0110/OT-0110D_cierre_helper_puro_inicial_expediente.md
@@ -1,0 +1,36 @@
+\# OT-0110D — Cierre técnico de helper puro inicial del expediente hidrológico mínimo
+
+
+
+\## Contexto
+
+
+
+OT-0110 se abrió después del cierre de OT-0109, donde se diseñó el helper puro para el expediente hidrológico mínimo y se auditó la dependencia real de `textoExpediente`.
+
+
+
+El propósito de OT-0110 fue crear una primera versión aislada del helper puro, sin integrarlo todavía al botón de copiado ni modificar el comportamiento funcional actual.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0110A — Apertura documental
+
+
+
+Se documentó la apertura del helper puro inicial del expediente hidrológico mínimo.
+
+
+
+Se definió como archivo objetivo:
+
+
+
+```js
+
+src/services/documentos/construirExpedienteHidrologicoMinimo.js
+

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -1,0 +1,214 @@
+// OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
+// Este helper NO está integrado todavía al botón de copiado.
+// No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
+
+export const VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO =
+  "expediente_hidrologico_minimo_v0_1";
+
+export const SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO = Object.freeze([
+  "# Expediente hidrológico mínimo — Cuenca activa",
+  "## 1. Identificación",
+  "## 2. Parámetros hidrológicos base",
+  "## 3. Tiempo de concentración y roles Tc",
+  "## 4. Volumen de referencia",
+  "## 5. Escenario Q-Tr activo — control de trazabilidad",
+  "## 6. Resumen Q-5 auditado",
+  "## 7. Método Racional — contraste global independiente",
+  "## 8. Contraste Q-5 vs Método Racional",
+  "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "## Diagnóstico temporal Q(t) no adoptivo",
+  "## 10. Validación interna del expediente exportado",
+  "## 11. Sello técnico de generación",
+  "## 12. Restricciones y advertencias técnicas"
+]);
+
+export const TOKENS_INVALIDOS_EXPEDIENTE_MINIMO = Object.freeze([
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+]);
+
+function textoSeguro(valor, fallback = "—") {
+  if (valor === null || valor === undefined || valor === "") return fallback;
+  return String(valor);
+}
+
+export function formatearNumeroExpediente(valor, decimales = 2) {
+  if (valor === null || valor === undefined || valor === "") return "—";
+
+  const numero = Number(valor);
+
+  return Number.isFinite(numero)
+    ? numero.toLocaleString("es-CO", {
+        maximumFractionDigits: decimales
+      })
+    : "—";
+}
+
+export function construirMetadataExpediente({
+  contextoBase = {},
+  fechaGeneracion = null,
+  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+  fuente = "helper_puro_inicial"
+} = {}) {
+  return {
+    versionExpediente,
+    fuente,
+    cuenca: contextoBase?.cuencaNombre ?? "Cuenca activa",
+    fechaGeneracion: fechaGeneracion ?? null,
+    tipoSalida: "expediente_hidrologico_minimo",
+    estadoIntegracion: "helper_no_integrado"
+  };
+}
+
+export function validarTextoExpedienteMinimo(
+  texto,
+  seccionesObligatorias = SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO
+) {
+  const contenido = textoSeguro(texto, "");
+
+  const tokensDetectados = TOKENS_INVALIDOS_EXPEDIENTE_MINIMO.filter((token) =>
+    contenido.includes(token)
+  );
+
+  const seccionesFaltantes = seccionesObligatorias.filter(
+    (seccion) => !contenido.includes(seccion)
+  );
+
+  const errores = [
+    ...tokensDetectados.map((token) => `Token inválido detectado: ${token}`),
+    ...seccionesFaltantes.map((seccion) => `Sección obligatoria faltante: ${seccion}`)
+  ];
+
+  return {
+    ok: errores.length === 0,
+    errores,
+    advertencias: [],
+    tokensDetectados,
+    seccionesFaltantes,
+    seccionesObligatorias: [...seccionesObligatorias]
+  };
+}
+
+export default function construirExpedienteHidrologicoMinimo({
+  contextoBase = {},
+  Tc_final = null,
+  metodos = [],
+  filasMorfologiaQt = [],
+  filasDictamenFormaQt = [],
+  filasRiesgoTemporalQt = [],
+  sintesisRiesgoTemporalQt = null,
+  fechaGeneracion = null,
+  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO
+} = {}) {
+  const metadata = construirMetadataExpediente({
+    contextoBase,
+    fechaGeneracion,
+    versionExpediente
+  });
+
+  const areaKm2 = Number(contextoBase?.area_km2);
+  const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
+
+  const volumenEsperadoM3 =
+    Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
+      ? areaKm2 * peTotalMm * 1000
+      : null;
+
+  const texto = [
+    "# Expediente hidrológico mínimo — Cuenca activa",
+    "Estado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.",
+    "Lectura técnica: este helper aún no reemplaza el expediente operativo construido en ComparadorMultiMetodo.jsx.",
+    "Alcance: contrato inicial de construcción documental; no copia al portapapeles, no modifica UI y no recalcula resultados.",
+    "",
+    "## 1. Identificación",
+    `Cuenca: ${metadata.cuenca}`,
+    `Área: ${Number.isFinite(areaKm2) ? formatearNumeroExpediente(areaKm2, 4) + " km²" : "—"}`,
+    `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
+    "",
+    "## 2. Parámetros hidrológicos base",
+    `CN: ${textoSeguro(contextoBase?.CN)}`,
+    `CN base: ${textoSeguro(contextoBase?.CN_base)}`,
+    `CN efectivo: ${textoSeguro(contextoBase?.CN_efectivo)}`,
+    `AMC: ${textoSeguro(contextoBase?.AMC)}`,
+    "",
+    "## 3. Tiempo de concentración y roles Tc",
+    `Tc comparador: ${
+      Tc_final !== null && Tc_final !== undefined
+        ? formatearNumeroExpediente(Tc_final, 1) + " min"
+        : "—"
+    }`,
+    "Nota: este helper no selecciona ni recalcula Tc.",
+    "",
+    "## 4. Volumen de referencia",
+    `Lluvia efectiva total: ${
+      Number.isFinite(peTotalMm) ? formatearNumeroExpediente(peTotalMm, 2) + " mm" : "—"
+    }`,
+    `Volumen esperado: ${
+      Number.isFinite(volumenEsperadoM3)
+        ? formatearNumeroExpediente(volumenEsperadoM3, 0) + " m³"
+        : "—"
+    }`,
+    "Fórmula: Pe(mm) × Área(km²) × 1000.",
+    "",
+    "## 5. Escenario Q-Tr activo — control de trazabilidad",
+    `Estado: ${contextoBase?.q_tr_activo_estado?.estado ?? "no_publicado"}`,
+    "Lectura técnica: bloque reservado para integración posterior sin recálculo.",
+    "",
+    "## 6. Resumen Q-5 auditado",
+    `Métodos recibidos: ${Array.isArray(metodos) ? metodos.length : 0}`,
+    "Estado: sección contractual inicial del helper puro.",
+    "",
+    "## 7. Método Racional — contraste global independiente",
+    "Uso: contraste global independiente de caudal pico.",
+    "Estado: sección contractual inicial del helper puro.",
+    "",
+    "## 8. Contraste Q-5 vs Método Racional",
+    "Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+    "",
+    "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+    "Estado: pendiente de integración completa con datos derivados del expediente operativo.",
+    "",
+    "## Diagnóstico temporal Q(t) no adoptivo",
+    `Filas morfológicas recibidas: ${Array.isArray(filasMorfologiaQt) ? filasMorfologiaQt.length : 0}`,
+    `Filas de forma recibidas: ${Array.isArray(filasDictamenFormaQt) ? filasDictamenFormaQt.length : 0}`,
+    `Filas de riesgo recibidas: ${Array.isArray(filasRiesgoTemporalQt) ? filasRiesgoTemporalQt.length : 0}`,
+    `Síntesis de riesgo temporal: ${sintesisRiesgoTemporalQt ? "recibida" : "no recibida"}`,
+    "Restricción: diagnóstico no adoptivo; no selecciona método ni levanta No coherente.",
+    "",
+    "## 10. Validación interna del expediente exportado",
+    "Estado de validación estructural: helper puro inicial con control de secciones y tokens inválidos.",
+    "",
+    "## 11. Sello técnico de generación",
+    "Herramienta: HidroFlow.",
+    "Tipo de salida: Expediente hidrológico mínimo.",
+    `Versión del expediente: ${versionExpediente}`,
+    `Fecha de generación: ${fechaGeneracion ?? "—"}`,
+    "Alcance: helper puro inicial no integrado al botón de copiado.",
+    "",
+    "## 12. Restricciones y advertencias técnicas",
+    "- No modifica el motor hidrológico.",
+    "- No recalcula hidrogramas.",
+    "- No altera Qp, tPico, Volumen ni Q(t).",
+    "- No copia al portapapeles.",
+    "- No reemplaza el expediente operativo actual.",
+    ""
+  ].join("\n");
+
+  const validacion = validarTextoExpedienteMinimo(texto);
+
+  const advertencias = [
+    "Helper puro inicial no integrado al botón.",
+    "El texto generado es contractual/base y no reemplaza todavía el expediente operativo actual."
+  ];
+
+  return {
+    ok: validacion.ok,
+    texto,
+    errores: validacion.errores,
+    advertencias,
+    secciones: [...SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO],
+    metadata
+  };
+}


### PR DESCRIPTION
## Resumen

Esta OT crea el helper puro inicial del expediente hidrológico mínimo como base técnica aislada.

No integra todavía el helper al botón de copiado ni modifica el comportamiento funcional existente.

## Secuencia técnica

- OT-0110A: apertura documental del helper puro inicial.
- OT-0110B: creación del helper `construirExpedienteHidrologicoMinimo.js`.
- OT-0110C: validación documental/build del helper.
- OT-0110D: cierre técnico documental.

## Archivo creado

```js
src/services/documentos/construirExpedienteHidrologicoMinimo.js