### PR TITLE
OT‑0113 — Integración diagnóstica no invasiva del helper del expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0113/OT-0113A_diseno_integracion_diagnostica_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0113/OT-0113A_diseno_integracion_diagnostica_helper_expediente.md
@@ -1,0 +1,36 @@
+\# OT-0113A — Diseño de integración diagnóstica no invasiva del helper del expediente
+
+
+
+\## Contexto
+
+
+
+OT-0113 se abre después del cierre de OT-0112, donde se comparó de forma controlada el helper puro inicial del expediente hidrológico mínimo contra el expediente operativo actual.
+
+
+
+OT-0112 confirmó que el helper y el expediente operativo comparten la estructura documental mínima esperada, con brechas estructurales igual a cero.
+
+
+
+\## Objetivo
+
+
+
+Integrar el helper puro del expediente dentro de `ComparadorMultiMetodo.jsx` únicamente como diagnóstico interno/no operativo.
+
+
+
+La integración no debe reemplazar `textoExpediente`, no debe modificar el botón de copiado y no debe cambiar el comportamiento del portapapeles.
+
+
+
+\## Archivo objetivo
+
+
+
+```js
+
+src/components/ComparadorMultiMetodo.jsx
+

--- a/00_ADMIN/bitacora/OT-0113/OT-0113C_validacion_integracion_diagnostica_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0113/OT-0113C_validacion_integracion_diagnostica_helper_expediente.md
@@ -1,0 +1,20 @@
+\# OT-0113C — Validación de integración diagnóstica no invasiva del helper del expediente
+
+
+
+\## Contexto
+
+
+
+Después de OT-0113B, se integró el helper puro del expediente hidrológico mínimo dentro de `ComparadorMultiMetodo.jsx` como diagnóstico interno/no operativo.
+
+
+
+El helper importado fue:
+
+
+
+```js
+
+src/services/documentos/construirExpedienteHidrologicoMinimo.js
+

--- a/00_ADMIN/bitacora/OT-0113/OT-0113D_cierre_integracion_diagnostica_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0113/OT-0113D_cierre_integracion_diagnostica_helper_expediente.md
@@ -1,0 +1,72 @@
+\# OT-0113D — Cierre técnico de integración diagnóstica no invasiva del helper del expediente
+
+
+
+\## Contexto
+
+
+
+OT-0113 se abrió después del cierre de OT-0112, donde se comparó de forma controlada el helper puro inicial del expediente hidrológico mínimo contra el expediente operativo actual.
+
+
+
+OT-0112 confirmó que el helper y el expediente operativo compartían la estructura documental mínima esperada, con brechas estructurales igual a cero.
+
+
+
+\## Objetivo de OT-0113
+
+
+
+Integrar el helper puro del expediente dentro de `ComparadorMultiMetodo.jsx` únicamente como diagnóstico interno/no operativo.
+
+
+
+La integración no debía reemplazar `textoExpediente`, no debía modificar el botón de copiado y no debía cambiar el comportamiento del portapapeles.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0113A — Diseño documental
+
+
+
+Se documentó el diseño de integración diagnóstica no invasiva del helper del expediente.
+
+
+
+El enfoque definido fue:
+
+
+
+\- importar el helper,
+
+\- ejecutarlo de forma controlada,
+
+\- capturar su resultado como diagnóstico interno,
+
+\- registrar advertencias en consola solo si falla,
+
+\- no mostrar bloque visual nuevo,
+
+\- no cambiar el texto copiado,
+
+\- no cambiar portapapeles.
+
+
+
+\### OT-0113B — Integración diagnóstica mínima
+
+
+
+Se modificó:
+
+
+
+```js
+
+src/components/ComparadorMultiMetodo.jsx
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -5,6 +5,7 @@ import { calcTc, mapTcResultados } from "../services/hidroEngine";
 import { seleccionarTc } from "../services/tcSelector";
 import { derivarRangoCompetenteTc } from "../services/tc/derivarRangoCompetenteTc";
 import adaptarExpedienteDocumental from "../services/documentos/adaptarExpedienteDocumental";
+import construirExpedienteHidrologicoMinimo from "../services/documentos/construirExpedienteHidrologicoMinimo";
 import adaptarQSeriesHidrogramas from "../services/hidrogramas/adaptarQSeriesHidrogramas";
 import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstructuraHidrogramas";
 import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
@@ -2007,6 +2008,33 @@ const handleClickSeguro = (accion) => () => {
             sintesisRiesgoTemporalQt
           });
 
+          // OT-0113B — Diagnóstico no invasivo del helper puro del expediente.
+          // No reemplaza textoExpediente, no modifica el botón y no cambia portapapeles.
+          try {
+            const diagnosticoHelperExpediente = construirExpedienteHidrologicoMinimo({
+              contextoBase,
+              Tc_final,
+              metodos,
+              filasMorfologiaQt,
+              filasDictamenFormaQt,
+              filasRiesgoTemporalQt,
+              sintesisRiesgoTemporalQt,
+              fechaGeneracion: new Date().toLocaleString("es-CO"),
+              versionExpediente: "expediente_hidrologico_minimo_v0_1"
+            });
+
+            if (!diagnosticoHelperExpediente?.ok) {
+              console.warn(
+                "Diagnóstico helper expediente no invasivo:",
+                diagnosticoHelperExpediente
+              );
+            }
+          } catch (errorDiagnosticoHelperExpediente) {
+            console.warn(
+              "Diagnóstico helper expediente no invasivo no ejecutado:",
+              errorDiagnosticoHelperExpediente
+            );
+          }
           const textoExpediente = [
             "# Expediente hidrológico mínimo — Cuenca activa",
             "Estado técnico del expediente: CONSISTENTE CON ADVERTENCIAS.",
@@ -3429,6 +3457,8 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta OT integra el helper puro del expediente hidrológico mínimo dentro de `ComparadorMultiMetodo.jsx` como diagnóstico interno/no operativo.

No reemplaza `textoExpediente`, no modifica el botón y no cambia el comportamiento del portapapeles.

## Secuencia técnica

- OT-0113A: diseño documental de integración diagnóstica.
- OT-0113B: import y ejecución diagnóstica del helper en `ComparadorMultiMetodo.jsx`.
- OT-0113C: validación documental/build/scripts.
- OT-0113D: cierre técnico documental.

## Cambio principal

Se importa:

```js
import construirExpedienteHidrologicoMinimo from "../services/documentos/construirExpedienteHidrologicoMinimo";