### PR TITLE
OT-0127 — Formato con unidades en Identificación delegada

### DIFF
--- a/00_ADMIN/bitacora/OT-0127/OT-0127A_apertura_formato_unidades_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0127/OT-0127A_apertura_formato_unidades_identificacion.md
@@ -1,0 +1,63 @@
+# OT-0127A — Apertura de formato con unidades en Identificación delegada
+
+## Objetivo
+
+Ajustar la función delegada:
+
+`construirLineasIdentificacionExpediente(...)`
+
+para que las líneas numéricas del bloque `## 1. Identificación` emitan unidades compatibles con el bloque operativo actual.
+
+## Antecedente
+
+OT-0126 comparó el bloque delegado frente al bloque operativo y confirmó:
+
+- 7 líneas delegadas;
+- 7 líneas operativas;
+- 4 coincidencias estrictas;
+- 3 diferencias estrictas;
+- 0 diferencias textuales fuertes;
+- sin residuos técnicos;
+- `textoExpediente` no sustituido;
+- portapapeles y fallback manual siguen usando `textoExpediente`.
+
+Las 3 diferencias corresponden exclusivamente a unidades/formato:
+
+- Área: falta `km²`;
+- Pendiente media: falta `%`;
+- Longitud cauce principal: falta `km`.
+
+## Alcance
+
+Modificar únicamente el helper documental:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+para que emita:
+
+- `Área: 46.8516 km²`;
+- `Pendiente media: 8.43 %`;
+- `Longitud cauce principal: 15.524 km`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0127 se considera válida si:
+
+- la validación aislada OT-0124 sigue pasando;
+- la comparación OT-0126 pasa con coincidencia estricta completa;
+- el build Vite pasa;
+- `ComparadorMultiMetodo.jsx` queda sin cambios.

--- a/00_ADMIN/bitacora/OT-0127/OT-0127B_aplicacion_unidades_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0127/OT-0127B_aplicacion_unidades_identificacion.md
@@ -1,0 +1,45 @@
+# OT-0127B — Aplicación de unidades en Identificación delegada
+
+## Cambio aplicado
+
+Se ajustó la función:
+
+`construirLineasIdentificacionExpediente(...)`
+
+en:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+para que las líneas numéricas del bloque `## 1. Identificación` emitan unidades institucionales:
+
+- `Área: <valor> km²`;
+- `Pendiente media: <valor> %`;
+- `Longitud cauce principal: <valor> km`.
+
+## Justificación
+
+OT-0126 demostró que el bloque delegado y el bloque operativo eran equivalentes en contenido esencial, pero no estrictamente iguales por ausencia de unidades en tres líneas.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Resultado esperado
+
+La comparación OT-0126 debe pasar ahora con:
+
+- 7 líneas delegadas;
+- 7 líneas operativas;
+- 7 coincidencias estrictas;
+- 0 diferencias estrictas;
+- 0 diferencias textuales fuertes.

--- a/00_ADMIN/bitacora/OT-0127/OT-0127C_validacion_unidades_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0127/OT-0127C_validacion_unidades_identificacion.md
@@ -1,0 +1,37 @@
+# OT-0127C — Validación de unidades en Identificación delegada
+
+## Validaciones ejecutadas
+
+Se ejecutaron las siguientes validaciones:
+
+1. Validación aislada histórica OT-0124:
+
+`validar_ot0124_identificacion.mjs`
+
+2. Comparación textual OT-0126:
+
+`comparar_ot0126_identificacion_delegada_operativa.mjs`
+
+3. Validación específica OT-0127:
+
+`validar_ot0127_unidades_identificacion.mjs`
+
+## Resultado esperado
+
+La validación específica OT-0127 confirma que el bloque delegado emite:
+
+- `Área: 46.8516 km²`;
+- `Pendiente media: 8.43 %`;
+- `Longitud cauce principal: 15.524 km`.
+
+La comparación OT-0126 debe confirmar coincidencia estricta total frente al bloque operativo de referencia.
+
+## Restricciones verificadas
+
+Se verifica que:
+
+- `areaTexto.value` sigue usando `textoExpediente`;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se modifica `ComparadorMultiMetodo.jsx`;
+- no se sustituye el bloque operativo;
+- no se toca motor ni cálculos hidrológicos.

--- a/00_ADMIN/bitacora/OT-0127/OT-0127D_correccion_efectiva_unidades_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0127/OT-0127D_correccion_efectiva_unidades_identificacion.md
@@ -1,0 +1,44 @@
+# OT-0127D — Corrección efectiva de aplicación de unidades
+
+## Hallazgo
+
+La primera ejecución de OT-0127 no modificó realmente el helper documental.
+
+La evidencia fue:
+
+- `git diff` sobre `construirExpedienteHidrologicoMinimo.js` salió vacío;
+- `validar_ot0124_identificacion.mjs` seguía mostrando líneas sin unidades;
+- `comparar_ot0126_identificacion_delegada_operativa.mjs` seguía reportando 3 diferencias estrictas;
+- los scripts temporales de aplicación/validación quedaron corruptos por interpolación de plantillas durante el pegado.
+
+## Corrección aplicada
+
+Se reescribieron los scripts de OT-0127 para aplicar los cambios mediante expresiones regulares sobre el texto fuente del helper, evitando evaluación accidental de variables internas como `areaKm2`, `pendienteMediaPct` o `longitudCauceKm`.
+
+## Resultado esperado
+
+El helper debe emitir ahora:
+
+- `Área: 46.8516 km²`;
+- `Pendiente media: 8.43 %`;
+- `Longitud cauce principal: 15.524 km`.
+
+La comparación OT-0126 debe pasar con:
+
+- 7 coincidencias estrictas;
+- 0 diferencias estrictas;
+- 0 diferencias textuales fuertes.
+
+## Restricciones mantenidas
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0127/OT-0127E_cierre_unidades_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0127/OT-0127E_cierre_unidades_identificacion.md
@@ -1,0 +1,80 @@
+# OT-0127E — Cierre técnico de unidades en Identificación delegada
+
+## Resultado técnico
+
+OT-0127 corrigió efectivamente la función `construirLineasIdentificacionExpediente(...)` en:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+El bloque delegado `## 1. Identificación` emite ahora unidades institucionales:
+
+- `Área: 46.8516 km²`
+- `Pendiente media: 8.43 %`
+- `Longitud cauce principal: 15.524 km`
+
+## Validaciones aprobadas
+
+### OT-0124
+
+`VALIDACION_OT_0124_IDENTIFICACION_OK`
+
+Confirmó contexto completo y fallback sin residuos técnicos.
+
+### OT-0126
+
+`COMPARACION_OT_0126_IDENTIFICACION_OK`
+
+Resumen validado:
+
+```json
+{
+  "lineasDelegadas": 7,
+  "lineasOperativas": 7,
+  "coincidenciasEstrictas": 7,
+  "diferenciasEstrictas": 0,
+  "diferenciasTextualesFuertes": 0,
+  "residuosDelegado": [],
+  "residuosOperativo": [],
+  "textoExpedienteNoSustituido": true,
+  "portapapelesSigueUsandoTextoExpediente": true,
+  "fallbackManualSigueUsandoTextoExpediente": true
+}
+```
+
+### OT-0127
+
+`VALIDACION_OT_0127_UNIDADES_IDENTIFICACION_OK`
+
+Confirmó:
+
+- 7 líneas;
+- encabezado `## 1. Identificación`;
+- Área con `km²`;
+- Pendiente media con `%`;
+- Longitud cauce principal con `km`;
+- ausencia de `undefined`, `null`, `NaN` y `[object Object]`;
+- portapapeles sin sustitución de `textoExpediente`.
+
+### Build
+
+Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0127 deja el bloque Identificación delegado en coincidencia estricta con el formato operativo de referencia.
+
+No se sustituye todavía el bloque operativo dentro de `textoExpediente`; la adopción parcial queda para una OT posterior.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -157,19 +157,19 @@ export function construirLineasIdentificacionExpediente(entrada = {}) {
     `Cuenca: ${textoSeguro(nombreCuenca, "Cuenca activa")}`,
     `Área: ${
       Number.isFinite(areaKm2)
-        ? areaKm2.toFixed(4)
+        ? areaKm2.toFixed(4) + " km²"
         : "—"
     }`,
     `Fuente de contexto: ${textoSeguro(fuenteContexto, fuenteFallback)}`,
     `Estación IDF: ${textoSeguro(estacionIdf, estacionIdfFallback)}`,
     `Pendiente media: ${
       Number.isFinite(pendienteMediaPct)
-        ? pendienteMediaPct.toFixed(2)
+        ? pendienteMediaPct.toFixed(2) + " %"
         : "—"
     }`,
     `Longitud cauce principal: ${
       Number.isFinite(longitudCauceKm)
-        ? longitudCauceKm.toFixed(3)
+        ? longitudCauceKm.toFixed(3) + " km"
         : "—"
     }`
   ];

--- a/07_TOOLBOX/validaciones/aplicar_ot0127_formato_unidades_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0127_formato_unidades_identificacion.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaHelper = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+const textoOriginal = fs.readFileSync(rutaHelper, "utf8");
+
+const reemplazos = [
+  {
+    nombre: "Área con unidad km²",
+    antes: `    \`Área: ${
+      Number.isFinite(areaKm2)
+        ? areaKm2.toFixed(4)
+        : "—"
+    }\`,`,
+    despues: `    \`Área: ${
+      Number.isFinite(areaKm2)
+        ? areaKm2.toFixed(4) + " km²"
+        : "—"
+    }\`,`
+  },
+  {
+    nombre: "Pendiente media con unidad %",
+    antes: `    \`Pendiente media: ${
+      Number.isFinite(pendienteMediaPct)
+        ? pendienteMediaPct.toFixed(2)
+        : "—"
+    }\`,`,
+    despues: `    \`Pendiente media: ${
+      Number.isFinite(pendienteMediaPct)
+        ? pendienteMediaPct.toFixed(2) + " %"
+        : "—"
+    }\`,`
+  },
+  {
+    nombre: "Longitud cauce principal con unidad km",
+    antes: `    \`Longitud cauce principal: ${
+      Number.isFinite(longitudCauceKm)
+        ? longitudCauceKm.toFixed(3)
+        : "—"
+    }\``,
+    despues: `    \`Longitud cauce principal: ${
+      Number.isFinite(longitudCauceKm)
+        ? longitudCauceKm.toFixed(3) + " km"
+        : "—"
+    }\``
+  }
+];
+
+let textoActualizado = textoOriginal;
+
+for (const reemplazo of reemplazos) {
+  assert.equal(
+    textoActualizado.includes(reemplazo.antes),
+    true,
+    `No se encontró el bloque esperado para reemplazar: ${reemplazo.nombre}`
+  );
+
+  textoActualizado = textoActualizado.replace(reemplazo.antes, reemplazo.despues);
+}
+
+fs.writeFileSync(rutaHelper, textoActualizado, "utf8");
+
+console.log("APLICACION_OT_0127_UNIDADES_IDENTIFICACION_OK");

--- a/07_TOOLBOX/validaciones/aplicar_ot0127_formato_unidades_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0127_formato_unidades_identificacion.mjs
@@ -6,62 +6,36 @@ const rutaHelper = path.resolve(
   "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
 );
 
-const textoOriginal = fs.readFileSync(rutaHelper, "utf8");
+let texto = fs.readFileSync(rutaHelper, "utf8");
 
 const reemplazos = [
   {
     nombre: "Área con unidad km²",
-    antes: `    \`Área: ${
-      Number.isFinite(areaKm2)
-        ? areaKm2.toFixed(4)
-        : "—"
-    }\`,`,
-    despues: `    \`Área: ${
-      Number.isFinite(areaKm2)
-        ? areaKm2.toFixed(4) + " km²"
-        : "—"
-    }\`,`
+    patron: /`Área: \$\{\s*Number\.isFinite\(areaKm2\)\s*\?\s*areaKm2\.toFixed\(4\)\s*:\s*"—"\s*\}`/,
+    reemplazo: '`Área: ${\n      Number.isFinite(areaKm2)\n        ? areaKm2.toFixed(4) + " km²"\n        : "—"\n    }`'
   },
   {
     nombre: "Pendiente media con unidad %",
-    antes: `    \`Pendiente media: ${
-      Number.isFinite(pendienteMediaPct)
-        ? pendienteMediaPct.toFixed(2)
-        : "—"
-    }\`,`,
-    despues: `    \`Pendiente media: ${
-      Number.isFinite(pendienteMediaPct)
-        ? pendienteMediaPct.toFixed(2) + " %"
-        : "—"
-    }\`,`
+    patron: /`Pendiente media: \$\{\s*Number\.isFinite\(pendienteMediaPct\)\s*\?\s*pendienteMediaPct\.toFixed\(2\)\s*:\s*"—"\s*\}`/,
+    reemplazo: '`Pendiente media: ${\n      Number.isFinite(pendienteMediaPct)\n        ? pendienteMediaPct.toFixed(2) + " %"\n        : "—"\n    }`'
   },
   {
     nombre: "Longitud cauce principal con unidad km",
-    antes: `    \`Longitud cauce principal: ${
-      Number.isFinite(longitudCauceKm)
-        ? longitudCauceKm.toFixed(3)
-        : "—"
-    }\``,
-    despues: `    \`Longitud cauce principal: ${
-      Number.isFinite(longitudCauceKm)
-        ? longitudCauceKm.toFixed(3) + " km"
-        : "—"
-    }\``
+    patron: /`Longitud cauce principal: \$\{\s*Number\.isFinite\(longitudCauceKm\)\s*\?\s*longitudCauceKm\.toFixed\(3\)\s*:\s*"—"\s*\}`/,
+    reemplazo: '`Longitud cauce principal: ${\n      Number.isFinite(longitudCauceKm)\n        ? longitudCauceKm.toFixed(3) + " km"\n        : "—"\n    }`'
   }
 ];
 
-let textoActualizado = textoOriginal;
-
 for (const reemplazo of reemplazos) {
   assert.equal(
-    textoActualizado.includes(reemplazo.antes),
+    reemplazo.patron.test(texto),
     true,
-    `No se encontró el bloque esperado para reemplazar: ${reemplazo.nombre}`
+    `No se encontró patrón esperado para: ${reemplazo.nombre}`
   );
 
-  textoActualizado = textoActualizado.replace(reemplazo.antes, reemplazo.despues);
+  texto = texto.replace(reemplazo.patron, reemplazo.reemplazo);
 }
 
-fs.writeFileSync(rutaHelper, textoActualizado, "utf8");
+fs.writeFileSync(rutaHelper, texto, "utf8");
 
 console.log("APLICACION_OT_0127_UNIDADES_IDENTIFICACION_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0127_unidades_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0127_unidades_identificacion.mjs
@@ -1,13 +1,59 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import { construirLineasIdentificacionExpediente } 46.8516 km²"), true, "Debe incluir área con km²");
-assert.equal(texto.includes("Pendiente media: 8.43 %"), true, "Debe incluir pendiente con %");
-assert.equal(texto.includes("Longitud cauce principal: 15.524 km"), true, "Debe incluir longitud con km");
-assert.equal(texto.includes("undefined"), false, "No debe incluir undefined");
-assert.equal(texto.includes("null"), false, "No debe incluir null");
-assert.equal(texto.includes("NaN"), false, "No debe incluir NaN");
-assert.equal(texto.includes("[object Object]"), false, "No debe incluir [object Object]");
+import { construirLineasIdentificacionExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+
+const contextoBase = {
+  cuencaNombre: "Quebrada La Iguaná - PC_80",
+  area_km2: 46.8516,
+  pendiente_media_pct: 8.43,
+  longitud_cauce_km: 15.524,
+  fuente: "HidroFlow"
+};
+
+const lineas = construirLineasIdentificacionExpediente({
+  contextoBase,
+  fuenteFallback: "HidroFlow",
+  estacionIdfFallback: "SAN CRISTOBAL"
+});
+
+const texto = lineas.join("\n");
+
+assert.equal(Array.isArray(lineas), true, "Debe retornar arreglo");
+assert.equal(lineas.length, 7, "Debe retornar 7 líneas");
+assert.equal(lineas[0], "## 1. Identificación", "Debe conservar encabezado");
+
+assert.equal(
+  texto.includes("Área: 46.8516 km²"),
+  true,
+  "Debe incluir área con km²"
+);
+
+assert.equal(
+  texto.includes("Pendiente media: 8.43 %"),
+  true,
+  "Debe incluir pendiente con %"
+);
+
+assert.equal(
+  texto.includes("Longitud cauce principal: 15.524 km"),
+  true,
+  "Debe incluir longitud con km"
+);
+
+for (const token of ["undefined", "null", "NaN", "[object Object]"]) {
+  assert.equal(
+    texto.includes(token),
+    false,
+    `No debe incluir ${token}`
+  );
+}
 
 assert.equal(
   textoComparador.includes("areaTexto.value = textoExpediente"),

--- a/07_TOOLBOX/validaciones/validar_ot0127_unidades_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0127_unidades_identificacion.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { construirLineasIdentificacionExpediente } 46.8516 km²"), true, "Debe incluir área con km²");
+assert.equal(texto.includes("Pendiente media: 8.43 %"), true, "Debe incluir pendiente con %");
+assert.equal(texto.includes("Longitud cauce principal: 15.524 km"), true, "Debe incluir longitud con km");
+assert.equal(texto.includes("undefined"), false, "No debe incluir undefined");
+assert.equal(texto.includes("null"), false, "No debe incluir null");
+assert.equal(texto.includes("NaN"), false, "No debe incluir NaN");
+assert.equal(texto.includes("[object Object]"), false, "No debe incluir [object Object]");
+
+assert.equal(
+  textoComparador.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+console.log("VALIDACION_OT_0127_UNIDADES_IDENTIFICACION_OK");
+console.log(texto);


### PR DESCRIPTION
## Objetivo

Ajustar la función delegada `construirLineasIdentificacionExpediente(...)` para que el bloque documental `## 1. Identificación` emita unidades compatibles con el bloque operativo actual del expediente hidrológico mínimo.

## Antecedente

OT-0126 comparó el bloque Identificación delegado frente al bloque operativo actual y confirmó equivalencia de contenido esencial, pero no coincidencia estricta por diferencias de formato/unidades.

Resultado OT-0126 antes de esta corrección:

```json
{
  "lineasDelegadas": 7,
  "lineasOperativas": 7,
  "coincidenciasEstrictas": 4,
  "diferenciasEstrictas": 3,
  "diferenciasTextualesFuertes": 0
}