### PR TITLE
OT-0129 — Validación post-adopción del bloque Identificación delegado

### DIFF
--- a/00_ADMIN/bitacora/OT-0129/OT-0129A_apertura_validacion_post_adopcion_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0129/OT-0129A_apertura_validacion_post_adopcion_identificacion.md
@@ -1,0 +1,50 @@
+# OT-0129A — Apertura de validación post-adopción Identificación delegada
+
+## Objetivo
+
+Validar que, después de OT-0128, el expediente operativo mantiene correctamente el bloque `## 1. Identificación` adoptado desde el helper delegado.
+
+## Antecedente
+
+OT-0128 sustituyó únicamente las 7 líneas manuales del bloque Identificación dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasIdentificacionExpediente({
+  contextoBase,
+  fuenteFallback: "HidroFlow",
+  estacionIdfFallback: estacionIdfExpediente
+}),
+```
+
+## Alcance
+
+Esta OT valida la adopción parcial ya aplicada. No sustituye nuevos bloques.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0129 se considera válida si:
+
+- `textoExpediente` sigue existiendo;
+- el bloque Identificación está delegado;
+- las líneas manuales antiguas no reaparecen;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no aparece `navigator.clipboard`;
+- no aparece `writeText`;
+- validaciones OT-0128, OT-0124 y OT-0127 pasan;
+- build Vite pasa;
+- `ComparadorMultiMetodo.jsx` no se modifica en esta OT.

--- a/00_ADMIN/bitacora/OT-0129/OT-0129B_cierre_validacion_post_adopcion_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0129/OT-0129B_cierre_validacion_post_adopcion_identificacion.md
@@ -1,0 +1,43 @@
+# OT-0129B — Cierre de validación post-adopción Identificación delegada
+
+## Resultado
+
+Se validó que el expediente operativo mantiene correctamente el bloque `## 1. Identificación` adoptado desde el helper delegado.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0129_POST_ADOPCION_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0128_SUSTITUCION_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0124_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0127_UNIDADES_IDENTIFICACION_OK`;
+- Build Vite aprobado.
+
+## Verificaciones confirmadas
+
+- `textoExpediente` sigue existiendo;
+- el bloque Identificación se arma mediante `construirLineasIdentificacionExpediente(...)`;
+- no reaparecen las líneas manuales antiguas del bloque Identificación;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introdujo `navigator.clipboard`;
+- no se introdujo `writeText`.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0129 confirma que la adopción parcial del bloque Identificación delegado quedó operativamente estable.
+
+No se sustituyen nuevos bloques en esta OT.

--- a/07_TOOLBOX/validaciones/validar_ot0129_post_adopcion_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0129_post_adopcion_identificacion.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const tieneTextoExpediente = texto.includes("const textoExpediente = [");
+const usaBloqueDelegado = texto.includes("...construirLineasIdentificacionExpediente({");
+const pasaContextoBase = texto.includes("contextoBase,");
+const pasaFuenteFallback = texto.includes('fuenteFallback: "HidroFlow"');
+const pasaEstacionFallback = texto.includes("estacionIdfFallback: estacionIdfExpediente");
+
+const portapapelesIntacto = texto.includes("areaTexto.value = textoExpediente");
+
+const fallbackManualIntacto = texto.includes(
+  "window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"
+);
+
+const sinNavigatorClipboard = !texto.includes("navigator.clipboard");
+const sinWriteText = !texto.includes("writeText");
+
+const lineasManualesAntiguas = [
+  '`Área: ${Number.isFinite(areaKm2) ? areaKm2.toFixed(4) + " km²" : "—"}`',
+  '`Pendiente media: ${Number.isFinite(Number(contextoBase?.pendiente_media_pct)) ? Number(contextoBase.pendiente_media_pct).toFixed(2) + " %" : "—"}`',
+  '`Longitud cauce principal: ${Number.isFinite(Number(contextoBase?.longitud_cauce_km)) ? Number(contextoBase.longitud_cauce_km).toFixed(3) + " km" : "—"}`'
+];
+
+const lineasManualesDetectadas = lineasManualesAntiguas.filter((linea) =>
+  texto.includes(linea)
+);
+
+assert.equal(tieneTextoExpediente, true, "Debe existir const textoExpediente = [");
+assert.equal(usaBloqueDelegado, true, "Debe usarse construirLineasIdentificacionExpediente como bloque delegado");
+assert.equal(pasaContextoBase, true, "Debe pasarse contextoBase al helper delegado");
+assert.equal(pasaFuenteFallback, true, "Debe conservarse fuenteFallback HidroFlow");
+assert.equal(pasaEstacionFallback, true, "Debe pasarse estacionIdfExpediente como fallback");
+assert.equal(portapapelesIntacto, true, "El portapapeles debe seguir usando textoExpediente");
+assert.equal(fallbackManualIntacto, true, "El fallback manual debe seguir usando textoExpediente");
+assert.equal(sinNavigatorClipboard, true, "No debe introducirse navigator.clipboard");
+assert.equal(sinWriteText, true, "No debe introducirse writeText");
+assert.equal(lineasManualesDetectadas.length, 0, "No deben reaparecer las líneas manuales antiguas del bloque Identificación");
+
+const resumen = {
+  tieneTextoExpediente,
+  usaBloqueDelegado,
+  pasaContextoBase,
+  pasaFuenteFallback,
+  pasaEstacionFallback,
+  portapapelesIntacto,
+  fallbackManualIntacto,
+  sinNavigatorClipboard,
+  sinWriteText,
+  lineasManualesDetectadas
+};
+
+console.log("VALIDACION_OT_0129_POST_ADOPCION_IDENTIFICACION_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Validar que, después de OT-0128, el expediente operativo mantiene correctamente el bloque `## 1. Identificación` adoptado desde el helper delegado `construirLineasIdentificacionExpediente(...)`.

## Antecedente

OT-0128 sustituyó únicamente las 7 líneas manuales del bloque Identificación dentro de `textoExpediente` por:

```javascript
...construirLineasIdentificacionExpediente({
  contextoBase,
  fuenteFallback: "HidroFlow",
  estacionIdfFallback: estacionIdfExpediente
}),