### PR TITLE
OT-0131 — Contrato documental del bloque Parámetros hidrológicos base

### DIFF
--- a/00_ADMIN/bitacora/OT-0131/OT-0131A_apertura_contrato_parametros_hidrologicos_base.md
+++ b/00_ADMIN/bitacora/OT-0131/OT-0131A_apertura_contrato_parametros_hidrologicos_base.md
@@ -1,0 +1,52 @@
+# OT-0131A — Apertura de contrato documental Parámetros hidrológicos base
+
+## Objetivo
+
+Definir el contrato documental del bloque `## 2. Parámetros hidrológicos base` antes de cualquier helper, integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0130 seleccionó y auditó el bloque `## 2. Parámetros hidrológicos base`.
+
+OT-0130C saneó la auditoría OT-0130B, dejando evidencia documental limpia.
+
+La auditoría confirmó que el bloque contiene campos hidrológicamente sensibles:
+
+- `CN`;
+- `CN base`;
+- `CN efectivo`;
+- `AMC`.
+
+## Alcance
+
+Esta OT solo define contrato documental.
+
+No implementa helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica principal
+
+No recalcular.
+
+No inferir.
+
+No derivar.
+
+Solo representar valores ya presentes en `contextoBase`.

--- a/00_ADMIN/bitacora/OT-0131/OT-0131B_contrato_parametros_hidrologicos_base.md
+++ b/00_ADMIN/bitacora/OT-0131/OT-0131B_contrato_parametros_hidrologicos_base.md
@@ -1,0 +1,78 @@
+# OT-0131B — Contrato documental del bloque Parámetros hidrológicos base
+
+## Bloque contractual
+
+```text
+## 2. Parámetros hidrológicos base
+CN: <valor | —>
+CN base: <valor | —>
+CN efectivo: <valor | —>
+AMC: <valor | —>
+```
+
+## Orden obligatorio
+
+1. Encabezado `## 2. Parámetros hidrológicos base`;
+2. `CN`;
+3. `CN base`;
+4. `CN efectivo`;
+5. `AMC`;
+6. línea separadora posterior.
+
+## Campos contractuales
+
+| Campo | Fuente esperada | Fallback | Recalcular | Inferir | Derivar | Formato |
+|---|---|---|---|---|---|---|
+| `CN` | `contextoBase.CN` | `—` | No | No | No | Literal |
+| `CN base` | `contextoBase.CN_base` | `—` | No | No | No | Literal |
+| `CN efectivo` | `contextoBase.CN_efectivo` | `—` | No | No | No | Literal |
+| `AMC` | `contextoBase.AMC` | `—` | No | No | No | Literal |
+
+## Reglas de representación
+
+- Si el valor existe en `contextoBase`, se representa literalmente.
+- Si el valor no existe, se representa `—`.
+- No se deben convertir unidades.
+- No se deben aplicar redondeos nuevos.
+- No se deben calcular valores faltantes.
+- No se deben completar valores por defecto técnico.
+- No se deben usar valores de otros módulos como sustitutos.
+- No se debe consultar el motor hidrológico.
+- No se debe modificar estado.
+
+## Residuos prohibidos
+
+El bloque no debe emitir:
+
+- `undefined`;
+- `null`;
+- `NaN`;
+- `[object Object]`.
+
+## Ejemplo con contexto completo
+
+```text
+## 2. Parámetros hidrológicos base
+CN: 88
+CN base: 82
+CN efectivo: 88
+AMC: II
+```
+
+## Ejemplo con contexto fallback
+
+```text
+## 2. Parámetros hidrológicos base
+CN: —
+CN base: —
+CN efectivo: —
+AMC: —
+```
+
+## Decisión contractual
+
+El bloque puede avanzar a diseño de helper puro en una OT posterior, siempre que el helper sea estrictamente representacional.
+
+## Próxima OT recomendada
+
+`OT-0132 — Diseño de función pura Parámetros hidrológicos base`


### PR DESCRIPTION
## Objetivo

Definir el contrato documental del bloque `## 2. Parámetros hidrológicos base` antes de cualquier helper, integración diagnóstica o sustitución.

## Antecedente

OT-0130 seleccionó y auditó el bloque `## 2. Parámetros hidrológicos base` como siguiente candidato documental.

OT-0130C saneó documentalmente la auditoría OT-0130B, dejando evidencia limpia para avanzar al contrato.

La auditoría confirmó que el bloque contiene campos hidrológicamente sensibles:

- `CN`;
- `CN base`;
- `CN efectivo`;
- `AMC`.

## Trabajo realizado

Se documentó el contrato del bloque con:

- bloque contractual esperado;
- orden obligatorio;
- fuente esperada por campo;
- fallback permitido;
- prohibición de recalcular;
- prohibición de inferir;
- prohibición de derivar;
- formato literal;
- reglas de representación;
- residuos prohibidos;
- ejemplo con contexto completo;
- ejemplo con contexto fallback;
- decisión contractual para avanzar a helper puro en una OT posterior.

## Regla técnica central

```text
No recalcular.
No inferir.
No derivar.
Solo representar valores ya presentes en contextoBase.