### PR TITLE
OT‑0123 — Función pura del bloque Identificación en helper

### DIFF
--- a/00_ADMIN/bitacora/OT-0123/OT-0123A_apertura_funcion_pura_identificacion_helper.md
+++ b/00_ADMIN/bitacora/OT-0123/OT-0123A_apertura_funcion_pura_identificacion_helper.md
@@ -1,0 +1,16 @@
+\# OT-0123A — Apertura de función pura del bloque Identificación en helper
+
+
+
+\## Contexto
+
+
+
+OT-0123 se abre después del cierre de OT-0122, donde se diseñó documentalmente la función auxiliar pura del bloque:
+
+
+
+```text
+
+\## 1. Identificación
+

--- a/00_ADMIN/bitacora/OT-0123/OT-0123C_validacion_funcion_pura_identificacion_helper.md
+++ b/00_ADMIN/bitacora/OT-0123/OT-0123C_validacion_funcion_pura_identificacion_helper.md
@@ -1,0 +1,16 @@
+\# OT-0123C — Validación de función pura del bloque Identificación en helper
+
+
+
+\## Contexto
+
+
+
+Después de OT-0123B, se implementó una función pura para construir las líneas del bloque:
+
+
+
+```text
+
+\## 1. Identificación
+

--- a/00_ADMIN/bitacora/OT-0123/OT-0123D_cierre_funcion_pura_identificacion_helper.md
+++ b/00_ADMIN/bitacora/OT-0123/OT-0123D_cierre_funcion_pura_identificacion_helper.md
@@ -1,0 +1,16 @@
+\# OT-0123D — Cierre técnico de función pura del bloque Identificación en helper
+
+
+
+\## Contexto
+
+
+
+OT-0123 se abrió después del cierre de OT-0122, donde se diseñó documentalmente la función auxiliar pura del bloque:
+
+
+
+```text
+
+\## 1. Identificación
+

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -91,6 +91,34 @@ export function validarTextoExpedienteMinimo(
   };
 }
 
+export function construirLineasIdentificacionExpediente({
+  contextoBase = {},
+  fuenteFallback = "HidroFlow",
+  estacionIdfFallback = "SAN CRISTOBAL"
+} = {}) {
+  const areaKm2 = Number(contextoBase?.area_km2);
+  const pendienteMediaPct = Number(contextoBase?.pendiente_media_pct);
+  const longitudCauceKm = Number(contextoBase?.longitud_cauce_km);
+
+  const estacionIdf =
+    textoSeguro(contextoBase?.estacion_idf, "") ||
+    textoSeguro(contextoBase?.estacionIDF, "") ||
+    textoSeguro(contextoBase?.estacion, "") ||
+    textoSeguro(contextoBase?.nombre_estacion, "") ||
+    textoSeguro(contextoBase?.idf?.nombre, "") ||
+    textoSeguro(contextoBase?.idf?.estacion, "") ||
+    estacionIdfFallback;
+
+  return [
+    "## 1. Identificación",
+    `Cuenca: ${textoSeguro(contextoBase?.cuencaNombre, "Cuenca activa")}`,
+    `Área: ${Number.isFinite(areaKm2) ? `${areaKm2.toFixed(4)} km²` : "—"}`,
+    `Fuente de contexto: ${textoSeguro(contextoBase?.fuente, fuenteFallback)}`,
+    `Estación IDF: ${textoSeguro(estacionIdf, estacionIdfFallback)}`,
+    `Pendiente media: ${Number.isFinite(pendienteMediaPct) ? `${pendienteMediaPct.toFixed(2)} %` : "—"}`,
+    `Longitud cauce principal: ${Number.isFinite(longitudCauceKm) ? `${longitudCauceKm.toFixed(3)} km` : "—"}`
+  ];
+}
 export function construirLineasSelloTecnicoAuxiliarExpediente({
   metadata = {},
   versionExpediente = metadata?.versionExpediente ?? VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
@@ -224,3 +252,4 @@ export default function construirExpedienteHidrologicoMinimo({
     metadata
   };
 }
+


### PR DESCRIPTION
## Resumen

Esta OT implementa la función pura `construirLineasIdentificacionExpediente(...)` en el helper del expediente hidrológico mínimo.

La función construye las líneas del bloque `## 1. Identificación`, pero no se integra todavía en `ComparadorMultiMetodo.jsx`.

## Secuencia técnica

- OT-0123A: apertura documental.
- OT-0123B: implementación de función pura en el helper.
- OT-0123C: validación documental/build/scripts.
- OT-0123D: cierre técnico documental.

## Función implementada

```js
construirLineasIdentificacionExpediente(...)