### PR TITLE
OT-0143 — Implementación de función pura Tiempo de concentración y roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0143/OT-0143A_apertura_helper_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0143/OT-0143A_apertura_helper_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,46 @@
+# OT-0143A — Apertura implementación helper puro Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Implementar la función pura `construirLineasTiempoConcentracionRolesTcExpediente(...)` en el helper documental del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0140 definió el contrato documental preliminar.
+
+OT-0141 extrajo la forma exacta del bloque operativo.
+
+OT-0142 diseñó la función pura futura.
+
+OT-0142C saneó documentalmente el diseño.
+
+## Alcance
+
+Esta OT implementa únicamente el helper puro.
+
+No integra el helper en `ComparadorMultiMetodo.jsx`.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica
+
+- No recalcular Tc.
+- No inferir Tc.
+- No derivar roles.
+- No reinterpretar competencia.
+- No generar advertencias nuevas.
+- Solo representar valores presentes o fallback documental.

--- a/00_ADMIN/bitacora/OT-0143/OT-0143B_implementacion_helper_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0143/OT-0143B_implementacion_helper_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,56 @@
+# OT-0143B — Implementación helper puro Tiempo de concentración y roles Tc
+
+## Cambio aplicado
+
+Se implementó en el helper documental la función:
+
+```javascript
+construirLineasTiempoConcentracionRolesTcExpediente(...)
+```
+
+Ubicación:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+## Comportamiento
+
+La función retorna el bloque:
+
+```text
+## 3. Tiempo de concentración y roles Tc
+Tc comparador: <valor | —>
+Tr global activo: <valor | —> años
+Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.
+Roles Tc:
+- Tc global Índice: referencia hidrológica general.
+- Tc operativo Q(t): ruta interna del hidrograma.
+- Duración evento: 3 h para almacenamiento/regulación.
+- Lag / forma SCS: parámetro derivado para forma temporal.
+- Tc comparador: referencia especializada para coherencia Q-5.
+```
+
+## Reglas mantenidas
+
+- No recalcula Tc.
+- No infiere Tc.
+- No deriva roles.
+- No reinterpreta competencia.
+- No genera advertencias nuevas.
+- No consulta motor.
+- No modifica estado.
+- No toca DOM.
+- No usa portapapeles.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0143/OT-0143C_cierre_helper_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0143/OT-0143C_cierre_helper_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,47 @@
+# OT-0143C — Cierre implementación helper Tiempo de concentración y roles Tc
+
+## Resultado
+
+Se implementó la función pura `construirLineasTiempoConcentracionRolesTcExpediente(...)` en el helper documental.
+
+## Validación aprobada
+
+`VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`
+
+La validación confirmó:
+
+- contexto completo;
+- contexto fallback;
+- contexto no finito;
+- retorno tipo arreglo;
+- 10 líneas;
+- encabezado exacto;
+- Tc formateado con una cifra decimal y `min`;
+- fallback `—` para Tc no finito;
+- Tr representado sin recalcular;
+- roles operativos conservados literalmente;
+- ausencia de `undefined`, `null`, `NaN` y `[object Object]`.
+
+## Build
+
+Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El bloque `## 3. Tiempo de concentración y roles Tc` ya cuenta con helper puro representacional implementado.
+
+No se integra todavía en `ComparadorMultiMetodo.jsx` y no se sustituye el bloque operativo.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -341,4 +341,48 @@ export function construirLineasParametrosHidrologicosBaseExpediente(entrada = {}
     `AMC: ${valorDocumental(contextoBase?.AMC)}`
   ];
 }
+export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}) {
+  const formatearTc = (valor) => {
+    const numero = Number(valor);
+
+    if (!Number.isFinite(numero)) {
+      return "—";
+    }
+
+    return `${numero.toFixed(1)} min`;
+  };
+
+  const valorDocumental = (valor) => {
+    if (valor === undefined || valor === null) {
+      return "—";
+    }
+
+    if (typeof valor === "number" && !Number.isFinite(valor)) {
+      return "—";
+    }
+
+    if (typeof valor === "object") {
+      return "—";
+    }
+
+    const textoValor = String(valor).trim();
+
+    return textoValor.length > 0 ? textoValor : "—";
+  };
+
+  const trGlobalActivo = valorDocumental(entrada?.trDisenoActivoExpediente);
+
+  return [
+    "## 3. Tiempo de concentración y roles Tc",
+    `Tc comparador: ${formatearTc(entrada?.Tc_final)}`,
+    `Tr global activo: ${trGlobalActivo} años`,
+    "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.",
+    "Roles Tc:",
+    "- Tc global Índice: referencia hidrológica general.",
+    "- Tc operativo Q(t): ruta interna del hidrograma.",
+    "- Duración evento: 3 h para almacenamiento/regulación.",
+    "- Lag / forma SCS: parámetro derivado para forma temporal.",
+    "- Tc comparador: referencia especializada para coherencia Q-5."
+  ];
+}
 

--- a/07_TOOLBOX/validaciones/validar_ot0143_helper_tiempo_concentracion_roles_tc.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0143_helper_tiempo_concentracion_roles_tc.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { construirLineasTiempoConcentracionRolesTcExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso} no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas.length, 10, `${nombreCaso}: debe retornar 10 líneas`);
+  assert.equal(lineas[0], "## 3. Tiempo de concentración y roles Tc", `${nombreCaso}: debe conservar encabezado`);
+  assert.equal(lineas[3], "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.", `${nombreCaso}: debe conservar nota Tr`);
+  assert.equal(lineas[4], "Roles Tc:", `${nombreCaso}: debe conservar Roles Tc`);
+  assert.equal(lineas[5], "- Tc global Índice: referencia hidrológica general.", `${nombreCaso}: debe conservar rol Tc global Índice`);
+  assert.equal(lineas[6], "- Tc operativo Q(t): ruta interna del hidrograma.", `${nombreCaso}: debe conservar rol Tc operativo`);
+  assert.equal(lineas[7], "- Duración evento: 3 h para almacenamiento/regulación.", `${nombreCaso}: debe conservar duración evento`);
+  assert.equal(lineas[8], "- Lag / forma SCS: parámetro derivado para forma temporal.", `${nombreCaso}: debe conservar lag SCS`);
+  assert.equal(lineas[9], "- Tc comparador: referencia especializada para coherencia Q-5.", `${nombreCaso}: debe conservar rol Tc comparador`);
+}
+
+function validarCasoCompleto() {
+  const lineas = construirLineasTiempoConcentracionRolesTcExpediente({
+    Tc_final: 114.23,
+    trDisenoActivoExpediente: 100
+  });
+
+  const texto = lineas.join("\n");
+
+  validarEstructura("contexto completo", lineas);
+  validarSinResiduos("contexto completo", texto);
+
+  assert.equal(texto.includes("Tc comparador: 114.2 min"), true, "Debe formatear Tc con una cifra decimal");
+  assert.equal(texto.includes("Tr global activo: 100 años"), true, "Debe representar Tr global activo");
+
+  console.log("OK contexto completo");
+  console.log(texto);
+}
+
+function validarCasoFallback() {
+  const lineas = construirLineasTiempoConcentracionRolesTcExpediente({});
+
+  const texto = lineas.join("\n");
+
+  validarEstructura("contexto fallback", lineas);
+  validarSinResiduos("contexto fallback", texto);
+
+  assert.equal(texto.includes("Tc comparador: —"), true, "Debe aplicar fallback Tc");
+  assert.equal(texto.includes("Tr global activo: — años"), true, "Debe aplicar fallback Tr");
+
+  console.log("OK contexto fallback");
+  console.log(texto);
+}
+
+function validarCasoNoFinito() {
+  const lineas = construirLineasTiempoConcentracionRolesTcExpediente({
+    Tc_final: Number.NaN,
+    trDisenoActivoExpediente: null
+  });
+
+  const texto = lineas.join("\n");
+
+  validarEstructura("contexto no finito", lineas);
+  validarSinResiduos("contexto no finito", texto);
+
+  assert.equal(texto.includes("Tc comparador: —"), true, "Debe aplicar fallback Tc no finito");
+  assert.equal(texto.includes("Tr global activo: — años"), true, "Debe aplicar fallback Tr null");
+
+  console.log("OK contexto no finito");
+  console.log(texto);
+}
+
+validarCasoCompleto();
+validarCasoFallback();
+validarCasoNoFinito();
+
+console.log("VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK");


### PR DESCRIPTION
## Objetivo

Implementar la función pura `construirLineasTiempoConcentracionRolesTcExpediente(...)` en el helper documental del expediente hidrológico mínimo.

## Antecedente

La implementación se basa en la secuencia controlada previa:

- OT-0140 definió el contrato documental preliminar del bloque `## 3. Tiempo de concentración y roles Tc`;
- OT-0141 extrajo la forma exacta del bloque operativo desde `ComparadorMultiMetodo.jsx`;
- OT-0142 diseñó la función pura futura;
- OT-0142C saneó documentalmente el diseño antes de implementar.

## Cambio aplicado

Se agregó en:

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js