### PR TITLE
OT-0144 — Validación reforzada helper Tiempo de concentración y roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0144/OT-0144A_apertura_validacion_reforzada_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0144/OT-0144A_apertura_validacion_reforzada_tiempo_concentracion.md
@@ -1,0 +1,50 @@
+# OT-0144A — Apertura validación reforzada helper Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Validar de forma aislada y reforzada el helper puro `construirLineasTiempoConcentracionRolesTcExpediente(...)` antes de cualquier integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0143 implementó el helper puro representacional para el bloque `## 3. Tiempo de concentración y roles Tc`.
+
+La validación inicial confirmó contexto completo, fallback y caso no finito.
+
+## Alcance
+
+Esta OT solo refuerza la validación aislada.
+
+No modifica el helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No integra en UI.
+
+No sustituye `textoExpediente`.
+
+## Casos borde a validar
+
+- `Tc_final: 0`;
+- `Tc_final: ""`;
+- `Tc_final: NaN`;
+- `Tc_final: null`;
+- `Tc_final: "114.23"`;
+- `trDisenoActivoExpediente: ""`;
+- `trDisenoActivoExpediente: null`;
+- `trDisenoActivoExpediente: object`;
+- entrada vacía.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- helper documental;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0144/OT-0144B_cierre_validacion_reforzada_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0144/OT-0144B_cierre_validacion_reforzada_tiempo_concentracion.md
@@ -1,0 +1,42 @@
+# OT-0144B — Cierre validación reforzada helper Tiempo de concentración y roles Tc
+
+## Resultado
+
+Se reforzó la validación aislada del helper `construirLineasTiempoConcentracionRolesTcExpediente(...)`.
+
+## Casos validados
+
+- `Tc_final: 0`;
+- `Tc_final: ""`;
+- `Tc_final: NaN`;
+- `Tc_final: null`;
+- `Tc_final: "114.23"`;
+- `trDisenoActivoExpediente: ""`;
+- `trDisenoActivoExpediente: null`;
+- `trDisenoActivoExpediente: object`;
+- entrada vacía.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0144_HELPER_TIEMPO_CONCENTRACION_REFORZADA_OK`;
+- `VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Tiempo de concentración y roles Tc queda reforzado frente a casos borde, manteniendo comportamiento estrictamente representacional.

--- a/00_ADMIN/bitacora/OT-0144/OT-0144C_correccion_validacion_reforzada_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0144/OT-0144C_correccion_validacion_reforzada_tiempo_concentracion.md
@@ -1,0 +1,54 @@
+# OT-0144C — Corrección y cierre validación reforzada helper Tiempo de concentración
+
+## Hallazgo
+
+La primera versión del script `validar_ot0144_helper_tiempo_concentracion_reforzada.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.
+
+## Corrección aplicada
+
+Se reescribió el validador reforzado con una matriz completa de casos borde.
+
+## Casos validados
+
+- `Tc_final: 0`;
+- `Tc_final: ""`;
+- `Tc_final: NaN`;
+- `Tc_final: null`;
+- `Tc_final: "114.23"`;
+- `trDisenoActivoExpediente: ""`;
+- `trDisenoActivoExpediente: null`;
+- `trDisenoActivoExpediente: object`;
+- entrada vacía.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0144_HELPER_TIEMPO_CONCENTRACION_REFORZADA_OK`;
+- `VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`;
+- Build Vite aprobado.
+
+## Nota técnica
+
+`Tc_final: ""` y `Tc_final: null` se representan como `0.0 min` con la función actual, porque `Number("")` y `Number(null)` producen `0` en JavaScript.
+
+Esta OT documenta el comportamiento existente sin modificar el helper.
+
+Si posteriormente se decide que ese comportamiento debe cambiar a fallback `—`, deberá abrirse una OT específica de ajuste funcional.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Tiempo de concentración y roles Tc queda validado frente a casos borde, manteniendo el comportamiento representacional existente.

--- a/07_TOOLBOX/validaciones/validar_ot0144_helper_tiempo_concentracion_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0144_helper_tiempo_concentracion_reforzada.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { construirLineasTiempoConcentracionRolesTcExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas.length, 10, `${nombreCaso}: debe retornar 10 líneas`);
+  assert.equal(lineas[0], "## 3. Tiempo de concentración y roles Tc", `${nombreCaso}: encabezado exacto`);
+  assert.equal(lineas[3], "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.", `${nombreCaso}: nota Tr literal`);
+  assert.equal(lineas[4], "Roles Tc:", `${nombreCaso}: roles Tc literal`);
+  assert.equal(lineas[5], "- Tc global Índice: referencia hidrológica general.", `${nombreCaso}: rol índice literal`);
+  assert.equal(lineas[6], "- Tc operativo Q(t): ruta interna del hidrograma.", `${nombreCaso}: rol Qt literal`);
+  assert.equal(lineas[7], "- Duración evento: 3 h para almacenamiento/regulación.", `${nombreCaso}: duración literal`);
+  assert.equal(lineas[8], "- Lag / forma SCS: parámetro derivado para forma temporal.", `${nombreCaso}: lag literal`);
+  assert.equal(lineas[9], "- Tc comparador: referencia especializada para coherencia Q-5.", `${nombreCaso}: comparador literal`);
+}
+
+function validarCaso(nombreCaso, entrada, esperados) {
+  const lineas = construirLineasTiempoConcentracionRolesTcExpediente(entrada);
+  const texto = lineas.join("\n");
+
+  validarEstructura(nombreCaso, lineas);
+  validarSinResiduos(nombreCaso, texto);
+
+  for (const esperado of esperados) {
+    assert.equal(
+      texto.includes(esperado),
+      true,
+      `${nombreCaso}: debe incluir ${esperado}`
+    );
+  }
+
+  console.log(`OK ${nombreCaso}`);
+  console.log(texto);
+}
+
+const casos = [
+  {
+    nombre: "Tc cero",
+    entrada: {
+      Tc_final: 0,
+      trDisenoActivoExpediente: 100
+    },
+    ños"
+    ]
+  },
+  {
+    nombre: "Tr vacio",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: ""
+    },
+    esperados: [
+      "Tc comparador: 114.2 min",
+      "Tr global activo: — años"
+    ]
+  },
+  {
+    nombre: "Tr null",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: null
+    },
+    esperados: [
+      "Tc comparador: 114.2 min",
+      "Tr global activo: — años"
+    ]
+  },
+  {
+    nombre: "Tr objeto",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: { valor: 100 }
+    },
+    esperados: [
+      "Tc comparador: 114.2 min",
+      "Tr global activo: — años"
+    ]
+  },
+  {
+    nombre: "entrada vacia",
+    entrada: {},
+    esperados: [
+      "Tc comparador: —",
+      "Tr global activo: — años"
+    ]
+  }
+];
+
+for (const caso of casos) {
+  validarCaso(caso.nombre, caso.entrada, caso.esperados);
+}
+
+console.log("VALIDACION_OT_0144_HELPER_TIEMPO_CONCENTRACION_REFORZADA_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0144_helper_tiempo_concentracion_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0144_helper_tiempo_concentracion_reforzada.mjs
@@ -17,7 +17,11 @@ function validarEstructura(nombreCaso, lineas) {
   assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
   assert.equal(lineas.length, 10, `${nombreCaso}: debe retornar 10 líneas`);
   assert.equal(lineas[0], "## 3. Tiempo de concentración y roles Tc", `${nombreCaso}: encabezado exacto`);
-  assert.equal(lineas[3], "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.", `${nombreCaso}: nota Tr literal`);
+  assert.equal(
+    lineas[3],
+    "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.",
+    `${nombreCaso}: nota Tr literal`
+  );
   assert.equal(lineas[4], "Roles Tc:", `${nombreCaso}: roles Tc literal`);
   assert.equal(lineas[5], "- Tc global Índice: referencia hidrológica general.", `${nombreCaso}: rol índice literal`);
   assert.equal(lineas[6], "- Tc operativo Q(t): ruta interna del hidrograma.", `${nombreCaso}: rol Qt literal`);
@@ -52,7 +56,53 @@ const casos = [
       Tc_final: 0,
       trDisenoActivoExpediente: 100
     },
-    ños"
+    esperados: [
+      "Tc comparador: 0.0 min",
+      "Tr global activo: 100 años"
+    ]
+  },
+  {
+    nombre: "Tc vacio",
+    entrada: {
+      Tc_final: "",
+      trDisenoActivoExpediente: 100
+    },
+    esperados: [
+      "Tc comparador: 0.0 min",
+      "Tr global activo: 100 años"
+    ]
+  },
+  {
+    nombre: "Tc NaN",
+    entrada: {
+      Tc_final: Number.NaN,
+      trDisenoActivoExpediente: 100
+    },
+    esperados: [
+      "Tc comparador: —",
+      "Tr global activo: 100 años"
+    ]
+  },
+  {
+    nombre: "Tc null",
+    entrada: {
+      Tc_final: null,
+      trDisenoActivoExpediente: 100
+    },
+    esperados: [
+      "Tc comparador: 0.0 min",
+      "Tr global activo: 100 años"
+    ]
+  },
+  {
+    nombre: "Tc string numerico",
+    entrada: {
+      Tc_final: "114.23",
+      trDisenoActivoExpediente: 100
+    },
+    esperados: [
+      "Tc comparador: 114.2 min",
+      "Tr global activo: 100 años"
     ]
   },
   {


### PR DESCRIPTION
## Objetivo

Reforzar la validación aislada del helper puro `construirLineasTiempoConcentracionRolesTcExpediente(...)` antes de cualquier integración diagnóstica o sustitución.

## Antecedente

OT-0143 implementó el helper puro representacional para el bloque:

```text
## 3. Tiempo de concentración y roles Tc