### PR TITLE
OT‑0117 — Validación reforzada del sello técnico delegado

### DIFF
--- a/00_ADMIN/bitacora/OT-0117/OT-0117A_diseno_validacion_reforzada_sello_tecnico_delegado.md
+++ b/00_ADMIN/bitacora/OT-0117/OT-0117A_diseno_validacion_reforzada_sello_tecnico_delegado.md
@@ -1,0 +1,20 @@
+\# OT-0117A — Diseño de validación reforzada del sello técnico delegado
+
+
+
+\## Contexto
+
+
+
+OT-0117 se abre después del cierre de OT-0116, donde el helper puro del expediente hidrológico mínimo empezó a construir un bloque auxiliar del sello técnico.
+
+
+
+OT-0116 incorporó la función:
+
+
+
+```js
+
+construirLineasSelloTecnicoAuxiliarExpediente(...)
+

--- a/00_ADMIN/bitacora/OT-0117/OT-0117C_validacion_reforzada_sello_tecnico_delegado.md
+++ b/00_ADMIN/bitacora/OT-0117/OT-0117C_validacion_reforzada_sello_tecnico_delegado.md
@@ -1,0 +1,16 @@
+\# OT-0117C — Validación reforzada del sello técnico auxiliar delegado
+
+
+
+\## Contexto
+
+
+
+Después de OT-0117B, se creó y ejecutó el script de validación reforzada:
+
+
+
+```js
+
+scripts/validarSelloTecnicoAuxiliarExpediente.mjs
+

--- a/00_ADMIN/bitacora/OT-0117/OT-0117D_cierre_validacion_reforzada_sello_tecnico_delegado.md
+++ b/00_ADMIN/bitacora/OT-0117/OT-0117D_cierre_validacion_reforzada_sello_tecnico_delegado.md
@@ -1,0 +1,20 @@
+\# OT-0117D — Cierre técnico de validación reforzada del sello técnico delegado
+
+
+
+\## Contexto
+
+
+
+OT-0117 se abrió después del cierre de OT-0116, donde el helper puro del expediente hidrológico mínimo empezó a construir un bloque auxiliar del sello técnico.
+
+
+
+OT-0116 incorporó la función:
+
+
+
+```js
+
+construirLineasSelloTecnicoAuxiliarExpediente(...)
+

--- a/01_APP/HIDROFLOW/scripts/validarSelloTecnicoAuxiliarExpediente.mjs
+++ b/01_APP/HIDROFLOW/scripts/validarSelloTecnicoAuxiliarExpediente.mjs
@@ -1,0 +1,149 @@
+// OT-0117B — Validación reforzada del sello técnico auxiliar delegado al helper.
+// Este script NO toca UI, NO modifica ComparadorMultiMetodo.jsx,
+// NO copia al portapapeles y NO reemplaza textoExpediente.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  construirLineasSelloTecnicoAuxiliarExpediente,
+  TOKENS_INVALIDOS_EXPEDIENTE_MINIMO,
+  VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO
+} from "../src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const rutaComparador = path.resolve(
+  process.cwd(),
+  "src/components/ComparadorMultiMetodo.jsx"
+);
+
+const metadataControlada = {
+  versionExpediente: VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+  estadoIntegracion: "helper_no_integrado",
+  tipoSalida: "expediente_hidrologico_minimo"
+};
+
+const lineas = construirLineasSelloTecnicoAuxiliarExpediente({
+  metadata: metadataControlada
+});
+
+const textoSello = Array.isArray(lineas) ? lineas.join("\n") : "";
+
+const fuenteComparador = fs.existsSync(rutaComparador)
+  ? fs.readFileSync(rutaComparador, "utf8")
+  : "";
+
+const errores = [];
+
+function verificar(condicion, mensaje) {
+  if (!condicion) errores.push(mensaje);
+}
+
+verificar(Array.isArray(lineas), "La función de sello técnico no retornó un arreglo.");
+verificar(lineas.length === 3, "El sello técnico auxiliar no contiene exactamente 3 líneas.");
+verificar(typeof textoSello === "string" && textoSello.length > 0, "El texto del sello auxiliar está vacío.");
+
+verificar(
+  textoSello.includes("Versión auxiliar helper expediente:"),
+  "Falta la línea de versión auxiliar del helper."
+);
+
+verificar(
+  textoSello.includes("Estado auxiliar helper expediente:"),
+  "Falta la línea de estado auxiliar del helper."
+);
+
+verificar(
+  textoSello.includes("Tipo auxiliar helper expediente:"),
+  "Falta la línea de tipo auxiliar del helper."
+);
+
+verificar(
+  textoSello.includes(VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO),
+  "La versión del expediente no aparece en el sello auxiliar."
+);
+
+verificar(
+  textoSello.includes("helper_no_integrado"),
+  "El estado de integración esperado no aparece en el sello auxiliar."
+);
+
+verificar(
+  textoSello.includes("expediente_hidrologico_minimo"),
+  "El tipo de salida esperado no aparece en el sello auxiliar."
+);
+
+const tokensDetectadosSello = TOKENS_INVALIDOS_EXPEDIENTE_MINIMO.filter((token) =>
+  textoSello.includes(token)
+);
+
+verificar(
+  tokensDetectadosSello.length === 0,
+  "El sello auxiliar contiene tokens inválidos."
+);
+
+verificar(
+  fuenteComparador.length > 0,
+  "No se pudo leer src/components/ComparadorMultiMetodo.jsx."
+);
+
+verificar(
+  fuenteComparador.includes("construirLineasSelloTecnicoAuxiliarExpediente"),
+  "ComparadorMultiMetodo.jsx no referencia construirLineasSelloTecnicoAuxiliarExpediente."
+);
+
+verificar(
+  fuenteComparador.includes("## 11. Sello técnico de generación"),
+  "ComparadorMultiMetodo.jsx no contiene el bloque ## 11. Sello técnico de generación."
+);
+
+verificar(
+  fuenteComparador.includes("diagnosticoHelperExpediente?.metadata"),
+  "ComparadorMultiMetodo.jsx no usa metadata del diagnóstico helper."
+);
+
+verificar(
+  fuenteComparador.includes("textoExpediente"),
+  "ComparadorMultiMetodo.jsx no conserva referencia a textoExpediente."
+);
+
+verificar(
+  fuenteComparador.includes("document.execCommand(\"copy\")") ||
+    fuenteComparador.includes("document.execCommand('copy')"),
+  "No se encontró el mecanismo existente document.execCommand copy."
+);
+
+const resumen = {
+  ok: errores.length === 0,
+  lineasSello: Array.isArray(lineas) ? lineas.length : null,
+  tokensDetectadosSello: tokensDetectadosSello.length,
+  versionExpediente: metadataControlada.versionExpediente,
+  estadoIntegracion: metadataControlada.estadoIntegracion,
+  tipoSalida: metadataControlada.tipoSalida,
+  comparador: {
+    contieneFuncionAuxiliar: fuenteComparador.includes(
+      "construirLineasSelloTecnicoAuxiliarExpediente"
+    ),
+    contieneBloqueSello: fuenteComparador.includes(
+      "## 11. Sello técnico de generación"
+    ),
+    usaMetadataHelper: fuenteComparador.includes(
+      "diagnosticoHelperExpediente?.metadata"
+    ),
+    conservaTextoExpediente: fuenteComparador.includes("textoExpediente")
+  }
+};
+
+console.log("OT-0117B — Validación reforzada sello técnico auxiliar delegado");
+console.log(JSON.stringify(resumen, null, 2));
+
+if (errores.length > 0) {
+  console.error("VALIDACIÓN FALLIDA:");
+  errores.forEach((error, indice) => {
+    console.error(`${indice + 1}. ${error}`);
+  });
+  process.exit(1);
+}
+
+console.log(
+  "VALIDACIÓN APROBADA: sello técnico auxiliar delegado al helper completo y sin tokens inválidos."
+);


### PR DESCRIPTION
## Resumen

Esta OT valida reforzadamente el bloque auxiliar del sello técnico delegado al helper puro del expediente.

No amplía funcionalidad ni delega nuevas secciones documentales.

## Secuencia técnica

- OT-0117A: diseño documental de validación reforzada.
- OT-0117B: script `validarSelloTecnicoAuxiliarExpediente.mjs`.
- OT-0117C: validación documental del resultado.
- OT-0117D: cierre técnico documental.

## Validación principal

El script valida que el sello técnico auxiliar:

- contiene exactamente 3 líneas,
- incluye versión auxiliar,
- incluye estado auxiliar,
- incluye tipo auxiliar,
- no contiene tokens inválidos,
- está referenciado desde `ComparadorMultiMetodo.jsx`,
- conserva `textoExpediente` como fuente operativa.

## Resultado observado

```text
ok = true
lineasSello = 3
tokensDetectadosSello = 0
versionExpediente = expediente_hidrologico_minimo_v0_1
estadoIntegracion = helper_no_integrado
tipoSalida = expediente_hidrologico_minimo
contieneFuncionAuxiliar = true
contieneBloqueSello = true
usaMetadataHelper = true
conservaTextoExpediente = true