### PR TITLE
OT‑0114 — Comparación runtime helper vs textoExpediente operativo

### DIFF
--- a/00_ADMIN/bitacora/OT-0114/OT-0114A_diseno_comparacion_runtime_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0114/OT-0114A_diseno_comparacion_runtime_helper_expediente.md
@@ -1,0 +1,28 @@
+\# OT-0114A — Diseño de comparación runtime helper vs textoExpediente operativo
+
+
+
+\## Contexto
+
+
+
+OT-0114 se abre después del cierre de OT-0113, donde se integró el helper puro del expediente hidrológico mínimo dentro de `ComparadorMultiMetodo.jsx` como diagnóstico interno/no operativo.
+
+
+
+OT-0113 ejecuta el helper en el contexto real del comparador, pero aún no compara su texto contra el `textoExpediente` operativo que se copia actualmente al portapapeles.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una comparación runtime, diagnóstica y no invasiva entre:
+
+
+
+```js
+
+diagnosticoHelperExpediente.texto
+

--- a/00_ADMIN/bitacora/OT-0114/OT-0114C_validacion_comparacion_runtime_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0114/OT-0114C_validacion_comparacion_runtime_helper_expediente.md
@@ -1,0 +1,28 @@
+\# OT-0114C — Validación de comparación runtime helper vs textoExpediente operativo
+
+
+
+\## Contexto
+
+
+
+Después de OT-0114B, se agregó una comparación runtime no invasiva dentro de `ComparadorMultiMetodo.jsx`.
+
+
+
+La comparación evalúa el texto generado por el helper puro del expediente frente al `textoExpediente` operativo construido dentro del mismo handler.
+
+
+
+\## Cambio aplicado
+
+
+
+Se modificó:
+
+
+
+```js
+
+src/components/ComparadorMultiMetodo.jsx
+

--- a/00_ADMIN/bitacora/OT-0114/OT-0114D_cierre_comparacion_runtime_helper_expediente.md
+++ b/00_ADMIN/bitacora/OT-0114/OT-0114D_cierre_comparacion_runtime_helper_expediente.md
@@ -1,0 +1,28 @@
+\# OT-0114D — Cierre técnico de comparación runtime helper vs textoExpediente operativo
+
+
+
+\## Contexto
+
+
+
+OT-0114 se abrió después del cierre de OT-0113, donde el helper puro del expediente hidrológico mínimo fue integrado dentro de `ComparadorMultiMetodo.jsx` como diagnóstico interno/no operativo.
+
+
+
+OT-0113 ejecutaba el helper en el contexto real del comparador, pero aún no comparaba su texto contra el `textoExpediente` operativo construido en el mismo flujo.
+
+
+
+\## Objetivo de OT-0114
+
+
+
+Agregar una comparación runtime no invasiva entre:
+
+
+
+```js
+
+diagnosticoHelperExpediente.texto
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2010,8 +2010,10 @@ const handleClickSeguro = (accion) => () => {
 
           // OT-0113B — Diagnóstico no invasivo del helper puro del expediente.
           // No reemplaza textoExpediente, no modifica el botón y no cambia portapapeles.
+          let diagnosticoHelperExpediente = null;
+
           try {
-            const diagnosticoHelperExpediente = construirExpedienteHidrologicoMinimo({
+            diagnosticoHelperExpediente = construirExpedienteHidrologicoMinimo({
               contextoBase,
               Tc_final,
               metodos,
@@ -2181,6 +2183,71 @@ const handleClickSeguro = (accion) => () => {
             "- No se alteran Qp, Tp, Volumen ni Q(t).",
             "",
           ].join("\n");
+          // OT-0114B — Comparación runtime no invasiva helper vs textoExpediente.
+          // No reemplaza textoExpediente, no modifica el botón y no cambia portapapeles.
+          try {
+            const textoHelperExpediente = diagnosticoHelperExpediente?.texto ?? "";
+
+            const marcadoresRuntimeExpediente = [
+              "# Expediente hidrológico mínimo — Cuenca activa",
+              "## 5. Escenario Q-Tr activo — control de trazabilidad",
+              "## 6. Resumen Q-5 auditado",
+              "## 7. Método Racional — contraste global independiente",
+              "## 8. Contraste Q-5 vs Método Racional",
+              "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+              "## Diagnóstico temporal Q(t) no adoptivo",
+              "## 10. Validación interna del expediente exportado",
+              "## 11. Sello técnico de generación",
+              "## 12. Restricciones y advertencias técnicas"
+            ];
+
+            const tokensInvalidosRuntimeExpediente = [
+              "undefined",
+              "null",
+              "NaN",
+              "[object Object]"
+            ];
+
+            const marcadoresFaltantesEnHelper = marcadoresRuntimeExpediente.filter(
+              (marcador) => !textoHelperExpediente.includes(marcador)
+            );
+
+            const marcadoresFaltantesEnOperativo = marcadoresRuntimeExpediente.filter(
+              (marcador) => !textoExpediente.includes(marcador)
+            );
+
+            const tokensHelper = tokensInvalidosRuntimeExpediente.filter((token) =>
+              textoHelperExpediente.includes(token)
+            );
+
+            const tokensOperativo = tokensInvalidosRuntimeExpediente.filter((token) =>
+              textoExpediente.includes(token)
+            );
+
+            const brechasRuntimeExpediente = [
+              ...marcadoresFaltantesEnHelper.map(
+                (marcador) => `Helper sin marcador: ${marcador}`
+              ),
+              ...marcadoresFaltantesEnOperativo.map(
+                (marcador) => `Operativo sin marcador: ${marcador}`
+              ),
+              ...tokensHelper.map((token) => `Helper con token inválido: ${token}`),
+              ...tokensOperativo.map((token) => `Operativo con token inválido: ${token}`)
+            ];
+
+            if (brechasRuntimeExpediente.length > 0) {
+              console.warn("Comparación runtime helper vs expediente operativo:", {
+                brechas: brechasRuntimeExpediente,
+                longitudHelper: textoHelperExpediente.length,
+                longitudOperativo: textoExpediente.length
+              });
+            }
+          } catch (errorComparacionRuntimeExpediente) {
+            console.warn(
+              "Comparación runtime helper vs expediente operativo no ejecutada:",
+              errorComparacionRuntimeExpediente
+            );
+          }
           try {
             const diagnosticoDocumentalExpediente = adaptarExpedienteDocumental(textoExpediente, {
               fuenteExpediente: "ComparadorMultiMetodo.textoExpediente",
@@ -3457,6 +3524,7 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta OT agrega una comparación runtime no invasiva entre el texto generado por el helper puro del expediente y el `textoExpediente` operativo actual dentro de `ComparadorMultiMetodo.jsx`.

No reemplaza `textoExpediente`, no modifica el botón y no cambia el comportamiento del portapapeles.

## Secuencia técnica

- OT-0114A: diseño documental de comparación runtime.
- OT-0114B: comparación runtime no invasiva en `ComparadorMultiMetodo.jsx`.
- OT-0114C: validación documental/build/scripts.
- OT-0114D: cierre técnico documental.

## Cambio principal

Se mantiene `diagnosticoHelperExpediente` accesible después de ejecutar el helper y se compara su texto contra `textoExpediente` operativo.

La comparación revisa:

- marcadores críticos del expediente.
- tokens inválidos.
- secciones faltantes en helper.
- secciones faltantes en operativo.

Solo registra `console.warn` si detecta brechas.

## Validaciones

Se ejecutaron:

```text
npm run build
node .\scripts\validarHelperExpedienteHidrologicoMinimo.mjs
node .\scripts\compararHelperVsExpedienteOperativo.mjs