### PR TITLE
OT-0140 — Contrato documental Tiempo de concentración y roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0140/OT-0140A_apertura_contrato_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0140/OT-0140A_apertura_contrato_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,44 @@
+# OT-0140A — Apertura contrato documental Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Definir el contrato documental del bloque `## 3. Tiempo de concentración y roles Tc` antes de cualquier helper, integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0139 seleccionó y auditó el bloque `## 3. Tiempo de concentración y roles Tc` como siguiente candidato documental.
+
+La auditoría confirmó que el bloque contiene campos técnicamente sensibles asociados al tiempo de concentración y roles Tc.
+
+## Alcance
+
+Esta OT solo define contrato documental.
+
+No implementa helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica principal
+
+- No recalcular Tc.
+- No inferir Tc.
+- No derivar roles.
+- No reinterpretar competencia.
+- No generar advertencias nuevas.
+- Solo representar valores ya presentes en el contexto operativo.

--- a/00_ADMIN/bitacora/OT-0140/OT-0140B_contrato_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0140/OT-0140B_contrato_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,60 @@
+# OT-0140B — Contrato documental del bloque Tiempo de concentración y roles Tc
+
+## Bloque contractual
+
+```text
+## 3. Tiempo de concentración y roles Tc
+Tc comparador: <valor | —>
+Tc sugerido: <valor | —>
+Rango competente Tc: <valor | —>
+Rol Tc: <valor | —>
+Advertencia Tc: <valor | —>
+```
+
+## Naturaleza del bloque
+
+Este bloque es documental en su salida, pero contiene campos hidrológicamente sensibles.
+
+Por tanto, cualquier helper futuro debe ser estrictamente representacional.
+
+## Campos contractuales preliminares
+
+| Campo | Fuente esperada | Fallback | Recalcular | Inferir | Derivar | Reinterpretar |
+|---|---|---|---|---|---|---|
+| `Tc comparador` | contexto operativo existente | `—` | No | No | No | No |
+| `Tc sugerido` | contexto operativo existente | `—` | No | No | No | No |
+| `Rango competente Tc` | contexto operativo existente | `—` | No | No | No | No |
+| `Rol Tc` | contexto operativo existente | `—` | No | No | No | No |
+| `Advertencia Tc` | texto operativo existente | `—` | No | No | No | No |
+
+## Reglas de representación
+
+- Si el valor existe en el contexto operativo, se representa literalmente.
+- Si el valor no existe, se representa `—`.
+- No se deben convertir unidades.
+- No se deben aplicar redondeos nuevos.
+- No se deben calcular valores faltantes.
+- No se deben completar valores por defecto técnico.
+- No se deben usar valores de otros módulos como sustitutos.
+- No se debe consultar el motor hidrológico.
+- No se debe modificar estado.
+- No se deben generar advertencias nuevas.
+
+## Residuos prohibidos
+
+El bloque no debe emitir:
+
+- `undefined`;
+- `null`;
+- `NaN`;
+- `[object Object]`.
+
+## Decisión contractual
+
+El bloque no debe avanzar directamente a helper.
+
+Primero debe abrirse una OT posterior para extraer la forma exacta del bloque operativo línea por línea desde `ComparadorMultiMetodo.jsx`.
+
+## Próxima OT recomendada
+
+`OT-0141 — Extracción exacta del bloque Tiempo de concentración operativo`


### PR DESCRIPTION
## Objetivo

Definir el contrato documental del bloque `## 3. Tiempo de concentración y roles Tc` antes de cualquier helper, integración diagnóstica o sustitución.

## Antecedente

OT-0139 seleccionó y auditó el bloque `## 3. Tiempo de concentración y roles Tc` como siguiente candidato documental.

La auditoría confirmó que el bloque contiene campos técnicamente sensibles asociados al tiempo de concentración y roles Tc.

Resumen OT-0139:

```json
{
  "lineasAuditadas": 11,
  "totalEncabezados": 1,
  "totalDocumentales": 4,
  "totalSensibles": 6,
  "comparadorModificado": false
}