### PR TITLE
OT-0157 — Comparación textual Volumen de referencia delegado vs operativo

### DIFF
--- a/00_ADMIN/bitacora/OT-0157/OT-0157A_apertura_comparacion_textual_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0157/OT-0157A_apertura_comparacion_textual_volumen_referencia.md
@@ -1,0 +1,47 @@
+# OT-0157A — Apertura comparación textual Volumen de referencia delegado vs operativo
+
+## Objetivo
+
+Comparar de forma controlada el bloque `## 4. Volumen de referencia` generado por el helper delegado frente al bloque operativo actual del expediente.
+
+## Antecedente
+
+OT-0154 implementó el helper puro `construirLineasVolumenReferenciaExpediente(...)`.
+
+OT-0155 reforzó su validación aislada.
+
+OT-0156 integró el helper en `ComparadorMultiMetodo.jsx` solo como diagnóstico no invasivo.
+
+## Alcance
+
+Esta OT solo compara texto delegado vs referencia operativa.
+
+No sustituye el bloque operativo.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Criterio de cierre
+
+OT-0157 se considera válida si:
+
+- el bloque delegado retorna 4 líneas;
+- el bloque operativo de referencia tiene 4 líneas;
+- encabezado, lluvia efectiva, volumen esperado y fórmula coinciden;
+- no hay residuos técnicos;
+- `ComparadorMultiMetodo.jsx` queda sin cambios.

--- a/00_ADMIN/bitacora/OT-0157/OT-0157B_comparacion_textual_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0157/OT-0157B_comparacion_textual_volumen_referencia.md
@@ -1,0 +1,63 @@
+# OT-0157B — Comparación textual Volumen de referencia delegado vs operativo
+
+## Resumen
+
+```json
+{
+  "lineasDelegadas": 4,
+  "lineasOperativas": 4,
+  "coincidenciasEstrictas": 4,
+  "diferenciasEstrictas": 0,
+  "residuosDelegado": [],
+  "residuosOperativo": [],
+  "textoExpedienteNoSustituido": true,
+  "portapapelesSigueUsandoTextoExpediente": true,
+  "fallbackManualSigueUsandoTextoExpediente": true
+}
+```
+
+## Bloque delegado
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: 56.65 mm
+Volumen esperado: 2.654.251 m³
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+## Bloque operativo de referencia
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: 56.65 mm
+Volumen esperado: 2.654.251 m³
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+## Comparación línea a línea
+
+| Línea | Delegada | Operativa | Resultado |
+|---:|---|---|---|
+| 1 | `## 4. Volumen de referencia` | `## 4. Volumen de referencia` | Sin diferencia |
+| 2 | `Lluvia efectiva total: 56.65 mm` | `Lluvia efectiva total: 56.65 mm` | Sin diferencia |
+| 3 | `Volumen esperado: 2.654.251 m³` | `Volumen esperado: 2.654.251 m³` | Sin diferencia |
+| 4 | `Fórmula: Pe(mm) × Área(km²) × 1000.` | `Fórmula: Pe(mm) × Área(km²) × 1000.` | Sin diferencia |
+
+## Lectura técnica
+
+- El bloque delegado coincide estrictamente con el bloque operativo de referencia.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se reemplazó `textoExpediente`.
+- No se modificó botón.
+- No se modificó portapapeles.
+- No se tocó Q-5.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.
+
+## Conclusión
+
+El bloque Volumen de referencia delegado queda en coincidencia textual estricta con la referencia operativa controlada.

--- a/00_ADMIN/bitacora/OT-0157/OT-0157C_cierre_comparacion_textual_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0157/OT-0157C_cierre_comparacion_textual_volumen_referencia.md
@@ -1,0 +1,41 @@
+# OT-0157C — Cierre comparación textual Volumen de referencia
+
+## Resultado
+
+Se comparó el bloque `## 4. Volumen de referencia` delegado frente a la referencia operativa controlada.
+
+## Validaciones aprobadas
+
+- `COMPARACION_OT_0157_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0156_DIAGNOSTICA_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK`;
+- `VALIDACION_OT_0154_HELPER_VOLUMEN_REFERENCIA_OK`;
+- Build Vite aprobado.
+
+## Resultado esperado
+
+- 4 líneas delegadas;
+- 4 líneas operativas;
+- coincidencia estricta 4/4;
+- 0 diferencias estrictas;
+- 0 residuos técnicos.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El bloque Volumen de referencia delegado queda listo para sustitución parcial controlada en una OT posterior.
+
+No se sustituye nada en esta OT.

--- a/07_TOOLBOX/validaciones/comparar_ot0157_volumen_referencia_delegado_operativo.mjs
+++ b/07_TOOLBOX/validaciones/comparar_ot0157_volumen_referencia_delegado_operativo.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { construirLineasVolumenReferenciaExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0157/OT-0157B_comparacion_textual_volumen_referencia.md"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+
+const contextoReferencia = {
+  peTotalMm: 56.65,
+  volumenEsperadoM3: 2654251
+};
+
+const lineasDelegadas =
+  construirLineasVolumenReferenciaExpediente(contextoReferencia);
+
+const lineasOperativasReferencia = [
+  "## 4. Volumen de referencia",
+  "Lluvia efectiva total: 56.65 mm",
+  "Volumen esperado: 2.654.251 m³",
+  "Fórmula: Pe(mm) × Área(km²) × 1000."
+];
+
+const residuosTecnicos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+function compararLinea(indice, delegada, operativa) {
+  const igualEstricta = delegada === operativa;
+
+  return {
+    linea: indice + 1,
+    delegada,
+    operativa,
+    igualEstricta,
+    diferencia: igualEstricta ? "Sin diferencia" : "Diferencia textual"
+  };
+}
+
+assert.equal(Array.isArray(lineasDelegadas), true, "El bloque delegado debe retornar arreglo");
+assert.equal(lineasDelegadas.length, 4, "El bloque delegado debe retornar 4 líneas");
+assert.equal(lineasOperativasReferencia.length, 4, "El bloque operativo de referencia debe tener 4 líneas");
+
+assert.equal(
+  textoComparador.includes("## 4. Volumen de referencia"),
+  true,
+  "ComparadorMultiMetodo.jsx debe conservar el bloque operativo de Volumen de referencia"
+);
+
+assert.equal(
+  textoComparador.includes("construirLineasVolumenReferenciaExpediente"),
+  true,
+  "ComparadorMultiMetodo.jsx debe conservar la integración diagnóstica del helper"
+);
+
+assert.equal(
+  textoComparador.includes("const textoExpediente = ["),
+  true,
+  "Debe mantenerse textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+assert.equal(
+  textoComparador.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard"
+);
+
+assert.equal(
+  textoComparador.includes("writeText"),
+  false,
+  "No debe introducirse writeText"
+);
+
+const textoDelegado = lineasDelegadas.join("\n");
+const textoOperativo = lineasOperativasReferencia.join("\n");
+
+const residuosDelegado = residuosTecnicos.filter((token) =>
+  textoDelegado.includes(token)
+);
+
+const residuosOperativo = residuosTecnicos.filter((token) =>
+  textoOperativo.includes(token)
+);
+
+assert.equal(residuosDelegado.length, 0, "El bloque delegado no debe contener residuos técnicos");
+assert.equal(residuosOperativo.length, 0, "El bloque operativo de referencia no debe contener residuos técnicos");
+
+const comparacion = lineasDelegadas.map((lineaDelegada, indice) =>
+  compararLinea(indice, lineaDelegada, lineasOperativasReferencia[indice])
+);
+
+const diferenciasEstrictas = comparacion.filter((item) => !item.igualEstricta);
+
+const resumen = {
+  lineasDelegadas: lineasDelegadas.length,
+  lineasOperativas: lineasOperativasReferencia.length,
+  coincidenciasEstrictas: comparacion.filter((item) => item.igualEstricta).length,
+  diferenciasEstrictas: diferenciasEstrictas.length,
+  residuosDelegado,
+  residuosOperativo,
+  textoExpedienteNoSustituido: textoComparador.includes("const textoExpediente = ["),
+  portapapelesSigueUsandoTextoExpediente: textoComparador.includes("areaTexto.value = textoExpediente"),
+  fallbackManualSigueUsandoTextoExpediente: textoComparador.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)")
+};
+
+const lineasReporte = [
+  "# OT-0157B — Comparación textual Volumen de referencia delegado vs operativo",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque delegado",
+  "",
+  "```text",
+  textoDelegado,
+  "```",
+  "",
+  "## Bloque operativo de referencia",
+  "",
+  "```text",
+  textoOperativo,
+  "```",
+  "",
+  "## Comparación línea a línea",
+  "",
+  "| Línea | Delegada | Operativa | Resultado |",
+  "|---:|---|---|---|",
+  ...comparacion.map((item) =>
+    `| ${item.linea} | \`${item.delegada}\` | \`${item.operativa}\` | ${item.diferencia} |`
+  ),
+  "",
+  "## Lectura técnica",
+  "",
+  diferenciasEstrictas.length === 0
+    ? "- El bloque delegado coincide estrictamente con el bloque operativo de referencia."
+    : "- El bloque delegado no coincide estrictamente con el bloque operativo de referencia.",
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se reemplazó `textoExpediente`.",
+  "- No se modificó botón.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico.",
+  "",
+  "## Conclusión",
+  "",
+  diferenciasEstrictas.length === 0
+    ? "El bloque Volumen de referencia delegado queda en coincidencia textual estricta con la referencia operativa controlada."
+    : "El bloque requiere revisión antes de cualquier sustitución."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("COMPARACION_OT_0157_VOLUMEN_REFERENCIA_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Comparar de forma controlada el bloque `## 4. Volumen de referencia` generado por el helper delegado frente al bloque operativo actual del expediente.

## Antecedente

OT-0154 implementó el helper puro `construirLineasVolumenReferenciaExpediente(...)`.

OT-0155 reforzó su validación aislada.

OT-0156 integró el helper en `ComparadorMultiMetodo.jsx` solo como diagnóstico no invasivo.

## Trabajo realizado

Se creó una comparación textual controlada entre:

- bloque delegado generado por `construirLineasVolumenReferenciaExpediente(...)`;
- bloque operativo de referencia con:
  - `## 4. Volumen de referencia`;
  - `Lluvia efectiva total`;
  - `Volumen esperado`;
  - `Fórmula: Pe(mm) × Área(km²) × 1000.`.

## Resultado

Validación aprobada:

```text
COMPARACION_OT_0157_VOLUMEN_REFERENCIA_OK