### PR TITLE
OT-0145 — Ajuste fallback Tc vacío/null en helper Tiempo de concentración

### DIFF
--- a/00_ADMIN/bitacora/OT-0145/OT-0145A_apertura_ajuste_fallback_tc_vacio_null.md
+++ b/00_ADMIN/bitacora/OT-0145/OT-0145A_apertura_ajuste_fallback_tc_vacio_null.md
@@ -1,0 +1,44 @@
+# OT-0145A — Apertura ajuste fallback Tc vacío/null
+
+## Objetivo
+
+Ajustar el helper `construirLineasTiempoConcentracionRolesTcExpediente(...)` para que `Tc_final` vacío o nulo no se represente como `0.0 min`.
+
+## Antecedente
+
+OT-0144 validó de forma reforzada el helper y documentó que:
+
+```text
+Tc_final: ""   → 0.0 min
+Tc_final: null → 0.0 min
+```
+
+Este comportamiento ocurre porque en JavaScript `Number("")` y `Number(null)` producen `0`.
+
+## Decisión técnica
+
+Para un bloque hidrológico sensible, un `Tc` vacío o nulo debe representarse como fallback documental `—`, no como `0.0 min`.
+
+## Alcance
+
+Esta OT modifica únicamente el helper documental.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No integra en UI.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0145/OT-0145B_ajuste_fallback_tc_vacio_null.md
+++ b/00_ADMIN/bitacora/OT-0145/OT-0145B_ajuste_fallback_tc_vacio_null.md
@@ -1,0 +1,34 @@
+# OT-0145B — Ajuste fallback Tc vacío/null en helper Tiempo de concentración
+
+## Cambio aplicado
+
+Se ajustó `formatearTc(...)` dentro de `construirLineasTiempoConcentracionRolesTcExpediente(...)`.
+
+## Comportamiento corregido
+
+```text
+Tc_final: ""   → —
+Tc_final: null → —
+```
+
+## Comportamiento conservado
+
+```text
+Tc_final: 0        → 0.0 min
+Tc_final: "114.23" → 114.2 min
+Tc_final: NaN      → —
+```
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0145/OT-0145C_cierre_ajuste_fallback_tc_vacio_null.md
+++ b/00_ADMIN/bitacora/OT-0145/OT-0145C_cierre_ajuste_fallback_tc_vacio_null.md
@@ -1,0 +1,47 @@
+# OT-0145C — Cierre ajuste fallback Tc vacío/null
+
+## Resultado
+
+Se corrigió el fallback de `Tc_final` vacío o nulo en `construirLineasTiempoConcentracionRolesTcExpediente(...)`.
+
+## Validación aprobada
+
+`VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK`
+
+También se mantuvo aprobada:
+
+`VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`
+
+## Comportamiento final
+
+```text
+Tc_final: 0        → 0.0 min
+Tc_final: "114.23" → 114.2 min
+Tc_final: NaN      → —
+Tc_final: ""       → —
+Tc_final: "   "    → —
+Tc_final: null     → —
+Tc_final: undefined → —
+```
+
+## Build
+
+Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Tiempo de concentración queda más seguro para valores vacíos/nulos antes de cualquier integración diagnóstica.

--- a/00_ADMIN/bitacora/OT-0145/OT-0145D_correccion_validacion_fallback_tc_vacio_null.md
+++ b/00_ADMIN/bitacora/OT-0145/OT-0145D_correccion_validacion_fallback_tc_vacio_null.md
@@ -1,0 +1,45 @@
+# OT-0145D — Corrección y cierre validación fallback Tc vacío/null
+
+## Hallazgo
+
+La primera versión del script `validar_ot0145_fallback_tc_vacio_null.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.
+
+## Corrección aplicada
+
+Se reescribió el validador con matriz completa de casos para confirmar el ajuste de fallback de `Tc_final` vacío, nulo, indefinido y no finito.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK`;
+- `VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`;
+- Build Vite aprobado.
+
+## Comportamiento final confirmado
+
+```text
+Tc_final: 0         → 0.0 min
+Tc_final: "114.23"  → 114.2 min
+Tc_final: NaN       → —
+Tc_final: ""        → —
+Tc_final: "   "     → —
+Tc_final: null      → —
+Tc_final: undefined → —
+```
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0145 queda corregida y validada. El helper de Tiempo de concentración ya no publica `Tc_final` vacío o nulo como `0.0 min`.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -343,6 +343,14 @@ export function construirLineasParametrosHidrologicosBaseExpediente(entrada = {}
 }
 export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}) {
   const formatearTc = (valor) => {
+    if (valor === undefined || valor === null) {
+      return "—";
+    }
+
+    if (typeof valor === "string" && valor.trim().length === 0) {
+      return "—";
+    }
+
     const numero = Number(valor);
 
     if (!Number.isFinite(numero)) {
@@ -385,4 +393,5 @@ export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}
     "- Tc comparador: referencia especializada para coherencia Q-5."
   ];
 }
+
 

--- a/07_TOOLBOX/validaciones/validar_ot0145_fallback_tc_vacio_null.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0145_fallback_tc_vacio_null.mjs
@@ -1,8 +1,35 @@
 import assert from "node:assert/strict";
 import { construirLineasTiempoConcentracionRolesTcExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
 
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
 function textoCaso(entrada) {
   return construirLineasTiempoConcentracionRolesTcExpediente(entrada).join("\n");
+}
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarCaso(caso) {
+  const texto = textoCaso(caso.entrada);
+
+  assert.equal(
+    texto.includes(caso.esperado),
+    true,
+    `${caso.nombre}: debe incluir ${caso.esperado}`
+  );
+
+  validarSinResiduos(caso.nombre, texto);
+
+  console.log(`OK ${caso.nombre}`);
+  console.log(texto);
 }
 
 const casos = [
@@ -15,45 +42,80 @@ const casos = [
     esperado: "Tc comparador: 0.0 min"
   },
   {
-    nombre  esperado: "Tc comparador: —"
+    nombre: "Tc string numerico conserva formato",
+    entrada: {
+      Tc_final: "114.23",
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: 114.2 min"
+  },
+  {
+    nombre: "Tc NaN fallback",
+    entrada: {
+      Tc_final: Number.NaN,
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: —"
+  },
+  {
+    nombre: "Tc vacio fallback",
+    entrada: {
+      Tc_final: "",
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: —"
+  },
+  {
+    nombre: "Tc espacios fallback",
+    entrada: {
+      Tc_final: "   ",
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: —"
+  },
+  {
+    nombre: "Tc null fallback",
+    entrada: {
+      Tc_final: null,
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: —"
+  },
+  {
+    nombre: "Tc undefined fallback",
+    entrada: {
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: —"
+  },
+  {
+    nombre: "Tr vacio conserva fallback",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: ""
+    },
+    esperado: "Tr global activo: — años"
+  },
+  {
+    nombre: "Tr null conserva fallback",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: null
+    },
+    esperado: "Tr global activo: — años"
+  },
+  {
+    nombre: "Tr objeto conserva fallback",
+    entrada: {
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: { valor: 100 }
+    },
+    esperado: "Tr global activo: — años"
   }
 ];
 
 for (const caso of casos) {
-  const texto = textoCaso(caso.entrada);
-
-  assert.equal(
-    texto.includes(caso.esperado),
-    true,
-    `${caso.nombre}: debe incluir ${caso.esperado}`
-  );
-
-  assert.equal(
-    texto.includes("undefined"),
-    false,
-    `${caso.nombre}: no debe emitir undefined`
-  );
-
-  assert.equal(
-    texto.includes("null"),
-    false,
-    `${caso.nombre}: no debe emitir null`
-  );
-
-  assert.equal(
-    texto.includes("NaN"),
-    false,
-    `${caso.nombre}: no debe emitir NaN`
-  );
-
-  assert.equal(
-    texto.includes("[object Object]"),
-    false,
-    `${caso.nombre}: no debe emitir [object Object]`
-  );
-
-  console.log(`OK ${caso.nombre}`);
-  console.log(texto);
+  validarCaso(caso);
 }
 
 console.log("VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0145_fallback_tc_vacio_null.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0145_fallback_tc_vacio_null.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { construirLineasTiempoConcentracionRolesTcExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+function textoCaso(entrada) {
+  return construirLineasTiempoConcentracionRolesTcExpediente(entrada).join("\n");
+}
+
+const casos = [
+  {
+    nombre: "Tc cero conserva cero",
+    entrada: {
+      Tc_final: 0,
+      trDisenoActivoExpediente: 100
+    },
+    esperado: "Tc comparador: 0.0 min"
+  },
+  {
+    nombre  esperado: "Tc comparador: —"
+  }
+];
+
+for (const caso of casos) {
+  const texto = textoCaso(caso.entrada);
+
+  assert.equal(
+    texto.includes(caso.esperado),
+    true,
+    `${caso.nombre}: debe incluir ${caso.esperado}`
+  );
+
+  assert.equal(
+    texto.includes("undefined"),
+    false,
+    `${caso.nombre}: no debe emitir undefined`
+  );
+
+  assert.equal(
+    texto.includes("null"),
+    false,
+    `${caso.nombre}: no debe emitir null`
+  );
+
+  assert.equal(
+    texto.includes("NaN"),
+    false,
+    `${caso.nombre}: no debe emitir NaN`
+  );
+
+  assert.equal(
+    texto.includes("[object Object]"),
+    false,
+    `${caso.nombre}: no debe emitir [object Object]`
+  );
+
+  console.log(`OK ${caso.nombre}`);
+  console.log(texto);
+}
+
+console.log("VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK");


### PR DESCRIPTION
## Objetivo

Ajustar el helper `construirLineasTiempoConcentracionRolesTcExpediente(...)` para que `Tc_final` vacío o nulo no se represente como `0.0 min`.

## Antecedente

OT-0144 validó de forma reforzada el helper y documentó que, con la función original:

```text
Tc_final: ""   → 0.0 min
Tc_final: null → 0.0 min