### PR TITLE
OT-0151 — Contrato documental Volumen de referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0151/OT-0151A_apertura_contrato_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0151/OT-0151A_apertura_contrato_volumen_referencia.md
@@ -1,0 +1,54 @@
+# OT-0151A — Apertura contrato documental Volumen de referencia
+
+## Objetivo
+
+Definir el contrato documental del bloque `## 4. Volumen de referencia` antes de cualquier helper, integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0150 auditó el bloque `## 4. Volumen de referencia` y lo clasificó como técnicamente sensible.
+
+OT-0150C saneó documentalmente la auditoría para dejar una base limpia.
+
+## Bloque auditado
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total
+Volumen esperado
+Fórmula Pe(mm) × Área(km²) × 1000
+```
+
+## Alcance
+
+Esta OT solo define contrato documental.
+
+No implementa helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica principal
+
+- No calcular volumen.
+- No recalcular lluvia efectiva.
+- No recalcular área.
+- No recalcular masa.
+- No inferir Q-5.
+- No consultar motor.
+- Solo representar valores ya presentes o fallback documental.

--- a/00_ADMIN/bitacora/OT-0151/OT-0151B_contrato_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0151/OT-0151B_contrato_volumen_referencia.md
@@ -1,0 +1,96 @@
+# OT-0151B — Contrato documental del bloque Volumen de referencia
+
+## Bloque contractual
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: <valor | —>
+Volumen esperado: <valor | —>
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+## Naturaleza del bloque
+
+Este bloque es documental en su salida, pero contiene magnitudes hidrológicas sensibles.
+
+Magnitudes sensibles identificadas:
+
+- lluvia efectiva total;
+- volumen esperado;
+- fórmula Pe(mm) × Área(km²) × 1000;
+- consistencia Pe–Área–Volumen.
+
+## Orden obligatorio
+
+1. Encabezado `## 4. Volumen de referencia`;
+2. `Lluvia efectiva total`;
+3. `Volumen esperado`;
+4. `Fórmula: Pe(mm) × Área(km²) × 1000.`
+
+## Campos contractuales preliminares
+
+| Campo | Fuente esperada | Fallback | Calcular | Recalcular | Inferir | Consultar motor | Observación |
+|---|---|---|---|---|---|---|---|
+| `Lluvia efectiva total` | `peTotalMm` ya existente | `—` | No | No | No | No | Representar solo si es finito. |
+| `Volumen esperado` | `volumenEsperadoM3` ya existente | `—` | No | No | No | No | Representar solo valor ya disponible. |
+| `Fórmula` | texto operativo fijo | texto fijo | No | No | No | No | No ejecutar fórmula en helper futuro. |
+
+## Reglas de representación
+
+- Si `peTotalMm` existe y es finito, se representa con dos decimales y unidad `mm`.
+- Si `peTotalMm` no existe o no es finito, se representa `—`.
+- Si `volumenEsperadoM3` existe, se representa con separador local y unidad `m³`.
+- Si `volumenEsperadoM3` no existe, se representa `—`.
+- La fórmula se representa como texto fijo.
+- No se debe ejecutar la fórmula dentro del helper futuro.
+- No se debe recalcular volumen desde Pe y área.
+- No se debe recalcular Pe.
+- No se debe recalcular área.
+- No se debe consultar motor hidrológico.
+- No se debe modificar estado.
+
+## Residuos prohibidos
+
+- `undefined`;
+- `null`;
+- `NaN`;
+- `[object Object]`.
+
+## Ejemplo con contexto completo
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: 56.65 mm
+Volumen esperado: 2.654.251 m³
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+## Ejemplo con fallback
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: —
+Volumen esperado: —
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+## Criterio de validación futura
+
+- retorno tipo arreglo;
+- 4 líneas;
+- encabezado exacto;
+- lluvia efectiva con `mm` si existe y es finita;
+- fallback `—` para lluvia efectiva no finita;
+- volumen esperado con `m³` si existe;
+- fallback `—` para volumen esperado ausente;
+- fórmula conservada literal;
+- ausencia de residuos técnicos;
+- ausencia de cálculo, recálculo, inferencia o consulta al motor.
+
+## Decisión contractual
+
+El bloque puede avanzar a una OT posterior de extracción exacta de forma operativa antes del diseño de helper puro.
+
+## Próxima OT recomendada
+
+`OT-0152 — Extracción exacta del bloque Volumen de referencia operativo`


### PR DESCRIPTION
## Objetivo

Definir el contrato documental del bloque `## 4. Volumen de referencia` antes de cualquier helper, integración diagnóstica o sustitución.

## Antecedente

OT-0150 auditó el bloque `## 4. Volumen de referencia` y lo clasificó como técnicamente sensible.

OT-0150C saneó documentalmente la auditoría para dejar una base limpia.

## Bloque contractual

```text
## 4. Volumen de referencia
Lluvia efectiva total: <valor | —>
Volumen esperado: <valor | —>
Fórmula: Pe(mm) × Área(km²) × 1000.
``