### PR TITLE
OT-0150C — Saneamiento documental auditoría Volumen de referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0150/OT-0150B_auditoria_bloque_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0150/OT-0150B_auditoria_bloque_volumen_referencia.md
@@ -2,7 +2,7 @@
 
 ## Resumen
 
-`json
+```json
 {
   "bloqueEncontrado": true,
   "lineaInicio": 2066,
@@ -15,19 +15,19 @@
   "comparadorModificado": false,
   "decisionPreliminar": "No delegar completo todavía. Conviene definir contrato documental y separar magnitudes hidrológicas sensibles antes de implementar helper."
 }
-`",
-  ",
-  
+```
 
-`jsx
+## Bloque auditado
+
+```jsx
  2066 |             "## 4. Volumen de referencia",
  2067 |             `Lluvia efectiva total: ${Number.isFinite(peTotalMm) ? peTotalMm.toFixed(2) + " mm" : "—"}`,
  2068 |             `Volumen esperado: ${volumenEsperadoM3 ? volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 }) + " m³" : "—"}`,
  2069 |             "Fórmula: Pe(mm) × Área(km²) × 1000.",
  2070 |             "",
-`",
-  ",
-  
+```
+
+## Clasificación general
 
 | Tipo | Cantidad |
 |---|---:|
@@ -36,9 +36,19 @@
 | Líneas técnicamente sensibles | 3 |
 | Separadores | 0 |
 
+## Clasificación línea a línea
+
+| Línea | Clasificación | Contenido |
+|---:|---|---|
+| 2066 | encabezado documental | `"## 4. Volumen de referencia",` |
+| 2067 | técnicamente sensible | `` `Lluvia efectiva total: ${Number.isFinite(peTotalMm) ? peTotalMm.toFixed(2) + " mm" : "—"}`, `` |
+| 2068 | técnicamente sensible | `` `Volumen esperado: ${volumenEsperadoM3 ? volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 }) + " m³" : "—"}`, `` |
+| 2069 | técnicamente sensible | `"Fórmula: Pe(mm) × Área(km²) × 1000.",` |
+| 2070 | documental / contextual | `"",` |
+
 ## Lectura técnica
 
-- El bloque contiene magnitudes hidrológicas sensibles asociadas a volumen, lluvia efectiva, área, Q-5 o consistencia de masa.
+- El bloque contiene magnitudes hidrológicas sensibles asociadas a volumen, lluvia efectiva, área y consistencia Pe–Área–Volumen.
 - No conviene delegar el bloque completo sin contrato documental previo.
 
 ## Decisión preliminar
@@ -47,8 +57,8 @@ No delegar completo todavía. Conviene definir contrato documental y separar mag
 
 ## Restricciones mantenidas
 
-- No se modificó ComparadorMultiMetodo.jsx.
-- No se sustituyó 	extoExpediente.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se sustituyó `textoExpediente`.
 - No se modificó botón.
 - No se modificó portapapeles.
 - No se tocó Q-5.
@@ -59,4 +69,4 @@ No delegar completo todavía. Conviene definir contrato documental y separar mag
 
 ## Siguiente paso recomendado
 
-Abrir una OT posterior para definir el contrato documental del bloque ## 4. Volumen de referencia, separando líneas puramente documentales de magnitudes hidrológicas sensibles.
+Abrir una OT posterior para definir el contrato documental del bloque `## 4. Volumen de referencia`, separando líneas puramente documentales de magnitudes hidrológicas sensibles.

--- a/00_ADMIN/bitacora/OT-0150/OT-0150C_saneamiento_auditoria_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0150/OT-0150C_saneamiento_auditoria_volumen_referencia.md
@@ -1,0 +1,33 @@
+# OT-0150C — Saneamiento documental auditoría Volumen de referencia
+
+## Hallazgo
+
+Después del merge de OT-0150, la bitácora `OT-0150B_auditoria_bloque_volumen_referencia.md` quedó con formato Markdown corrupto en los bloques JSON/JSX y con una línea de restricción alterada.
+
+## Corrección aplicada
+
+Se reescribió `OT-0150B` conservando el resultado técnico de la auditoría:
+
+- bloque encontrado;
+- líneas 2066 a 2070;
+- 5 líneas auditadas;
+- 3 líneas técnicamente sensibles;
+- decisión preliminar de no delegar sin contrato documental previo.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0150 queda documentalmente saneada y lista para servir como base de OT-0151.


### PR DESCRIPTION
## Objetivo

Sanear documentalmente la bitácora `OT-0150B_auditoria_bloque_volumen_referencia.md`.

## Hallazgo

Después del merge de OT-0150, la bitácora quedó con formato Markdown corrupto en los bloques JSON/JSX y una línea de restricción alterada.

## Corrección

Se reescribió `OT-0150B` conservando el resultado técnico de la auditoría:

- bloque encontrado;
- líneas 2066 a 2070;
- 5 líneas auditadas;
- 3 líneas técnicamente sensibles;
- decisión preliminar de no delegar sin contrato documental previo.

## Restricciones

No se modificó código operativo ni `ComparadorMultiMetodo.jsx`.

## Conclusión

OT-0150 queda documentalmente saneada y lista para servir como base de OT-0151.