### PR TITLE
OT-0126 — Comparación textual Identificación delegada vs operativa

### DIFF
--- a/00_ADMIN/bitacora/OT-0126/OT-0126A_apertura_comparacion_textual_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0126/OT-0126A_apertura_comparacion_textual_identificacion.md
@@ -1,0 +1,57 @@
+# OT-0126A — Apertura de comparación textual Identificación delegada vs operativa
+
+## Objetivo
+
+Comparar de forma controlada el bloque documental `## 1. Identificación` generado por la función delegada:
+
+`construirLineasIdentificacionExpediente(...)`
+
+frente al bloque operativo actual construido manualmente dentro de `textoExpediente` en:
+
+`01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx`
+
+## Antecedente
+
+OT-0125 integró la función delegada dentro de `ComparadorMultiMetodo.jsx` como diagnóstico no invasivo.
+
+La integración quedó validada mediante:
+
+`VALIDACION_OT_0125D_IDENTIFICACION_DIAGNOSTICA_OK`
+
+y build Vite aprobado.
+
+## Alcance de OT-0126
+
+Esta OT no sustituye el bloque operativo.
+
+Solo compara:
+
+- cantidad de líneas;
+- encabezado;
+- línea Cuenca;
+- línea Área;
+- Fuente de contexto;
+- Estación IDF;
+- Pendiente media;
+- Longitud cauce principal;
+- diferencias de formato;
+- presencia de unidades;
+- ausencia de residuos técnicos.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0126 se considera válida si se genera una comparación explícita entre bloque delegado y bloque operativo, documentando coincidencias y brechas sin adoptar todavía el resultado delegado.

--- a/00_ADMIN/bitacora/OT-0126/OT-0126B_comparacion_textual_identificacion_delegada_operativa.md
+++ b/00_ADMIN/bitacora/OT-0126/OT-0126B_comparacion_textual_identificacion_delegada_operativa.md
@@ -1,0 +1,74 @@
+# OT-0126B — Comparación textual Identificación delegada vs operativa
+
+## Resumen
+
+```json
+{
+  "lineasDelegadas": 7,
+  "lineasOperativas": 7,
+  "coincidenciasEstrictas": 4,
+  "diferenciasEstrictas": 3,
+  "diferenciasTextualesFuertes": 0,
+  "residuosDelegado": [],
+  "residuosOperativo": [],
+  "textoExpedienteNoSustituido": true,
+  "portapapelesSigueUsandoTextoExpediente": true,
+  "fallbackManualSigueUsandoTextoExpediente": true
+}
+```
+
+## Bloque delegado
+
+```text
+## 1. Identificación
+Cuenca: Quebrada La Iguaná - PC_80
+Área: 46.8516
+Fuente de contexto: HidroFlow
+Estación IDF: SAN CRISTOBAL
+Pendiente media: 8.43
+Longitud cauce principal: 15.524
+```
+
+## Bloque operativo de referencia
+
+```text
+## 1. Identificación
+Cuenca: Quebrada La Iguaná - PC_80
+Área: 46.8516 km²
+Fuente de contexto: HidroFlow
+Estación IDF: SAN CRISTOBAL
+Pendiente media: 8.43 %
+Longitud cauce principal: 15.524 km
+```
+
+## Comparación línea a línea
+
+| Línea | Delegada | Operativa | Resultado |
+|---:|---|---|---|
+| 1 | `## 1. Identificación` | `## 1. Identificación` | Sin diferencia |
+| 2 | `Cuenca: Quebrada La Iguaná - PC_80` | `Cuenca: Quebrada La Iguaná - PC_80` | Sin diferencia |
+| 3 | `Área: 46.8516` | `Área: 46.8516 km²` | Diferencia de unidades/formato |
+| 4 | `Fuente de contexto: HidroFlow` | `Fuente de contexto: HidroFlow` | Sin diferencia |
+| 5 | `Estación IDF: SAN CRISTOBAL` | `Estación IDF: SAN CRISTOBAL` | Sin diferencia |
+| 6 | `Pendiente media: 8.43` | `Pendiente media: 8.43 %` | Diferencia de unidades/formato |
+| 7 | `Longitud cauce principal: 15.524` | `Longitud cauce principal: 15.524 km` | Diferencia de unidades/formato |
+
+## Lectura técnica
+
+- El bloque delegado no coincide estrictamente con el bloque operativo de referencia.
+- Las diferencias detectadas son compatibles con formato/unidades, no con pérdida de contenido esencial.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se reemplazó `textoExpediente`.
+- No se modificó botón.
+- No se modificó portapapeles.
+- No se tocó Q-5.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.
+
+## Conclusión
+
+La comparación queda documentada para decidir, en una OT posterior, si procede ajustar el helper o adoptar parcialmente el bloque delegado.

--- a/07_TOOLBOX/validaciones/comparar_ot0126_identificacion_delegada_operativa.mjs
+++ b/07_TOOLBOX/validaciones/comparar_ot0126_identificacion_delegada_operativa.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { construirLineasIdentificacionExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0126/OT-0126B_comparacion_textual_identificacion_delegada_operativa.md"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+
+const contextoBase = {
+  cuencaNombre: "Quebrada La Iguaná - PC_80",
+  area_km2: 46.8516,
+  pendiente_media_pct: 8.43,
+  longitud_cauce_km: 15.524,
+  fuente: "HidroFlow"
+};
+
+const estacionIdfExpediente = "SAN CRISTOBAL";
+
+const lineasDelegadas = construirLineasIdentificacionExpediente({
+  contextoBase,
+  fuenteFallback: "HidroFlow",
+  estacionIdfFallback: estacionIdfExpediente
+});
+
+const areaKm2 = Number(contextoBase?.area_km2);
+
+const lineasOperativasReferencia = [
+  "## 1. Identificación",
+  `Cuenca: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}`,
+  `Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`,
+  `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
+  `Estación IDF: ${estacionIdfExpediente}`,
+  `Pendiente media: ${
+    Number.isFinite(Number(contextoBase?.pendiente_media_pct))
+      ? Number(contextoBase.pendiente_media_pct).toFixed(2) + " %"
+      : "—"
+  }`,
+  `Longitud cauce principal: ${
+    Number.isFinite(Number(contextoBase?.longitud_cauce_km))
+      ? Number(contextoBase.longitud_cauce_km).toFixed(3) + " km"
+      : "—"
+  }`
+];
+
+const residuosTecnicos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+function normalizarTexto(texto) {
+  return String(texto)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sinUnidadesBasicas(texto) {
+  return normalizarTexto(texto)
+    .replace(/ km²/g, "")
+    .replace(/ %/g, "")
+    .replace(/ km/g, "");
+}
+
+function compararLinea(indice, delegada, operativa) {
+  const igualEstricta = delegada === operativa;
+  const igualSinUnidades = sinUnidadesBasicas(delegada) === sinUnidadesBasicas(operativa);
+
+  return {
+    linea: indice + 1,
+    delegada,
+    operativa,
+    igualEstricta,
+    igualSinUnidades,
+    diferencia: igualEstricta
+      ? "Sin diferencia"
+      : igualSinUnidades
+      ? "Diferencia de unidades/formato"
+      : "Diferencia textual"
+  };
+}
+
+assert.equal(
+  Array.isArray(lineasDelegadas),
+  true,
+  "El bloque delegado debe retornar arreglo"
+);
+
+assert.equal(
+  lineasDelegadas.length,
+  7,
+  "El bloque delegado debe retornar 7 líneas"
+);
+
+assert.equal(
+  lineasOperativasReferencia.length,
+  7,
+  "El bloque operativo de referencia debe tener 7 líneas"
+);
+
+assert.equal(
+  lineasDelegadas[0],
+  "## 1. Identificación",
+  "El bloque delegado debe conservar el encabezado"
+);
+
+assert.equal(
+  lineasOperativasReferencia[0],
+  "## 1. Identificación",
+  "El bloque operativo debe conservar el encabezado"
+);
+
+assert.equal(
+  textoComparador.includes("## 1. Identificación"),
+  true,
+  "ComparadorMultiMetodo.jsx debe conservar el bloque operativo de Identificación"
+);
+
+assert.equal(
+  textoComparador.includes("construirLineasIdentificacionExpediente"),
+  true,
+  "ComparadorMultiMetodo.jsx debe conservar la integración diagnóstica delegada"
+);
+
+assert.equal(
+  textoComparador.includes("const textoExpediente = ["),
+  true,
+  "ComparadorMultiMetodo.jsx debe conservar el armado operativo de textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+const textoDelegado = lineasDelegadas.join("\n");
+const textoOperativo = lineasOperativasReferencia.join("\n");
+
+const residuosDelegado = residuosTecnicos.filter((token) =>
+  textoDelegado.includes(token)
+);
+
+const residuosOperativo = residuosTecnicos.filter((token) =>
+  textoOperativo.includes(token)
+);
+
+assert.equal(
+  residuosDelegado.length,
+  0,
+  "El bloque delegado no debe contener residuos técnicos"
+);
+
+assert.equal(
+  residuosOperativo.length,
+  0,
+  "El bloque operativo de referencia no debe contener residuos técnicos"
+);
+
+const comparacion = lineasDelegadas.map((lineaDelegada, indice) =>
+  compararLinea(indice, lineaDelegada, lineasOperativasReferencia[indice])
+);
+
+const diferenciasEstrictas = comparacion.filter((item) => !item.igualEstricta);
+
+const diferenciasTextualesFuertes = comparacion.filter(
+  (item) => !item.igualEstricta && !item.igualSinUnidades
+);
+
+const resumen = {
+  lineasDelegadas: lineasDelegadas.length,
+  lineasOperativas: lineasOperativasReferencia.length,
+  coincidenciasEstrictas: comparacion.filter((item) => item.igualEstricta).length,
+  diferenciasEstrictas: diferenciasEstrictas.length,
+  diferenciasTextualesFuertes: diferenciasTextualesFuertes.length,
+  residuosDelegado,
+  residuosOperativo,
+  textoExpedienteNoSustituido: textoComparador.includes("const textoExpediente = ["),
+  portapapelesSigueUsandoTextoExpediente: textoComparador.includes("areaTexto.value = textoExpediente"),
+  fallbackManualSigueUsandoTextoExpediente: textoComparador.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)")
+};
+
+const lineasReporte = [
+  "# OT-0126B — Comparación textual Identificación delegada vs operativa",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque delegado",
+  "",
+  "```text",
+  textoDelegado,
+  "```",
+  "",
+  "## Bloque operativo de referencia",
+  "",
+  "```text",
+  textoOperativo,
+  "```",
+  "",
+  "## Comparación línea a línea",
+  "",
+  "| Línea | Delegada | Operativa | Resultado |",
+  "|---:|---|---|---|",
+  ...comparacion.map((item) =>
+    `| ${item.linea} | \`${item.delegada}\` | \`${item.operativa}\` | ${item.diferencia} |`
+  ),
+  "",
+  "## Lectura técnica",
+  "",
+  diferenciasEstrictas.length === 0
+    ? "- El bloque delegado coincide estrictamente con el bloque operativo de referencia."
+    : "- El bloque delegado no coincide estrictamente con el bloque operativo de referencia.",
+  diferenciasTextualesFuertes.length === 0
+    ? "- Las diferencias detectadas son compatibles con formato/unidades, no con pérdida de contenido esencial."
+    : "- Existen diferencias textuales fuertes que requieren revisión antes de cualquier sustitución.",
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se reemplazó `textoExpediente`.",
+  "- No se modificó botón.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico.",
+  "",
+  "## Conclusión",
+  "",
+  "La comparación queda documentada para decidir, en una OT posterior, si procede ajustar el helper o adoptar parcialmente el bloque delegado."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("COMPARACION_OT_0126_IDENTIFICACION_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Comparar de forma controlada el bloque documental `## 1. Identificación` generado por la función delegada `construirLineasIdentificacionExpediente(...)` frente al bloque operativo actual construido manualmente dentro de `textoExpediente`.

## Antecedente

OT-0125 integró la función delegada dentro de `ComparadorMultiMetodo.jsx` como diagnóstico no invasivo, sin sustituir el bloque operativo.

La integración previa quedó validada mediante:

```text
VALIDACION_OT_0125D_IDENTIFICACION_DIAGNOSTICA_OK