### PR TITLE
OT-0134 — Validación aislada reforzada del helper Parámetros hidrológicos base

### DIFF
--- a/00_ADMIN/bitacora/OT-0134/OT-0134A_apertura_validacion_reforzada_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0134/OT-0134A_apertura_validacion_reforzada_parametros_base.md
@@ -1,0 +1,49 @@
+# OT-0134A — Apertura de validación reforzada helper Parámetros hidrológicos base
+
+## Objetivo
+
+Validar de forma aislada y reforzada el helper puro `construirLineasParametrosHidrologicosBaseExpediente(...)` antes de cualquier integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0133 implementó el helper puro representacional para el bloque `## 2. Parámetros hidrológicos base`.
+
+La validación inicial confirmó contexto completo, fallback y contexto directo.
+
+## Alcance
+
+Esta OT solo refuerza la validación aislada.
+
+No modifica el helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No integra en UI.
+
+No sustituye `textoExpediente`.
+
+## Casos borde a validar
+
+- `CN: 0`;
+- `CN: ""`;
+- `CN: NaN`;
+- `CN_base: null`;
+- `CN_efectivo: object`;
+- `AMC: ""`;
+- `AMC: "III"`;
+- `contextoBase` ausente;
+- contexto directo.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0134/OT-0134B_cierre_validacion_reforzada_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0134/OT-0134B_cierre_validacion_reforzada_parametros_base.md
@@ -1,0 +1,42 @@
+# OT-0134B — Cierre de validación reforzada helper Parámetros hidrológicos base
+
+## Resultado
+
+Se reforzó la validación aislada del helper `construirLineasParametrosHidrologicosBaseExpediente(...)`.
+
+## Casos validados
+
+- `CN: 0`;
+- `CN: ""`;
+- `CN: NaN`;
+- `CN_base: null`;
+- `CN_efectivo: object`;
+- `AMC: ""`;
+- `AMC: "III"`;
+- `contextoBase` ausente;
+- contexto directo.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK`;
+- `VALIDACION_OT_0133_HELPER_PARAMETROS_BASE_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Parámetros hidrológicos base queda reforzado frente a casos borde, manteniendo comportamiento estrictamente representacional.

--- a/00_ADMIN/bitacora/OT-0134/OT-0134C_correccion_validacion_reforzada_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0134/OT-0134C_correccion_validacion_reforzada_parametros_base.md
@@ -1,0 +1,46 @@
+# OT-0134C — Corrección y cierre validación reforzada helper Parámetros hidrológicos base
+
+## Hallazgo
+
+La primera versión del script de validación reforzada quedó incompleta por corte de pegado y produjo un error de sintaxis.
+
+## Corrección aplicada
+
+Se reescribió `validar_ot0134_helper_parametros_base_reforzada.mjs` con una matriz explícita de casos borde.
+
+## Casos validados
+
+- `CN: 0`;
+- `CN: ""`;
+- `CN: NaN`;
+- `CN_base: null`;
+- `CN_efectivo: object`;
+- `AMC: ""`;
+- `AMC: "III"`;
+- `contextoBase` ausente;
+- contexto directo.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK`;
+- `VALIDACION_OT_0133_HELPER_PARAMETROS_BASE_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Parámetros hidrológicos base queda reforzado frente a casos borde, manteniendo comportamiento estrictamente representacional.

--- a/07_TOOLBOX/validaciones/validar_ot0134_helper_parametros_base_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0134_helper_parametros_base_reforzada.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { construirLineasParametrosHidrologicosBaseExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function textoDe(lineas) {
+  return lineas.join("\n");
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas.length, 5, `${nombreCaso}: debe retornar 5 líneas`);
+  assert.equal(lineas[0], "## 2. Parámetros hidrológicos base", `${nombreCaso}: debe conservar encabezado`);
+}
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarTexto(nombreCaso, entrada, esperados) {
+  const lineas = construirLineasParametrosHidrologicosBaseExpediente(entrada);
+  const texto = textoDe(lineas);
+
+  validarEstructura(nombreCaso, lineas);
+  validarSinResiduos(nombreCaso, texto);
+
+  for (const esperado of esperados) {
+    assert.equal(
+      texto.includes(esperado),
+      true,
+      `${nombreCaso}: debe incluir ${esperado}`
+    );
+  }
+
+  console.log(`OK ${nombreCaso}`);
+  console.log(texto);
+}
+
+validarTexto(
+  "CN cero",
+  {
+    contextoBase: {
+      CN: 0,
+      CN_base: 82,
+      CN_efectivo: 88,
+      AMC: "II"
+    }
+  },
+  [
+    "CN: 0",
+    "CN base: 82",
+    "CN efectivo: 88",
+    "AMC: II"
+  ]
+);
+
+validarTexto(
+  "CN vacio",
+  {
+    contextoBase: {
+      CN: "",
+      CN_base: 82,
+      CN_efectivo: 88,
+      AMC: "II"
+    }
+  },
+  [
+    "CN: —",
+    "CN base: 82",
+    "CN efectivo: 88",
+    "AMC: II"
+  ]
+);
+
+validarTexto(
+  "CN NaN",
+  {
+    contextoBase: {
+      CN: Number.NaN,
+      CN_base: 82,
+      CN_efectivo: 88,
+      AMC: "II"
+    }
+  },
+  [
+    "CN: —",
+    "CN base: 82",
+    "CN efectivo: 88",
+    "AMC: II"
+  ]
+);
+
+validarTexto(
+  "CN_base null",
+  {
+    contextoBase: {
+      CN: 88,
+      CN_base: null,
+      CN_efectivo: 88,
+      AMC: "II"
+    }
+  },
+  [
+    "CN: 88",
+    "CN base: —",
+    "CN efectivo: 88",
+    "AMC: II"
+  ]
+);
+  "contexto directo",
+  {
+    CN: 91,
+    CN_base: 85,
+    CN_efectivo: 92,
+    AMC: "I"
+  },
+  [
+    "CN: 91",
+    "CN base: 85",
+    "CN efectivo: 92",
+    "AMC: I"
+  ]
+);
+
+console.log("VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0134_helper_parametros_base_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0134_helper_parametros_base_reforzada.mjs
@@ -3,16 +3,6 @@ import { construirLineasParametrosHidrologicosBaseExpediente } from "../../01_AP
 
 const residuos = ["undefined", "null", "NaN", "[object Object]"];
 
-function textoDe(lineas) {
-  return lineas.join("\n");
-}
-
-function validarEstructura(nombreCaso, lineas) {
-  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
-  assert.equal(lineas.length, 5, `${nombreCaso}: debe retornar 5 líneas`);
-  assert.equal(lineas[0], "## 2. Parámetros hidrológicos base", `${nombreCaso}: debe conservar encabezado`);
-}
-
 function validarSinResiduos(nombreCaso, texto) {
   const detectados = residuos.filter((token) => texto.includes(token));
 
@@ -23,9 +13,19 @@ function validarSinResiduos(nombreCaso, texto) {
   );
 }
 
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas.length, 5, `${nombreCaso}: debe retornar 5 líneas`);
+  assert.equal(
+    lineas[0],
+    "## 2. Parámetros hidrológicos base",
+    `${nombreCaso}: debe conservar encabezado`
+  );
+}
+
 function validarTexto(nombreCaso, entrada, esperados) {
   const lineas = construirLineasParametrosHidrologicosBaseExpediente(entrada);
-  const texto = textoDe(lineas);
+  const texto = lineas.join("\n");
 
   validarEstructura(nombreCaso, lineas);
   validarSinResiduos(nombreCaso, texto);
@@ -42,90 +42,110 @@ function validarTexto(nombreCaso, entrada, esperados) {
   console.log(texto);
 }
 
-validarTexto(
-  "CN cero",
+const casos = [
   {
-    contextoBase: {
-      CN: 0,
-      CN_base: 82,
-      CN_efectivo: 88,
-      AMC: "II"
-    }
+    nombre: "CN cero",
+    entrada: {
+      contextoBase: {
+        CN: 0,
+        CN_base: 82,
+        CN_efectivo: 88,
+        AMC: "II"
+      }
+    },
+    esperados: ["CN: 0", "CN base: 82", "CN efectivo: 88", "AMC: II"]
   },
-  [
-    "CN: 0",
-    "CN base: 82",
-    "CN efectivo: 88",
-    "AMC: II"
-  ]
-);
+  {
+    nombre: "CN vacio",
+    entrada: {
+      contextoBase: {
+        CN: "",
+        CN_base: 82,
+        CN_efectivo: 88,
+        AMC: "II"
+      }
+    },
+    esperados: ["CN: —", "CN base: 82", "CN efectivo: 88", "AMC: II"]
+  },
+  {
+    nombre: "CN NaN",
+    entrada: {
+      contextoBase: {
+        CN: Number.NaN,
+        CN_base: 82,
+        CN_efectivo: 88,
+        AMC: "II"
+      }
+    },
+    esperados: ["CN: —", "CN base: 82", "CN efectivo: 88", "AMC: II"]
+  },
+  {
+    nombre: "CN_base null",
+    entrada: {
+      contextoBase: {
+        CN: 88,
+        CN_base: null,
+        CN_efectivo: 88,
+        AMC: "II"
+      }
+    },
+    esperados: ["CN: 88", "CN base: —", "CN efectivo: 88", "AMC: II"]
+  },
+  {
+    nombre: "CN_efectivo objeto",
+    entrada: {
+      contextoBase: {
+        CN: 88,
+        CN_base: 82,
+        CN_efectivo: { valor: 88 },
+        AMC: "II"
+      }
+    },
+    esperados: ["CN: 88", "CN base: 82", "CN efectivo: —", "AMC: II"]
+  },
+  {
+    nombre: "AMC vacio",
+    entrada: {
+      contextoBase: {
+        CN: 88,
+        CN_base: 82,
+        CN_efectivo: 88,
+        AMC: ""
+      }
+    },
+    esperados: ["CN: 88", "CN base: 82", "CN efectivo: 88", "AMC: —"]
+  },
+  {
+    nombre: "AMC III",
+    entrada: {
+      contextoBase: {
+        CN: 90,
+        CN_base: 84,
+        CN_efectivo: 91,
+        AMC: "III"
+      }
+    },
+    esperados: ["CN: 90", "CN base: 84", "CN efectivo: 91", "AMC: III"]
+  },
+  {
+    nombre: "contextoBase ausente",
+    entrada: {},
+    esperados: ["CN: —", "CN base: —", "CN efectivo: —", "AMC: —"]
+  },
+  {
+    nombre: "contexto directo",
+    entrada: {
+      CN: 91,
+      CN_base: 85,
+      CN_efectivo: 92,
+      AMC: "I"
+    },
+    esperados: ["CN: 91", "CN base: 85", "CN efectivo: 92", "AMC: I"]
+  }
+];
 
-validarTexto(
-  "CN vacio",
-  {
-    contextoBase: {
-      CN: "",
-      CN_base: 82,
-      CN_efectivo: 88,
-      AMC: "II"
-    }
-  },
-  [
-    "CN: —",
-    "CN base: 82",
-    "CN efectivo: 88",
-    "AMC: II"
-  ]
-);
-
-validarTexto(
-  "CN NaN",
-  {
-    contextoBase: {
-      CN: Number.NaN,
-      CN_base: 82,
-      CN_efectivo: 88,
-      AMC: "II"
-    }
-  },
-  [
-    "CN: —",
-    "CN base: 82",
-    "CN efectivo: 88",
-    "AMC: II"
-  ]
-);
-
-validarTexto(
-  "CN_base null",
-  {
-    contextoBase: {
-      CN: 88,
-      CN_base: null,
-      CN_efectivo: 88,
-      AMC: "II"
-    }
-  },
-  [
-    "CN: 88",
-    "CN base: —",
-    "CN efectivo: 88",
-    "AMC: II"
-  ]
-);
-  "contexto directo",
-  {
-    CN: 91,
-    CN_base: 85,
-    CN_efectivo: 92,
-    AMC: "I"
-  },
-  [
-    "CN: 91",
-    "CN base: 85",
-    "CN efectivo: 92",
-    "AMC: I"
-  ]
-);
+for (const caso of casos) {
+  validarTexto(caso.nombre, caso.entrada, caso.esperados);
+}
 
 console.log("VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK");


### PR DESCRIPTION
## Objetivo

Reforzar la validación aislada del helper puro `construirLineasParametrosHidrologicosBaseExpediente(...)` antes de cualquier integración diagnóstica o sustitución en `ComparadorMultiMetodo.jsx`.

## Antecedente

OT-0133 implementó el helper puro representacional para el bloque:

```text
## 2. Parámetros hidrológicos base