### PR TITLE
OT-0137 — Sustitución parcial Parámetros hidrológicos base

### DIFF
--- a/00_ADMIN/bitacora/OT-0137/OT-0137A_apertura_sustitucion_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0137/OT-0137A_apertura_sustitucion_parametros_base.md
@@ -1,0 +1,48 @@
+# OT-0137A — Apertura sustitución parcial Parámetros hidrológicos base
+
+## Objetivo
+
+Sustituir únicamente el bloque operativo `## 2. Parámetros hidrológicos base` dentro de `textoExpediente` por el helper delegado `construirLineasParametrosHidrologicosBaseExpediente(...)`.
+
+## Antecedente
+
+OT-0133 implementó el helper puro.
+
+OT-0134 reforzó la validación aislada.
+
+OT-0135 integró el helper como diagnóstico no invasivo.
+
+OT-0136 confirmó coincidencia textual estricta 5/5 entre delegado y referencia operativa.
+
+## Alcance
+
+Esta OT sustituye solo el bloque `## 2. Parámetros hidrológicos base`.
+
+No modifica el bloque `## 1. Identificación`.
+
+No modifica otros bloques del expediente.
+
+## Restricciones
+
+No se modifica:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0137 se considera válida si:
+
+- el bloque Parámetros base se arma con `construirLineasParametrosHidrologicosBaseExpediente(...)`;
+- las líneas manuales antiguas de CN, CN base, CN efectivo y AMC no reaparecen;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introduce `navigator.clipboard`;
+- no se introduce `writeText`;
+- validaciones OT-0137, OT-0136, OT-0135, OT-0134 y OT-0133 pasan;
+- build Vite pasa.

--- a/00_ADMIN/bitacora/OT-0137/OT-0137B_sustitucion_parcial_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0137/OT-0137B_sustitucion_parcial_parametros_base.md
@@ -1,0 +1,30 @@
+# OT-0137B — Sustitución parcial del bloque Parámetros hidrológicos base
+
+## Cambio aplicado
+
+Se sustituyeron únicamente las líneas manuales del bloque `## 2. Parámetros hidrológicos base` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasParametrosHidrologicosBaseExpediente({
+  contextoBase
+}),
+```
+
+## Alcance del cambio
+
+La sustitución se limitó al bloque Parámetros hidrológicos base.
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Nota técnica
+
+La sustitución se habilitó porque OT-0136 confirmó coincidencia textual estricta 5/5 entre bloque delegado y referencia operativa controlada.

--- a/00_ADMIN/bitacora/OT-0137/OT-0137C_cierre_sustitucion_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0137/OT-0137C_cierre_sustitucion_parametros_base.md
@@ -1,0 +1,49 @@
+# OT-0137C — Cierre sustitución parcial Parámetros hidrológicos base
+
+## Resultado
+
+Se sustituyó parcialmente el bloque `## 2. Parámetros hidrológicos base` dentro de `textoExpediente` por el helper delegado.
+
+## Cambio aplicado
+
+Las líneas manuales de `CN`, `CN base`, `CN efectivo` y `AMC` fueron reemplazadas por:
+
+```javascript
+...construirLineasParametrosHidrologicosBaseExpediente({
+  contextoBase
+}),
+```
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0137_SUSTITUCION_PARAMETROS_BASE_OK`;
+- `COMPARACION_OT_0136_PARAMETROS_BASE_OK`;
+- `VALIDACION_OT_0135_DIAGNOSTICA_PARAMETROS_BASE_OK`;
+- `VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK`;
+- `VALIDACION_OT_0133_HELPER_PARAMETROS_BASE_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Verificaciones clave
+
+`areaTexto.value = textoExpediente` sigue intacto.
+
+`window.prompt(..., textoExpediente)` sigue intacto.
+
+No se introdujo `navigator.clipboard` ni `writeText`.
+
+## Conclusión
+
+El bloque Parámetros hidrológicos base queda adoptado parcialmente desde el helper delegado, manteniendo el resto del expediente operativo sin sustituciones adicionales.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2053,11 +2053,9 @@ const handleClickSeguro = (accion) => () => {
               estacionIdfFallback: estacionIdfExpediente
             }),
             "",
-            "## 2. Parámetros hidrológicos base",
-            `CN: ${contextoBase?.CN ?? "—"}`,
-            `CN base: ${contextoBase?.CN_base ?? "—"}`,
-            `CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`,
-            `AMC: ${contextoBase?.AMC ?? "—"}`,
+            ...construirLineasParametrosHidrologicosBaseExpediente({
+              contextoBase
+            }),
             "",
             "## 3. Tiempo de concentración y roles Tc",
             `Tc comparador: ${Tc_final !== null && Tc_final !== undefined ? Number(Tc_final).toFixed(1) + " min" : "—"}`,

--- a/07_TOOLBOX/validaciones/validar_ot0137_sustitucion_parametros_base.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0137_sustitucion_parametros_base.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe mantenerse el arreglo textoExpediente"
+);
+
+assert.equal(
+  texto.includes("...construirLineasParametrosHidrologicosBaseExpediente({"),
+  true,
+  "El bloque Parámetros base debe usar expansión delegada"
+);
+
+assert.equal(
+  texto.includes("contextoBase"),
+  true,
+  "La sustitución delegada debe pasar contextoBase"
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard"
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText"
+);
+
+const lineasManualesAntiguas = [
+  '`CN: ${contextoBase?.CN ?? "—"}`',
+  '`CN base: ${contextoBase?.CN_base ?? "—"}`',
+  '`CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`',
+  '`AMC: ${contextoBase?.AMC ?? "—"}`'
+];
+
+const manualesDetectadas = lineasManualesAntiguas.filter((linea) =>
+  texto.includes(linea)
+);
+
+assert.equal(
+  manualesDetectadas.length,
+  0,
+  `No deben reaparecer líneas manuales antiguas: ${manualesDetectadas.join(", ")}`
+);
+
+assert.equal(
+  texto.includes("## 1. Identificación"),
+  true,
+  "Debe conservarse el bloque Identificación"
+);
+
+assert.equal(
+  texto.includes("## 3. Tiempo de concentración"),
+  true,
+  "Debe conservarse el bloque siguiente de Tiempo de concentración"
+);
+
+console.log("VALIDACION_OT_0137_SUSTITUCION_PARAMETROS_BASE_OK");


### PR DESCRIPTION
## Objetivo

Sustituir únicamente el bloque operativo `## 2. Parámetros hidrológicos base` dentro de `textoExpediente` por el helper delegado `construirLineasParametrosHidrologicosBaseExpediente(...)`.

## Antecedente

La sustitución se habilita después de una secuencia controlada:

- OT-0133 implementó el helper puro representacional;
- OT-0134 reforzó su validación aislada con casos borde;
- OT-0135 integró el helper como diagnóstico no invasivo;
- OT-0136 confirmó coincidencia textual estricta 5/5 entre el bloque delegado y la referencia operativa.

## Cambio aplicado

Las líneas manuales del bloque:

```text
## 2. Parámetros hidrológicos base
CN
CN base
CN efectivo
AMC