### PR TITLE
OT‑0115 — Sustitución parcial controlada del armado documental auxiliar

### DIFF
--- a/00_ADMIN/bitacora/OT-0115/OT-0115A_diseno_sustitucion_parcial_armado_documental_auxiliar.md
+++ b/00_ADMIN/bitacora/OT-0115/OT-0115A_diseno_sustitucion_parcial_armado_documental_auxiliar.md
@@ -1,0 +1,84 @@
+\# OT-0115A — Diseño de sustitución parcial controlada del armado documental auxiliar
+
+
+
+\## Contexto
+
+
+
+OT-0115 se abre después del cierre de OT-0114, donde el helper puro del expediente hidrológico mínimo fue comparado en runtime contra `textoExpediente` operativo.
+
+
+
+La cadena previa dejó el helper en estado maduro para una primera sustitución parcial:
+
+
+
+\- OT-0109: diseño del helper.
+
+\- OT-0110: helper puro inicial creado.
+
+\- OT-0111: helper validado aislado.
+
+\- OT-0112: helper comparado contra expediente operativo.
+
+\- OT-0113: helper ejecutado en runtime como diagnóstico no invasivo.
+
+\- OT-0114: helper comparado en runtime contra `textoExpediente`.
+
+
+
+\## Objetivo
+
+
+
+Diseñar una sustitución parcial, controlada y reversible del armado documental auxiliar del expediente hidrológico mínimo.
+
+
+
+La sustitución no debe reemplazar `textoExpediente` completo.
+
+
+
+\## Tesis técnica
+
+
+
+El primer uso operativo parcial del helper debe limitarse a un bloque auxiliar de bajo riesgo.
+
+
+
+No se recomienda iniciar por:
+
+
+
+\- Q-5,
+
+\- Método Racional,
+
+\- diagnóstico Q(t),
+
+\- control Pe–Área–Volumen,
+
+\- validaciones finales,
+
+\- portapapeles.
+
+
+
+La sustitución inicial más segura es usar metadata o sello documental auxiliar generado por el helper.
+
+
+
+\## Bloque candidato
+
+
+
+El bloque candidato para sustitución parcial es:
+
+
+
+```text
+
+metadata / versión / sello auxiliar del expediente
+

--- a/00_ADMIN/bitacora/OT-0115/OT-0115C_validacion_sustitucion_parcial_metadata_helper.md
+++ b/00_ADMIN/bitacora/OT-0115/OT-0115C_validacion_sustitucion_parcial_metadata_helper.md
@@ -1,0 +1,28 @@
+\# OT-0115C — Validación de sustitución parcial controlada con metadata auxiliar del helper
+
+
+
+\## Contexto
+
+
+
+Después de OT-0115B, se incorporó una sustitución parcial y controlada del armado documental auxiliar del expediente hidrológico mínimo.
+
+
+
+La sustitución consistió en usar metadata del helper puro del expediente dentro del bloque de sello técnico del expediente operativo.
+
+
+
+\## Cambio aplicado
+
+
+
+Se modificó:
+
+
+
+```js
+
+src/components/ComparadorMultiMetodo.jsx
+

--- a/00_ADMIN/bitacora/OT-0115/OT-0115D_cierre_sustitucion_parcial_metadata_helper.md
+++ b/00_ADMIN/bitacora/OT-0115/OT-0115D_cierre_sustitucion_parcial_metadata_helper.md
@@ -1,0 +1,58 @@
+\# OT-0115D — Cierre técnico de sustitución parcial controlada con metadata auxiliar del helper
+
+
+
+\## Contexto
+
+
+
+OT-0115 se abrió después del cierre de OT-0114, donde el helper puro del expediente hidrológico mínimo fue comparado en runtime contra `textoExpediente` operativo.
+
+
+
+La cadena previa dejó al helper en estado maduro para una primera sustitución parcial:
+
+
+
+\- OT-0109: diseño del helper.
+
+\- OT-0110: helper puro inicial creado.
+
+\- OT-0111: helper validado aislado.
+
+\- OT-0112: helper comparado contra expediente operativo.
+
+\- OT-0113: helper ejecutado en runtime como diagnóstico no invasivo.
+
+\- OT-0114: helper comparado en runtime contra `textoExpediente`.
+
+
+
+\## Objetivo de OT-0115
+
+
+
+Realizar una sustitución parcial, controlada y reversible del armado documental auxiliar del expediente hidrológico mínimo.
+
+
+
+La sustitución no debía reemplazar `textoExpediente` completo.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0115A — Diseño documental
+
+
+
+Se documentó que la sustitución parcial inicial debía concentrarse en un bloque de bajo riesgo:
+
+
+
+```text
+
+metadata / versión / sello auxiliar del expediente
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2167,6 +2167,7 @@ const handleClickSeguro = (accion) => () => {
             "## 11. Sello técnico de generación",
             "Herramienta: HidroFlow.",
             "Tipo de salida: Expediente hidrológico mínimo.",
+            `Versión auxiliar helper expediente: ${diagnosticoHelperExpediente?.metadata?.versionExpediente ?? "no integrada"}.`,
             `Cuenca activa: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}.`,
             `Fecha de generación: ${new Date().toLocaleString("es-CO")}.`,
             "Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.",
@@ -3524,6 +3525,7 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+
 
 
 


### PR DESCRIPTION
## Resumen

Esta OT inicia una sustitución parcial, controlada y reversible del armado documental auxiliar del expediente hidrológico mínimo.

El helper puro del expediente aporta metadata auxiliar de versión dentro del sello técnico, sin reemplazar `textoExpediente`.

## Secuencia técnica

- OT-0115A: diseño documental de sustitución parcial controlada.
- OT-0115B: integración de metadata auxiliar del helper en el sello técnico.
- OT-0115C: validación documental/build/scripts.
- OT-0115D: cierre técnico documental.

## Cambio principal

En `ComparadorMultiMetodo.jsx`, dentro de:

```text
## 11. Sello técnico de generación