### PR TITLE
OT-0148 — Sustitución parcial Tiempo de concentración y roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0148/OT-0148A_apertura_sustitucion_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0148/OT-0148A_apertura_sustitucion_tiempo_concentracion.md
@@ -1,0 +1,37 @@
+# OT-0148A — Apertura sustitución parcial Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Sustituir únicamente el bloque operativo `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por el helper delegado `construirLineasTiempoConcentracionRolesTcExpediente(...)`.
+
+## Antecedente
+
+OT-0143 implementó el helper puro.
+
+OT-0144 reforzó su validación aislada.
+
+OT-0145 corrigió el fallback `Tc_final` vacío/null.
+
+OT-0146 integró el helper como diagnóstico no invasivo.
+
+OT-0147 confirmó coincidencia textual estricta 10/10 entre delegado y referencia operativa.
+
+## Alcance
+
+Esta OT sustituye solo el bloque `## 3. Tiempo de concentración y roles Tc`.
+
+No modifica los bloques `## 1. Identificación` ni `## 2. Parámetros hidrológicos base`.
+
+No modifica otros bloques del expediente.
+
+## Restricciones
+
+No se modifica:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0148/OT-0148B_sustitucion_parcial_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0148/OT-0148B_sustitucion_parcial_tiempo_concentracion.md
@@ -1,0 +1,32 @@
+# OT-0148B — Sustitución parcial del bloque Tiempo de concentración y roles Tc
+
+## Cambio aplicado
+
+Se sustituyeron únicamente las líneas manuales del bloque `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente
+}),
+```
+
+## Alcance del cambio
+
+La sustitución se limitó al bloque Tiempo de concentración y roles Tc.
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- bloque `## 2. Parámetros hidrológicos base`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Nota técnica
+
+La sustitución se habilitó porque OT-0147 confirmó coincidencia textual estricta 10/10 entre bloque delegado y referencia operativa controlada.

--- a/00_ADMIN/bitacora/OT-0148/OT-0148C_cierre_sustitucion_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0148/OT-0148C_cierre_sustitucion_tiempo_concentracion.md
@@ -1,0 +1,51 @@
+# OT-0148C — Cierre sustitución parcial Tiempo de concentración y roles Tc
+
+## Resultado
+
+Se sustituyó parcialmente el bloque `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por el helper delegado.
+
+## Cambio aplicado
+
+Las líneas manuales del bloque fueron reemplazadas por:
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente
+}),
+```
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0148_SUSTITUCION_TIEMPO_CONCENTRACION_OK`;
+- `COMPARACION_OT_0147_TIEMPO_CONCENTRACION_OK`;
+- `VALIDACION_OT_0146_DIAGNOSTICA_TIEMPO_CONCENTRACION_OK`;
+- `VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK`;
+- `VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- bloque `## 2. Parámetros hidrológicos base`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Verificaciones clave
+
+`areaTexto.value = textoExpediente` sigue intacto.
+
+`window.prompt(..., textoExpediente)` sigue intacto.
+
+No se introdujo `navigator.clipboard` ni `writeText`.
+
+## Conclusión
+
+El bloque Tiempo de concentración y roles Tc queda adoptado parcialmente desde el helper delegado, manteniendo el resto del expediente operativo sin sustituciones adicionales.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2058,16 +2058,10 @@ const handleClickSeguro = (accion) => () => {
               contextoBase
             }),
             "",
-            "## 3. Tiempo de concentración y roles Tc",
-            `Tc comparador: ${Tc_final !== null && Tc_final !== undefined ? Number(Tc_final).toFixed(1) + " min" : "—"}`,
-            `Tr global activo: ${trDisenoActivoExpediente} años`,
-            "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.",
-            "Roles Tc:",
-            "- Tc global Índice: referencia hidrológica general.",
-            "- Tc operativo Q(t): ruta interna del hidrograma.",
-            "- Duración evento: 3 h para almacenamiento/regulación.",
-            "- Lag / forma SCS: parámetro derivado para forma temporal.",
-            "- Tc comparador: referencia especializada para coherencia Q-5.",
+            ...construirLineasTiempoConcentracionRolesTcExpediente({
+              Tc_final,
+              trDisenoActivoExpediente
+            }),
             "",
             "## 4. Volumen de referencia",
             `Lluvia efectiva total: ${Number.isFinite(peTotalMm) ? peTotalMm.toFixed(2) + " mm" : "—"}`,
@@ -3681,3 +3675,4 @@ const handleClickSeguro = (accion) => () => {
     </main>
   );
 }
+

--- a/07_TOOLBOX/validaciones/validar_ot0148_sustitucion_tiempo_concentracion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0148_sustitucion_tiempo_concentracion.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const patronBloqueManual =
+  /[ \t]*"## 3\. Tiempo de concentración y roles Tc",\s*`Tc comparador: \$\{Tc_final !== null && Tc_final !== undefined \? Number\(Tc_final\)\.toFixed\(1\) \+ " min" : "—"\}`,\s*`Tr global activo: \$\{trDisenoActivoExpediente\} años`,\s*"Nota Tr: estado global visual\/exportable; no implica recálculo automático hasta propagación hidrológica controlada\.",\s*"Roles Tc:",\s*"- Tc global Índice: referencia hidrológica general\.",\s*"- Tc operativo Q\(t\): ruta interna del hidrograma\.",\s*"- Duración evento: 3 h para almacenamiento\/regulación\.",\s*"- Lag \/ forma SCS: parámetro derivado para forma temporal\.",\s*"- Tc comparador: referencia especializada para coherencia Q-5\.",/s;
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe mantenerse textoExpediente"
+);
+
+assert.equal(
+  texto.includes("...construirLineasTiempoConcentracionRolesTcExpediente({"),
+  true,
+  "El bloque Tiempo de concentración debe usar expansión delegada"
+);
+
+assert.equal(
+  texto.includes("Tc_final"),
+  true,
+  "La sustitución delegada debe pasar Tc_final"
+);
+
+assert.equal(
+  texto.includes("trDisenoActivoExpediente"),
+  true,
+  "La sustitución delegada debe pasar trDisenoActivoExpediente"
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard"
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText"
+);
+
+assert.equal(
+  patronBloqueManual.test(texto),
+  false,
+  "No debe reaparecer el bloque manual antiguo de Tiempo de concentración"
+);
+
+assert.equal(
+  texto.includes("## 1. Identificación"),
+  true,
+  "Debe conservarse bloque Identificación"
+);
+
+assert.equal(
+  texto.includes("## 2. Parámetros hidrológicos base"),
+  true,
+  "Debe conservarse bloque Parámetros base"
+);
+
+assert.equal(
+  texto.includes("## 4."),
+  true,
+  "Debe conservarse bloque siguiente"
+);
+
+console.log("VALIDACION_OT_0148_SUSTITUCION_TIEMPO_CONCENTRACION_OK");


### PR DESCRIPTION
## Objetivo

Sustituir únicamente el bloque operativo `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por el helper delegado `construirLineasTiempoConcentracionRolesTcExpediente(...)`.

## Antecedente

La sustitución se realiza después de una secuencia controlada:

- OT-0143 implementó el helper puro;
- OT-0144 reforzó su validación aislada;
- OT-0145 corrigió el fallback de `Tc_final` vacío/null;
- OT-0146 integró el helper como diagnóstico no invasivo;
- OT-0147 confirmó coincidencia textual estricta 10/10 entre bloque delegado y referencia operativa.

## Cambio aplicado

Las líneas manuales del bloque:

```text
## 3. Tiempo de concentración y roles Tc
Tc comparador
Tr global activo
Nota Tr
Roles Tc
- Tc global Índice
- Tc operativo Q(t)
- Duración evento
- Lag / forma SCS
- Tc comparador Q-5