### PR TITLE
OT-0155 — Validación reforzada helper Volumen de referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0155/OT-0155A_apertura_validacion_reforzada_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0155/OT-0155A_apertura_validacion_reforzada_volumen_referencia.md
@@ -1,0 +1,51 @@
+# OT-0155A — Apertura validación reforzada helper Volumen de referencia
+
+## Objetivo
+
+Validar de forma aislada y reforzada el helper puro `construirLineasVolumenReferenciaExpediente(...)` antes de cualquier integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0154 implementó el helper puro representacional para el bloque `## 4. Volumen de referencia`.
+
+La validación inicial confirmó contexto completo, fallback, lluvia no finita, volumen vacío y volumen objeto.
+
+## Alcance
+
+Esta OT solo refuerza la validación aislada.
+
+No modifica el helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No integra en UI.
+
+No sustituye `textoExpediente`.
+
+## Casos borde a validar
+
+- `peTotalMm: 0`;
+- `peTotalMm: ""`;
+- `peTotalMm: "56.65"`;
+- `peTotalMm: null`;
+- `peTotalMm: object`;
+- `volumenEsperadoM3: 0`;
+- `volumenEsperadoM3: "2654251"`;
+- `volumenEsperadoM3: NaN`;
+- `volumenEsperadoM3: null`;
+- entrada vacía.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- helper documental;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0155/OT-0155B_cierre_validacion_reforzada_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0155/OT-0155B_cierre_validacion_reforzada_volumen_referencia.md
@@ -1,0 +1,43 @@
+# OT-0155B — Cierre validación reforzada helper Volumen de referencia
+
+## Resultado
+
+Se reforzó la validación aislada del helper `construirLineasVolumenReferenciaExpediente(...)`.
+
+## Casos validados
+
+- `peTotalMm: 0`;
+- `peTotalMm: ""`;
+- `peTotalMm: "56.65"`;
+- `peTotalMm: null`;
+- `peTotalMm: object`;
+- `volumenEsperadoM3: 0`;
+- `volumenEsperadoM3: "2654251"`;
+- `volumenEsperadoM3: NaN`;
+- `volumenEsperadoM3: null`;
+- entrada vacía.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK`;
+- `VALIDACION_OT_0154_HELPER_VOLUMEN_REFERENCIA_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Volumen de referencia queda reforzado frente a casos borde, manteniendo comportamiento estrictamente representacional.

--- a/00_ADMIN/bitacora/OT-0155/OT-0155C_correccion_validacion_reforzada_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0155/OT-0155C_correccion_validacion_reforzada_volumen_referencia.md
@@ -1,0 +1,47 @@
+# OT-0155C — Corrección validación reforzada helper Volumen de referencia
+
+## Hallazgo
+
+La primera versión del script `validar_ot0155_helper_volumen_referencia_reforzada.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.
+
+## Corrección aplicada
+
+Se reescribió el validador reforzado con matriz completa de casos borde para `peTotalMm` y `volumenEsperadoM3`.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK`;
+- `VALIDACION_OT_0154_HELPER_VOLUMEN_REFERENCIA_OK`;
+- Build Vite aprobado.
+
+## Casos confirmados
+
+- `peTotalMm: 0`;
+- `peTotalMm: ""`;
+- `peTotalMm: "56.65"`;
+- `peTotalMm: null`;
+- `peTotalMm: object`;
+- `volumenEsperadoM3: 0`;
+- `volumenEsperadoM3: "2654251"`;
+- `volumenEsperadoM3: NaN`;
+- `volumenEsperadoM3: null`;
+- entrada vacía.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0155 queda corregida y validada. El helper de Volumen de referencia queda reforzado frente a casos borde.

--- a/07_TOOLBOX/validaciones/validar_ot0155_helper_volumen_referencia_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0155_helper_volumen_referencia_reforzada.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { construirLineasVolumenReferenciaExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas.length, 4, `${nombreCaso}: debe retornar 4 líneas`);
+  assert.equal(lineas[0], "## 4. Volumen de referencia", `${nombreCaso}: encabezado exacto`);
+  assert.equal(lineas[3], "Fórmula: Pe(mm) × Área(km²) × 1000.", `${nombreCaso}: fórmula literal`);
+}
+
+function validarCaso(nombreCaso, entrada, esperados) {
+  const lineas = construirLineasVolumenReferenciaExpediente(entrada);
+  const texto = lineas.join("\n");
+
+  validarEstructura(nombreCaso, lineas);
+  validarSinResiduos(nombreCaso, texto);
+
+  for (const esperado of esperados) {
+    assert.equal(
+      texto.includes(esperado),
+      true,
+      `${nombreCaso}: debe incluir ${esperado}`
+    );
+  }
+
+  console.log(`OK ${nombreCaso}`);
+  console.log(texto);
+}
+
+const casos = [
+  {
+    nombre: "pe cero",
+    entrada: {
+      peTotalMm: 0,
+      volumenEsperadoM3: 2654251
+    },
+    esperados: [
+      "Lluvia efectiva total: 0.00 mm",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "pe vacio",
+    entrada: {
+      peTotalMm: "",
+      volumenEsperadoM3: 2654251
+    },
+    esperados: [
+      "Lluvia efectiva total: —",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "pe string numerico",
+    entrada: {
+      peTotalMm: "56.65",
+      volumenEsperadoM3: 2654251
+    },
+    esperados: [
+      "Lluvia efectiva total: 56.65 mm",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "pe null",
+    entrada: {
+      peTotalMm: null,
+      volumenEsperadoM3: 2654251
+    },
+    esperados: [
+      "Lluvia efectiva total: —",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "pe objeto",
+    entrada: {
+      peTotalMm: { 
+    esperados: [
+      "Lluvia efectiva total: 56.65 mm",
+      "Volumen esperado: —"
+    ]
+  },
+  {
+    nombre: "entrada vacia",
+    entrada: {},
+    esperados: [
+      "Lluvia efectiva total: —",
+      "Volumen esperado: —"
+    ]
+  }
+];
+
+for (const caso of casos) {
+  validarCaso(caso.nombre, caso.entrada, caso.esperados);
+}
+
+console.log("VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0155_helper_volumen_referencia_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0155_helper_volumen_referencia_reforzada.mjs
@@ -87,7 +87,53 @@ const casos = [
   {
     nombre: "pe objeto",
     entrada: {
-      peTotalMm: { 
+      peTotalMm: { valor: 56.65 },
+      volumenEsperadoM3: 2654251
+    },
+    esperados: [
+      "Lluvia efectiva total: —",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "volumen cero",
+    entrada: {
+      peTotalMm: 56.65,
+      volumenEsperadoM3: 0
+    },
+    esperados: [
+      "Lluvia efectiva total: 56.65 mm",
+      "Volumen esperado: 0 m³"
+    ]
+  },
+  {
+    nombre: "volumen string numerico",
+    entrada: {
+      peTotalMm: 56.65,
+      volumenEsperadoM3: "2654251"
+    },
+    esperados: [
+      "Lluvia efectiva total: 56.65 mm",
+      "Volumen esperado: 2.654.251 m³"
+    ]
+  },
+  {
+    nombre: "volumen NaN",
+    entrada: {
+      peTotalMm: 56.65,
+      volumenEsperadoM3: Number.NaN
+    },
+    esperados: [
+      "Lluvia efectiva total: 56.65 mm",
+      "Volumen esperado: —"
+    ]
+  },
+  {
+    nombre: "volumen null",
+    entrada: {
+      peTotalMm: 56.65,
+      volumenEsperadoM3: null
+    },
     esperados: [
       "Lluvia efectiva total: 56.65 mm",
       "Volumen esperado: —"


### PR DESCRIPTION
## Objetivo

Validar de forma aislada y reforzada el helper puro `construirLineasVolumenReferenciaExpediente(...)` antes de cualquier integración diagnóstica o sustitución.

## Antecedente

OT-0154 implementó el helper puro representacional para el bloque `## 4. Volumen de referencia`.

La validación inicial confirmó:

- contexto completo;
- contexto fallback;
- lluvia no finita;
- volumen vacío;
- volumen objeto.

## Corrección aplicada

La primera versión del script `validar_ot0155_helper_volumen_referencia_reforzada.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.

Se corrigió mediante el commit:

```text
fix(expediente): corrige validacion reforzada volumen referencia