### PR TITLE
OT-0128 — Sustitución parcial del bloque Identificación por delegado

### DIFF
--- a/00_ADMIN/bitacora/OT-0128/OT-0128A_apertura_sustitucion_identificacion_delegada.md
+++ b/00_ADMIN/bitacora/OT-0128/OT-0128A_apertura_sustitucion_identificacion_delegada.md
@@ -1,0 +1,52 @@
+# OT-0128A — Apertura de sustitución parcial controlada Identificación delegada
+
+## Objetivo
+
+Sustituir únicamente las 7 líneas operativas del bloque `## 1. Identificación` dentro de `textoExpediente` por el resultado de la función delegada:
+
+`construirLineasIdentificacionExpediente(...)`
+
+## Antecedente
+
+OT-0124 validó aisladamente la función pura.
+
+OT-0125 integró la función como diagnóstico no invasivo.
+
+OT-0126 comparó el bloque delegado frente al operativo.
+
+OT-0127 ajustó el formato con unidades hasta lograr coincidencia estricta:
+
+- 7 líneas delegadas;
+- 7 líneas operativas;
+- 7 coincidencias estrictas;
+- 0 diferencias estrictas;
+- 0 diferencias textuales fuertes.
+
+## Alcance
+
+Esta OT sustituye solo el bloque `## 1. Identificación` dentro del arreglo `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0128 se considera válida si:
+
+- `textoExpediente` sigue existiendo;
+- el bloque Identificación se arma mediante `construirLineasIdentificacionExpediente(...)`;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no aparece `navigator.clipboard`;
+- no aparece `writeText`;
+- validaciones OT-0124, OT-0126 y OT-0127 pasan;
+- build Vite pasa.

--- a/00_ADMIN/bitacora/OT-0128/OT-0128B_sustitucion_parcial_identificacion_delegada.md
+++ b/00_ADMIN/bitacora/OT-0128/OT-0128B_sustitucion_parcial_identificacion_delegada.md
@@ -1,0 +1,31 @@
+# OT-0128B — Sustitución parcial controlada del bloque Identificación
+
+## Cambio aplicado
+
+Se sustituyeron únicamente las 7 líneas manuales del bloque `## 1. Identificación` dentro de `textoExpediente` por una expansión del bloque delegado:
+
+```javascript
+...construirLineasIdentificacionExpediente({
+  contextoBase,
+  fuenteFallback: "HidroFlow",
+  estacionIdfFallback: estacionIdfExpediente
+}),
+```
+
+## Alcance del cambio
+
+La sustitución se limitó al bloque Identificación.
+
+No se modificó:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Nota técnica
+
+El bloque delegado ya había sido validado en OT-0127 con coincidencia estricta frente al bloque operativo de referencia.

--- a/00_ADMIN/bitacora/OT-0128/OT-0128C_cierre_sustitucion_identificacion_delegada.md
+++ b/00_ADMIN/bitacora/OT-0128/OT-0128C_cierre_sustitucion_identificacion_delegada.md
@@ -1,0 +1,48 @@
+# OT-0128C — Validación y cierre de sustitución parcial Identificación
+
+## Resultado
+
+Se sustituyó parcialmente el bloque `## 1. Identificación` dentro de `textoExpediente` por el bloque delegado generado con `construirLineasIdentificacionExpediente(...)`.
+
+## Cambio aplicado
+
+Las 7 líneas manuales del bloque Identificación fueron reemplazadas por:
+
+```javascript
+...construirLineasIdentificacionExpediente({
+  contextoBase,
+  fuenteFallback: "HidroFlow",
+  estacionIdfFallback: estacionIdfExpediente
+}),
+```
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0128_SUSTITUCION_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0124_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0127_UNIDADES_IDENTIFICACION_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Verificaciones clave
+
+`areaTexto.value = textoExpediente` sigue intacto.
+
+`window.prompt(..., textoExpediente)` sigue intacto.
+
+No se introdujo `navigator.clipboard` ni `writeText`.
+
+## Conclusión
+
+El bloque Identificación queda adoptado parcialmente desde el helper delegado, manteniendo el resto del expediente operativo sin sustituciones adicionales.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2046,13 +2046,11 @@ const handleClickSeguro = (accion) => () => {
             "Lectura técnica: expediente exportable completo, con controles internos presentes, no adoptivo y sujeto a revisión hidrológica profesional.",
             "Alcance: estado textual/exportable; no recalcula resultados ni reemplaza criterio profesional.",
             "",
-            "## 1. Identificación",
-            `Cuenca: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}`,
-            `Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`,
-            `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
-            `Estación IDF: ${estacionIdfExpediente}`,
-            `Pendiente media: ${Number.isFinite(Number(contextoBase?.pendiente_media_pct)) ? Number(contextoBase.pendiente_media_pct).toFixed(2) + " %" : "—"}`,
-            `Longitud cauce principal: ${Number.isFinite(Number(contextoBase?.longitud_cauce_km)) ? Number(contextoBase.longitud_cauce_km).toFixed(3) + " km" : "—"}`,
+            ...construirLineasIdentificacionExpediente({
+              contextoBase,
+              fuenteFallback: "HidroFlow",
+              estacionIdfFallback: estacionIdfExpediente
+            }),
             "",
             "## 2. Parámetros hidrológicos base",
             `CN: ${contextoBase?.CN ?? "—"}`,

--- a/07_TOOLBOX/validaciones/validar_ot0128_sustitucion_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0128_sustitucion_identificacion.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe mantenerse el arreglo textoExpediente"
+);
+
+assert.equal(
+  texto.includes("...construirLineasIdentificacionExpediente({"),
+  true,
+  "El bloque Identificación debe usar expansión delegada"
+);
+
+assert.equal(
+  texto.includes("contextoBase,"),
+  true,
+  "La sustitución delegada debe pasar contextoBase"
+);
+
+assert.equal(
+  texto.includes('fuenteFallback: "HidroFlow"'),
+  true,
+  "La sustitución delegada debe conservar fuenteFallback"
+);
+
+assert.equal(
+  texto.includes("estacionIdfFallback: estacionIdfExpediente"),
+  true,
+  "La sustitución delegada debe pasar estacionIdfExpediente como fallback"
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard"
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText"
+);
+
+assert.equal(
+  texto.includes('`Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`'),
+  false,
+  "La línea manual de Área ya no debe estar en textoExpediente"
+);
+
+assert.equal(
+  texto.includes('`Pendiente media: ${Number.isFinite(Number(contextoBase?.pendiente_media_pct)) ? Number(contextoBase.pendiente_media_pct).toFixed(2) + " %" : "—"}`'),
+  false,
+  "La línea manual de Pendiente media ya no debe estar en textoExpediente"
+);
+
+assert.equal(
+  texto.includes('`Longitud cauce principal: ${Number.isFinite(Number(contextoBase?.longitud_cauce_km)) ? Number(contextoBase.longitud_cauce_km).toFixed(3) + " km" : "—"}`'),
+  false,
+  "La línea manual de Longitud cauce principal ya no debe estar en textoExpediente"
+);
+
+console.log("VALIDACION_OT_0128_SUSTITUCION_IDENTIFICACION_OK");


### PR DESCRIPTION
## Objetivo

Sustituir únicamente las 7 líneas operativas del bloque documental `## 1. Identificación` dentro de `textoExpediente` por el bloque delegado generado mediante:

```javascript
construirLineasIdentificacionExpediente(...)