### PR TITLE
OT-0149 — Validación post-adopción Tiempo de concentración y roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0149/OT-0149A_apertura_validacion_post_adopcion_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0149/OT-0149A_apertura_validacion_post_adopcion_tiempo_concentracion.md
@@ -1,0 +1,40 @@
+# OT-0149A — Apertura validación post-adopción Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Validar que, después de OT-0148, el expediente operativo mantiene correctamente adoptado el bloque `## 3. Tiempo de concentración y roles Tc` desde el helper delegado.
+
+## Antecedente
+
+OT-0148 sustituyó parcialmente las líneas manuales del bloque `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente
+}),
+```
+
+## Alcance
+
+Esta OT solo valida post-adopción.
+
+No sustituye nuevos bloques.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0149/OT-0149B_cierre_validacion_post_adopcion_tiempo_concentracion.md
+++ b/00_ADMIN/bitacora/OT-0149/OT-0149B_cierre_validacion_post_adopcion_tiempo_concentracion.md
@@ -1,0 +1,48 @@
+# OT-0149B — Cierre validación post-adopción Tiempo de concentración y roles Tc
+
+## Resultado
+
+Se validó que el expediente operativo mantiene correctamente adoptado el bloque `## 3. Tiempo de concentración y roles Tc` desde el helper delegado.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0149_POST_ADOPCION_TIEMPO_CONCENTRACION_OK`;
+- `VALIDACION_OT_0148_SUSTITUCION_TIEMPO_CONCENTRACION_OK`;
+- `COMPARACION_OT_0147_TIEMPO_CONCENTRACION_OK`;
+- `VALIDACION_OT_0146_DIAGNOSTICA_TIEMPO_CONCENTRACION_OK`;
+- `VALIDACION_OT_0145_FALLBACK_TC_VACIO_NULL_OK`;
+- `VALIDACION_OT_0143_HELPER_TIEMPO_CONCENTRACION_OK`;
+- Build Vite aprobado.
+
+## Verificaciones confirmadas
+
+- `textoExpediente` sigue existiendo;
+- el bloque Tiempo de concentración se arma mediante `construirLineasTiempoConcentracionRolesTcExpediente(...)`;
+- no reaparece el bloque manual antiguo;
+- el bloque `## 1. Identificación` sigue presente;
+- el bloque `## 2. Parámetros hidrológicos base` sigue presente;
+- el bloque siguiente `## 4.` sigue presente;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introdujo `navigator.clipboard`;
+- no se introdujo `writeText`.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0149 confirma que la adopción parcial del bloque Tiempo de concentración y roles Tc quedó operativamente estable.
+
+No se sustituyen nuevos bloques en esta OT.

--- a/07_TOOLBOX/validaciones/validar_ot0149_post_adopcion_tiempo_concentracion.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0149_post_adopcion_tiempo_concentracion.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const patronBloqueManual =
+  /[ \t]*"## 3\. Tiempo de concentración y roles Tc",\s*`Tc comparador: \$\{Tc_final !== null && Tc_final !== undefined \? Number\(Tc_final\)\.toFixed\(1\) \+ " min" : "—"\}`,\s*`Tr global activo: \$\{trDisenoActivoExpediente\} años`,\s*"Nota Tr: estado global visual\/exportable; no implica recálculo automático hasta propagación hidrológica controlada\.",\s*"Roles Tc:",\s*"- Tc global Índice: referencia hidrológica general\.",\s*"- Tc operativo Q\(t\): ruta interna del hidrograma\.",\s*"- Duración evento: 3 h para almacenamiento\/regulación\.",\s*"- Lag \/ forma SCS: parámetro derivado para forma temporal\.",\s*"- Tc comparador: referencia especializada para coherencia Q-5\.",/s;
+
+const resumen = {
+  tieneTextoExpediente: texto.includes("const textoExpediente = ["),
+  usaHelperTiempoConcentracion: texto.includes("...construirLineasTiempoConcentracionRolesTcExpediente({"),
+  pasaTcFinal: texto.includes("Tc_final"),
+  pasaTrDisenoActivoExpediente: texto.includes("trDisenoActivoExpediente"),
+  bloqueIdentificacionPresente: texto.includes("## 1. Identificación"),
+  bloqueParametrosBasePresente: texto.includes("## 2. Parámetros hidrológicos base"),
+  bloqueSiguientePresente: texto.includes("## 4."),
+  portapapelesIntacto: texto.includes("areaTexto.value = textoExpediente"),
+  fallbackManualIntacto: texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  sinNavigatorClipboard: !texto.includes("navigator.clipboard"),
+  sinWriteText: !texto.includes("writeText"),
+  bloqueManualAntiguoDetectado: patronBloqueManual.test(texto)
+};
+
+assert.equal(resumen.tieneTextoExpediente, true, "Debe existir textoExpediente");
+assert.equal(resumen.usaHelperTiempoConcentracion, true, "Debe usarse helper delegado de Tiempo de concentración");
+assert.equal(resumen.pasaTcFinal, true, "Debe pasarse Tc_final");
+assert.equal(resumen.pasaTrDisenoActivoExpediente, true, "Debe pasarse trDisenoActivoExpediente");
+assert.equal(resumen.bloqueIdentificacionPresente, true, "Debe conservarse bloque Identificación");
+assert.equal(resumen.bloqueParametrosBasePresente, true, "Debe conservarse bloque Parámetros base");
+assert.equal(resumen.bloqueSiguientePresente, true, "Debe conservarse bloque siguiente");
+assert.equal(resumen.portapapelesIntacto, true, "Debe mantenerse areaTexto.value = textoExpediente");
+assert.equal(resumen.fallbackManualIntacto, true, "Debe mantenerse fallback manual con textoExpediente");
+assert.equal(resumen.sinNavigatorClipboard, true, "No debe introducirse navigator.clipboard");
+assert.equal(resumen.sinWriteText, true, "No debe introducirse writeText");
+assert.equal(resumen.bloqueManualAntiguoDetectado, false, "No debe reaparecer el bloque manual antiguo");
+
+console.log("VALIDACION_OT_0149_POST_ADOPCION_TIEMPO_CONCENTRACION_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Validar que, después de OT-0148, el expediente operativo mantiene correctamente adoptado el bloque `## 3. Tiempo de concentración y roles Tc` desde el helper delegado.

## Antecedente

OT-0148 sustituyó parcialmente las líneas manuales del bloque `## 3. Tiempo de concentración y roles Tc` dentro de `textoExpediente` por:

```javascript
...construirLineasTiempoConcentracionRolesTcExpediente({
  Tc_final,
  trDisenoActivoExpediente
}),