### PR TITLE
OT-0142C — Saneamiento documental diseño Tiempo de concentración

### DIFF
--- a/00_ADMIN/bitacora/OT-0142/OT-0142B_diseno_funcion_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0142/OT-0142B_diseno_funcion_tiempo_concentracion_roles_tc.md
@@ -21,21 +21,19 @@ La función debe aceptar un objeto de entrada con valores ya calculados o textos
 ```javascript
 {
   Tc_final,
-  trDisenoActivoExpediente,
-  notaTr,
-  rolesTc
+  trDisenoActivoExpediente
 }
 ```
 
 ## Salida esperada
 
-Debe retornar un arreglo de líneas equivalente al bloque operativo actual:
+Debe retornar un arreglo equivalente al bloque operativo actual:
 
 ```text
 ## 3. Tiempo de concentración y roles Tc
 Tc comparador: <valor | —>
 Tr global activo: <valor | —> años
-Nota Tr: <texto operativo>
+Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.
 Roles Tc:
 - Tc global Índice: referencia hidrológica general.
 - Tc operativo Q(t): ruta interna del hidrograma.
@@ -77,7 +75,52 @@ Roles Tc:
 - No debe recalcular `Tc_final`.
 - No debe inferir `Tc_final`.
 - No debe recalcular `trDisenoActivoExpediente`.
-- No debe reinnto/regulación.
+- No debe reinterpretar roles Tc.
+- No debe generar advertencias nuevas.
+- Solo debe representar valores presentes o fallback documental.
+
+## Regla de formato Tc
+
+Si `Tc_final` es finito, se representa como:
+
+```text
+Number(Tc_final).toFixed(1) + " min"
+```
+
+Si no existe o no es finito, se representa:
+
+```text
+—
+```
+
+## Regla de formato Tr
+
+Si `trDisenoActivoExpediente` existe, se representa literalmente seguido de `años`.
+
+Si no existe, se representa:
+
+```text
+Tr global activo: — años
+```
+
+## Residuos prohibidos
+
+- `undefined`;
+- `null`;
+- `NaN`;
+- `[object Object]`.
+
+## Ejemplo con contexto completo
+
+```text
+## 3. Tiempo de concentración y roles Tc
+Tc comparador: 114.2 min
+Tr global activo: 100 años
+Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.
+Roles Tc:
+- Tc global Índice: referencia hidrológica general.
+- Tc operativo Q(t): ruta interna del hidrograma.
+- Duración evento: 3 h para almacenamiento/regulación.
 - Lag / forma SCS: parámetro derivado para forma temporal.
 - Tc comparador: referencia especializada para coherencia Q-5.
 ```
@@ -105,7 +148,7 @@ Roles Tc:
 - Tc finito formateado con una cifra decimal y `min`;
 - fallback `—` para Tc no finito;
 - Tr representado sin recalcular;
-- roles operativos conservados literal;
+- roles operativos conservados literalmente;
 - ausencia de residuos técnicos;
 - ausencia de recálculo, inferencia, derivación o reinterpretación.
 

--- a/00_ADMIN/bitacora/OT-0142/OT-0142C_saneamiento_diseno_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0142/OT-0142C_saneamiento_diseno_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,42 @@
+# OT-0142C — Saneamiento documental del diseño Tiempo de concentración y roles Tc
+
+## Hallazgo
+
+La bitácora `OT-0142B_diseno_funcion_tiempo_concentracion_roles_tc.md` contenía texto cortado y mezclado en la sección de reglas funcionales y ejemplos.
+
+## Corrección aplicada
+
+Se reescribió la bitácora OT-0142B con estructura limpia:
+
+- nombre de función;
+- ubicación futura;
+- firma conceptual;
+- entrada esperada;
+- salida esperada;
+- orden obligatorio;
+- fuentes contractuales;
+- reglas funcionales;
+- formato Tc;
+- formato Tr;
+- residuos prohibidos;
+- ejemplos completos;
+- criterio de validación futura.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- helper documental;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0142 queda documentalmente saneada y lista para servir como base de OT-0143.


### PR DESCRIPTION
## Objetivo

Sanear documentalmente el diseño de la función pura para el bloque `## 3. Tiempo de concentración y roles Tc`.

## Motivo

La bitácora `OT-0142B_diseno_funcion_tiempo_concentracion_roles_tc.md` contenía texto cortado y mezclado en la sección de reglas funcionales y ejemplos.

Antes de avanzar a implementación del helper puro, era necesario dejar la evidencia documental limpia.

## Cambio aplicado

Se reescribió `OT-0142B_diseno_funcion_tiempo_concentracion_roles_tc.md` con estructura limpia:

- nombre de función;
- ubicación futura;
- firma conceptual;
- entrada esperada;
- salida esperada;
- orden obligatorio;
- fuentes contractuales;
- reglas funcionales;
- formato Tc;
- formato Tr;
- residuos prohibidos;
- ejemplos completos;
- criterio de validación futura.

También se creó:

```text
00_ADMIN/bitacora/OT-0142/OT-0142C_saneamiento_diseno_tiempo_concentracion_roles_tc.md