### PR TITLE
OT-0138 — Validación post-adopción Parámetros hidrológicos base

### DIFF
--- a/00_ADMIN/bitacora/OT-0138/OT-0138A_apertura_validacion_post_adopcion_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0138/OT-0138A_apertura_validacion_post_adopcion_parametros_base.md
@@ -1,0 +1,55 @@
+# OT-0138A — Apertura validación post-adopción Parámetros hidrológicos base
+
+## Objetivo
+
+Validar que, después de OT-0137, el expediente operativo mantiene correctamente adoptado el bloque `## 2. Parámetros hidrológicos base` desde el helper delegado.
+
+## Antecedente
+
+OT-0137 sustituyó parcialmente las líneas manuales de `CN`, `CN base`, `CN efectivo` y `AMC` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasParametrosHidrologicosBaseExpediente({
+  contextoBase
+}),
+```
+
+## Alcance
+
+Esta OT solo valida post-adopción.
+
+No sustituye nuevos bloques.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0138 se considera válida si:
+
+- `textoExpediente` sigue existiendo;
+- el bloque Parámetros base se arma mediante `construirLineasParametrosHidrologicosBaseExpediente(...)`;
+- no reaparecen las líneas manuales antiguas de `CN`, `CN base`, `CN efectivo` y `AMC`;
+- el bloque `## 1. Identificación` sigue presente;
+- el bloque `## 3. Tiempo de concentración` sigue presente;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introduce `navigator.clipboard`;
+- no se introduce `writeText`;
+- validaciones encadenadas pasan;
+- build Vite pasa.

--- a/00_ADMIN/bitacora/OT-0138/OT-0138B_cierre_validacion_post_adopcion_parametros_base.md
+++ b/00_ADMIN/bitacora/OT-0138/OT-0138B_cierre_validacion_post_adopcion_parametros_base.md
@@ -1,0 +1,46 @@
+# OT-0138B — Cierre validación post-adopción Parámetros hidrológicos base
+
+## Resultado
+
+Se validó que el expediente operativo mantiene correctamente adoptado el bloque `## 2. Parámetros hidrológicos base` desde el helper delegado.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0138_POST_ADOPCION_PARAMETROS_BASE_OK`;
+- `VALIDACION_OT_0137_SUSTITUCION_PARAMETROS_BASE_OK`;
+- `VALIDACION_OT_0135_DIAGNOSTICA_PARAMETROS_BASE_OK`;
+- `VALIDACION_OT_0134_HELPER_PARAMETROS_BASE_REFORZADA_OK`;
+- `VALIDACION_OT_0133_HELPER_PARAMETROS_BASE_OK`;
+- Build Vite aprobado.
+
+## Verificaciones confirmadas
+
+- `textoExpediente` sigue existiendo;
+- el bloque Parámetros base se arma mediante `construirLineasParametrosHidrologicosBaseExpediente(...)`;
+- no reaparecen líneas manuales antiguas de `CN`, `CN base`, `CN efectivo` ni `AMC`;
+- el bloque `## 1. Identificación` sigue presente;
+- el bloque `## 3. Tiempo de concentración` sigue presente;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introdujo `navigator.clipboard`;
+- no se introdujo `writeText`.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0138 confirma que la adopción parcial del bloque Parámetros hidrológicos base quedó operativamente estable.
+
+No se sustituyen nuevos bloques en esta OT.

--- a/07_TOOLBOX/validaciones/validar_ot0138_post_adopcion_parametros_base.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0138_post_adopcion_parametros_base.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const lineasManualesAntiguas = [
+  '`CN: ${contextoBase?.CN ?? "—"}`',
+  '`CN base: ${contextoBase?.CN_base ?? "—"}`',
+  '`CN efectivo: ${contextoBase?.CN_efectivo ?? "—"}`',
+  '`AMC: ${contextoBase?.AMC ?? "—"}`'
+];
+
+const manualesDetectadas = lineasManualesAntiguas.filter((linea) =>
+  texto.includes(linea)
+);
+
+const resumen = {
+  tieneTextoExpediente: texto.includes("const textoExpediente = ["),
+  usaHelperParametrosBase: texto.includes("...construirLineasParametrosHidrologicosBaseExpediente({"),
+  pasaContextoBase: texto.includes("contextoBase"),
+  bloqueIdentificacionPresente: texto.includes("## 1. Identificación"),
+  bloqueParametrosBasePresente: texto.includes("## 2. Parámetros hidrológicos base"),
+  bloqueTiempoConcentracionPresente: texto.includes("## 3. Tiempo de concentración"),
+  portapapelesIntacto: texto.includes("areaTexto.value = textoExpediente"),
+  fallbackManualIntacto: texto.includes(
+    "window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"
+  ),
+  sinNavigatorClipboard: !texto.includes("navigator.clipboard"),
+  sinWriteText: !texto.includes("writeText"),
+  manualesDetectadas
+};
+
+assert.equal(resumen.tieneTextoExpediente, true, "Debe existir textoExpediente");
+assert.equal(resumen.usaHelperParametrosBase, true, "Debe usarse helper delegado de Parámetros base");
+assert.equal(resumen.pasaContextoBase, true, "Debe pasarse contextoBase");
+assert.equal(resumen.bloqueIdentificacionPresente, true, "Debe conservarse bloque Identificación");
+assert.equal(resumen.bloqueParametrosBasePresente, true, "Debe conservarse encabezado Parámetros base");
+assert.equal(resumen.bloqueTiempoConcentracionPresente, true, "Debe conservarse bloque Tiempo de concentración");
+assert.equal(resumen.portapapelesIntacto, true, "Debe mantenerse areaTexto.value = textoExpediente");
+assert.equal(resumen.fallbackManualIntacto, true, "Debe mantenerse fallback manual con textoExpediente");
+assert.equal(resumen.sinNavigatorClipboard, true, "No debe introducirse navigator.clipboard");
+assert.equal(resumen.sinWriteText, true, "No debe introducirse writeText");
+assert.equal(
+  resumen.manualesDetectadas.length,
+  0,
+  `No deben reaparecer líneas manuales antiguas: ${resumen.manualesDetectadas.join(", ")}`
+);
+
+console.log("VALIDACION_OT_0138_POST_ADOPCION_PARAMETROS_BASE_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Validar que, después de OT-0137, el expediente operativo mantiene correctamente adoptado el bloque `## 2. Parámetros hidrológicos base` desde el helper delegado.

## Antecedente

OT-0137 sustituyó parcialmente las líneas manuales de:

```text
CN
CN base
CN efectivo
AMC