### PR TITLE
OT-0130C — Saneamiento documental de auditoría Parámetros base

### DIFF
--- a/00_ADMIN/bitacora/OT-0130/OT-0130B_auditoria_bloque_parametros_hidrologicos_base.md
+++ b/00_ADMIN/bitacora/OT-0130/OT-0130B_auditoria_bloque_parametros_hidrologicos_base.md
@@ -2,7 +2,7 @@
 
 ## Resumen
 
-`json
+```json
 {
   "bloqueEncontrado": true,
   "lineaInicio": 2055,
@@ -15,128 +15,35 @@
   "comparadorModificado": false,
   "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
 }
-`"
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} += "
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} += 
+```
 
-`jsx
+## Bloque auditado
+
+```jsx
  2055 |             "## 2. Parámetros hidrológicos base",
  2056 |             `CN: ${contextoBase?.CN ?? "—"}`,
  2057 |             `CN base: ${contextoBase?.CN_base ?? "—"}`,
  2058 |             `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,
  2059 |             `AMC: ${contextoBase?.AMC ?? "—"}`,
  2060 |             "",
-`"
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} `"
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} += "
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} +=   `jsx  2055 |             "## 2. Parámetros hidrológicos base",  2056 |             `CN: ${contextoBase?.CN ?? "—"}`,  2057 |             `CN base: ${contextoBase?.CN_base ?? "—"}`,  2058 |             `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,  2059 |             `AMC: ${contextoBase?.AMC ?? "—"}`,  2060 |             "", += "
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} `"
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} += "
-# OT-0130B — Auditoría del bloque Parámetros hidrológicos base  ## Resumen  `json {
-  "bloqueEncontrado": true,
-  "lineaInicio": 2055,
-  "lineaFinAntesDeBloque3": 2060,
-  "lineasAuditadas": 6,
-  "totalEncabezados": 1,
-  "totalDocumentales": 1,
-  "totalSensibles": 4,
-  "totalSeparadores": 0,
-  "comparadorModificado": false,
-  "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar campos sensibles antes de implementar helper."
-} +=   `jsx  2055 |             "## 2. Parámetros hidrológicos base",  2056 |             `CN: ${contextoBase?.CN ?? "—"}`,  2057 |             `CN base: ${contextoBase?.CN_base ?? "—"}`,  2058 |             `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,  2059 |             `AMC: ${contextoBase?.AMC ?? "—"}`,  2060 |             "", += 
+```
+
+## Clasificación línea a línea
 
 | Línea | Clasificación | Contenido |
 |---:|---|---|
-            "## 2. Parámetros hidrológicos base",
-            `CN: ${contextoBase?.CN ?? "—"}`,
-            `CN base: ${contextoBase?.CN_base ?? "—"}`,
-            `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,
-            `AMC: ${contextoBase?.AMC ?? "—"}`,
-            "",
-`",
-  ",
-  
+| 2055 | encabezado documental | `"## 2. Parámetros hidrológicos base",` |
+| 2056 | técnicamente sensible | `` `CN: ${contextoBase?.CN ?? "—"}`, `` |
+| 2057 | técnicamente sensible | `` `CN base: ${contextoBase?.CN_base ?? "—"}`, `` |
+| 2058 | técnicamente sensible | `` `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`, `` |
+| 2059 | técnicamente sensible | `` `AMC: ${contextoBase?.AMC ?? "—"}`, `` |
+| 2060 | documental / contextual | `"",` |
 
-- El bloque ## 2. Parámetros hidrológicos base contiene campos hidrológicos sensibles o potencialmente sensibles.
-- Entre los campos a tratar con cautela están CN, CN base, CN efectivo, AMC y lluvia efectiva.
-- Por tanto, no conviene delegar el bloque completo sin contrato documental previo.
+## Lectura técnica
+
+- El bloque contiene campos hidrológicamente sensibles.
+- Los campos sensibles identificados son `CN`, `CN base`, `CN efectivo` y `AMC`.
+- No conviene delegar el bloque completo sin contrato documental previo.
 
 ## Decisión preliminar
 
@@ -144,8 +51,8 @@ No delegar completo todavía. Conviene definir contrato documental y separar cam
 
 ## Restricciones mantenidas
 
-- No se modificó ComparadorMultiMetodo.jsx.
-- No se sustituyó 	extoExpediente.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se sustituyó `textoExpediente`.
 - No se modificó botón.
 - No se modificó portapapeles.
 - No se tocó Q-5.
@@ -156,4 +63,4 @@ No delegar completo todavía. Conviene definir contrato documental y separar cam
 
 ## Siguiente paso recomendado
 
-Abrir una OT posterior para definir el contrato documental del bloque ## 2. Parámetros hidrológicos base, separando campos puramente documentales de campos hidrológicamente sensibles.
+Abrir una OT posterior para definir el contrato documental del bloque `## 2. Parámetros hidrológicos base`, separando campos puramente documentales de campos hidrológicamente sensibles.


### PR DESCRIPTION
## Objetivo

Sanear documentalmente la bitácora:

`00_ADMIN/bitacora/OT-0130/OT-0130B_auditoria_bloque_parametros_hidrologicos_base.md`

## Motivo

Durante la generación original de OT-0130B quedaron residuos de PowerShell en el Markdown, incluyendo fragmentos de concatenación, backticks mal cerrados y contenido repetido.

La auditoría técnica era válida en intención, pero la evidencia documental necesitaba limpieza antes de servir como base para OT-0131.

## Cambio aplicado

Se reescribió únicamente la bitácora OT-0130B con estructura Markdown limpia:

- resumen JSON válido;
- bloque auditado legible;
- clasificación línea a línea;
- lectura técnica;
- decisión preliminar;
- restricciones mantenidas;
- siguiente paso recomendado.

## Bloque auditado

```text
## 2. Parámetros hidrológicos base
CN
CN base
CN efectivo
AMC