### PR TITLE
OT-0120 — Contrato del bloque Identificación delegado

### DIFF
--- a/00_ADMIN/bitacora/OT-0120/OT-0120A_diseno_contrato_bloque_identificacion_delegado.md
+++ b/00_ADMIN/bitacora/OT-0120/OT-0120A_diseno_contrato_bloque_identificacion_delegado.md
@@ -1,0 +1,40 @@
+\# OT-0120A — Diseño contractual del bloque Identificación delegado
+
+
+
+\## Contexto
+
+
+
+OT-0120 se abre después del cierre de OT-0119, donde se seleccionó el bloque `## 1. Identificación` como siguiente bloque documental no crítico candidato para futura delegación parcial al helper del expediente hidrológico mínimo.
+
+
+
+La cadena previa dejó un patrón seguro:
+
+
+
+\- OT-0115: helper aporta una línea auxiliar.
+
+\- OT-0116: helper construye bloque auxiliar de sello técnico.
+
+\- OT-0117: sello técnico delegado validado reforzadamente.
+
+\- OT-0118: contrato del sello técnico delegado congelado.
+
+\- OT-0119: selección del bloque `## 1. Identificación` como siguiente candidato prudente.
+
+
+
+\## Objetivo
+
+
+
+Diseñar el contrato documental del bloque:
+
+
+
+```text
+
+\## 1. Identificación
+

--- a/00_ADMIN/bitacora/OT-0120/OT-0120B_matriz_contrato_bloque_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0120/OT-0120B_matriz_contrato_bloque_identificacion.md
@@ -1,0 +1,84 @@
+\# OT-0120B — Matriz contractual del bloque Identificación delegado
+
+
+
+\## Contexto
+
+
+
+OT-0120 define el contrato del bloque `## 1. Identificación` antes de implementar una delegación parcial al helper.
+
+
+
+Este bloque fue seleccionado en OT-0119 como el siguiente candidato documental no crítico.
+
+
+
+\## Objetivo
+
+
+
+Formalizar una matriz contractual de campos, líneas, fallbacks y riesgos del bloque Identificación.
+
+
+
+\## Matriz contractual
+
+
+
+| Línea documental | Campo fuente permitido | Fallback | Riesgo | Observación |
+
+|---|---|---|---:|---|
+
+| `## 1. Identificación` | constante documental | obligatorio | Bajo | Encabezado contractual del bloque |
+
+| `Cuenca:` | `contextoBase.cuencaNombre` | `Cuenca activa` | Bajo | No debe inferir otro nombre |
+
+| `Área:` | `contextoBase.area\_km2` | `—` | Bajo | Solo formatear si es numérico finito |
+
+| `Fuente de contexto:` | `contextoBase.fuente` | `HidroFlow` | Bajo | Descriptivo |
+
+| `Estación IDF:` | `estacion\_idf`, `estacionIDF`, `estacion`, `nombre\_estacion`, `idf.nombre`, `idf.estacion` | `SAN CRISTOBAL` | Bajo-medio | Debe tomar primer valor disponible seguro |
+
+| `Pendiente media:` | `contextoBase.pendiente\_media\_pct` | `—` | Bajo-medio | Solo formatear si es numérico finito |
+
+| `Longitud cauce principal:` | `contextoBase.longitud\_cauce\_km` | `—` | Bajo-medio | Solo formatear si es numérico finito |
+
+
+
+\## Reglas de formato
+
+
+
+\- El área debe expresarse en km².
+
+\- La pendiente debe expresarse en %.
+
+\- La longitud debe expresarse en km.
+
+\- Los valores numéricos solo deben formatearse si son finitos.
+
+\- Si no hay dato seguro, usar fallback.
+
+\- No se deben emitir tokens inválidos.
+
+
+
+\## Tokens prohibidos
+
+
+
+El bloque no puede emitir:
+
+
+
+```text
+
+undefined
+
+null
+
+NaN
+
+\[object Object]
+

--- a/00_ADMIN/bitacora/OT-0120/OT-0120C_cierre_contrato_bloque_identificacion_delegado.md
+++ b/00_ADMIN/bitacora/OT-0120/OT-0120C_cierre_contrato_bloque_identificacion_delegado.md
@@ -1,0 +1,20 @@
+\# OT-0120C — Cierre técnico del contrato del bloque Identificación delegado
+
+
+
+\## Contexto
+
+
+
+OT-0120 se abrió después del cierre de OT-0119, donde se seleccionó el bloque `## 1. Identificación` como siguiente bloque documental no crítico candidato para una futura delegación parcial al helper del expediente hidrológico mínimo.
+
+
+
+Durante la ejecución inicial de OT-0120, los documentos OT-0120A y OT-0120B fueron commiteados accidentalmente sobre `main`. Como `main` está protegido, la recuperación se realizó mediante commits de `revert` sobre `main` y posterior reaplicación de los documentos sobre la rama correcta:
+
+
+
+```text
+
+ot-0120-contrato-bloque-identificacion-delegado
+


### PR DESCRIPTION
## Resumen

Esta OT define el contrato documental del bloque `## 1. Identificación` como siguiente bloque candidato para una futura delegación parcial al helper del expediente hidrológico mínimo.

No implementa código funcional.

## Contexto

OT-0120 se abre después de OT-0119, donde se seleccionó el bloque `## 1. Identificación` como siguiente bloque documental no crítico.

Durante la ejecución inicial, los documentos OT-0120A y OT-0120B fueron commiteados accidentalmente sobre `main`. Como `main` está protegido, la recuperación se realizó mediante commits de revert sobre `main` y posterior reaplicación de los documentos sobre la rama correcta:

```text
ot-0120-contrato-bloque-identificacion-delegado