### PR TITLE
OT‑0116 — Sustitución parcial controlada de bloque de sello técnico

### DIFF
--- a/00_ADMIN/bitacora/OT-0116/OT-0116A_diseno_sustitucion_parcial_bloque_sello_tecnico.md
+++ b/00_ADMIN/bitacora/OT-0116/OT-0116A_diseno_sustitucion_parcial_bloque_sello_tecnico.md
@@ -1,0 +1,20 @@
+\# OT-0116A — Diseño de sustitución parcial controlada de bloque de sello técnico
+
+
+
+\## Contexto
+
+
+
+OT-0116 se abre después del cierre de OT-0115, donde el helper puro del expediente hidrológico mínimo empezó a participar de forma auxiliar en el armado documental operativo.
+
+
+
+OT-0115 incorporó una línea de metadata auxiliar del helper en el bloque:
+
+
+
+```text
+
+\## 11. Sello técnico de generación
+

--- a/00_ADMIN/bitacora/OT-0116/OT-0116C_validacion_sustitucion_parcial_sello_tecnico.md
+++ b/00_ADMIN/bitacora/OT-0116/OT-0116C_validacion_sustitucion_parcial_sello_tecnico.md
@@ -1,0 +1,28 @@
+\# OT-0116C — Validación de sustitución parcial controlada del bloque de sello técnico
+
+
+
+\## Contexto
+
+
+
+Después de OT-0116B, el helper puro del expediente hidrológico mínimo asumió una porción más completa del bloque auxiliar de sello técnico.
+
+
+
+La sustitución sigue siendo parcial, controlada y reversible.
+
+
+
+\## Cambio aplicado
+
+
+
+Se modificó el helper:
+
+
+
+```js
+
+src/services/documentos/construirExpedienteHidrologicoMinimo.js
+

--- a/00_ADMIN/bitacora/OT-0116/OT-0116D_cierre_sustitucion_parcial_sello_tecnico.md
+++ b/00_ADMIN/bitacora/OT-0116/OT-0116D_cierre_sustitucion_parcial_sello_tecnico.md
@@ -1,0 +1,40 @@
+\# OT-0116D — Cierre técnico de sustitución parcial controlada del bloque de sello técnico
+
+
+
+\## Contexto
+
+
+
+OT-0116 se abrió después del cierre de OT-0115, donde el helper puro del expediente hidrológico mínimo empezó a participar como fuente auxiliar del armado documental operativo mediante una línea de metadata en el sello técnico.
+
+
+
+OT-0116 amplía esa participación de forma parcial, controlada y reversible dentro del bloque de sello técnico.
+
+
+
+\## Objetivo de OT-0116
+
+
+
+Delegar al helper una porción más completa del bloque auxiliar de sello técnico, sin reemplazar `textoExpediente` completo y sin tocar secciones sensibles del expediente.
+
+
+
+\## Secuencia ejecutada
+
+
+
+\### OT-0116A — Diseño documental
+
+
+
+Se documentó que el siguiente paso prudente era limitar la sustitución parcial a un bloque de bajo riesgo:
+
+
+
+```text
+
+\## 11. Sello técnico de generación
+

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -5,7 +5,9 @@ import { calcTc, mapTcResultados } from "../services/hidroEngine";
 import { seleccionarTc } from "../services/tcSelector";
 import { derivarRangoCompetenteTc } from "../services/tc/derivarRangoCompetenteTc";
 import adaptarExpedienteDocumental from "../services/documentos/adaptarExpedienteDocumental";
-import construirExpedienteHidrologicoMinimo from "../services/documentos/construirExpedienteHidrologicoMinimo";
+import construirExpedienteHidrologicoMinimo, {
+  construirLineasSelloTecnicoAuxiliarExpediente
+} from "../services/documentos/construirExpedienteHidrologicoMinimo";
 import adaptarQSeriesHidrogramas from "../services/hidrogramas/adaptarQSeriesHidrogramas";
 import resumirEstructuraHidrogramas from "../services/hidrogramas/resumirEstructuraHidrogramas";
 import calcularMetricasMorfologiaQt from "../services/hidrogramas/calcularMetricasMorfologiaQt";
@@ -2167,7 +2169,11 @@ const handleClickSeguro = (accion) => () => {
             "## 11. Sello técnico de generación",
             "Herramienta: HidroFlow.",
             "Tipo de salida: Expediente hidrológico mínimo.",
-            `Versión auxiliar helper expediente: ${diagnosticoHelperExpediente?.metadata?.versionExpediente ?? "no integrada"}.`,
+            ...(diagnosticoHelperExpediente?.metadata
+              ? construirLineasSelloTecnicoAuxiliarExpediente({
+                  metadata: diagnosticoHelperExpediente.metadata
+                })
+              : ["Versión auxiliar helper expediente: no integrada."]),
             `Cuenca activa: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}.`,
             `Fecha de generación: ${new Date().toLocaleString("es-CO")}.`,
             "Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.",
@@ -3525,6 +3531,8 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+
+
 
 
 

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -91,6 +91,18 @@ export function validarTextoExpedienteMinimo(
   };
 }
 
+export function construirLineasSelloTecnicoAuxiliarExpediente({
+  metadata = {},
+  versionExpediente = metadata?.versionExpediente ?? VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+  estadoIntegracion = metadata?.estadoIntegracion ?? "helper_no_integrado",
+  tipoSalida = metadata?.tipoSalida ?? "expediente_hidrologico_minimo"
+} = {}) {
+  return [
+    `Versión auxiliar helper expediente: ${textoSeguro(versionExpediente, "no integrada")}.`,
+    `Estado auxiliar helper expediente: ${textoSeguro(estadoIntegracion, "no informado")}.`,
+    `Tipo auxiliar helper expediente: ${textoSeguro(tipoSalida, "expediente_hidrologico_minimo")}.`
+  ];
+}
 export default function construirExpedienteHidrologicoMinimo({
   contextoBase = {},
   Tc_final = null,


### PR DESCRIPTION
## Resumen

Esta OT amplía la participación auxiliar del helper puro del expediente dentro del bloque de sello técnico del expediente operativo.

No reemplaza `textoExpediente`, no modifica el botón y no cambia el comportamiento del portapapeles.

## Secuencia técnica

- OT-0116A: diseño documental de sustitución parcial del sello técnico.
- OT-0116B: función auxiliar `construirLineasSelloTecnicoAuxiliarExpediente`.
- OT-0116C: validación documental/build/scripts.
- OT-0116D: cierre técnico documental.

## Cambio principal

En el helper:

```js
construirLineasSelloTecnicoAuxiliarExpediente(...)