### PR TITLE
OT-0158 — Sustitución parcial Volumen de referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0158/OT-0158A_apertura_sustitucion_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0158/OT-0158A_apertura_sustitucion_volumen_referencia.md
@@ -1,0 +1,35 @@
+# OT-0158A — Apertura sustitución parcial Volumen de referencia
+
+## Objetivo
+
+Sustituir únicamente el bloque operativo `## 4. Volumen de referencia` dentro de `textoExpediente` por el helper delegado `construirLineasVolumenReferenciaExpediente(...)`.
+
+## Antecedente
+
+OT-0154 implementó el helper puro.
+
+OT-0155 reforzó su validación aislada.
+
+OT-0156 integró el helper como diagnóstico no invasivo.
+
+OT-0157 confirmó coincidencia textual estricta 4/4 entre delegado y referencia operativa.
+
+## Alcance
+
+Esta OT sustituye solo el bloque `## 4. Volumen de referencia`.
+
+No modifica los bloques `## 1`, `## 2` ni `## 3`.
+
+No modifica otros bloques del expediente.
+
+## Restricciones
+
+No se modifica:
+
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0158/OT-0158B_sustitucion_parcial_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0158/OT-0158B_sustitucion_parcial_volumen_referencia.md
@@ -1,0 +1,33 @@
+# OT-0158B — Sustitución parcial del bloque Volumen de referencia
+
+## Cambio aplicado
+
+Se sustituyeron únicamente las líneas manuales del bloque `## 4. Volumen de referencia` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasVolumenReferenciaExpediente({
+  peTotalMm,
+  volumenEsperadoM3
+}),
+```
+
+## Alcance del cambio
+
+La sustitución se limitó al bloque Volumen de referencia.
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- bloque `## 2. Parámetros hidrológicos base`;
+- bloque `## 3. Tiempo de concentración y roles Tc`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Nota técnica
+
+La sustitución se habilitó porque OT-0157 confirmó coincidencia textual estricta 4/4 entre bloque delegado y referencia operativa controlada.

--- a/00_ADMIN/bitacora/OT-0158/OT-0158C_cierre_sustitucion_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0158/OT-0158C_cierre_sustitucion_volumen_referencia.md
@@ -1,0 +1,51 @@
+# OT-0158C — Cierre sustitución parcial Volumen de referencia
+
+## Resultado
+
+Se sustituyó parcialmente el bloque `## 4. Volumen de referencia` dentro de `textoExpediente` por el helper delegado.
+
+## Cambio aplicado
+
+Las líneas manuales del bloque fueron reemplazadas por:
+
+```javascript
+...construirLineasVolumenReferenciaExpediente({
+  peTotalMm,
+  volumenEsperadoM3
+}),
+```
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0158_SUSTITUCION_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0156_DIAGNOSTICA_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK`;
+- `VALIDACION_OT_0154_HELPER_VOLUMEN_REFERENCIA_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- bloque `## 1. Identificación`;
+- bloque `## 2. Parámetros hidrológicos base`;
+- bloque `## 3. Tiempo de concentración y roles Tc`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Verificaciones clave
+
+`areaTexto.value = textoExpediente` sigue intacto.
+
+`window.prompt(..., textoExpediente)` sigue intacto.
+
+No se introdujo `navigator.clipboard` ni `writeText`.
+
+## Conclusión
+
+El bloque Volumen de referencia queda adoptado parcialmente desde el helper delegado, manteniendo el resto del expediente operativo sin sustituciones adicionales.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2064,10 +2064,10 @@ const handleClickSeguro = (accion) => () => {
               trDisenoActivoExpediente
             }),
             "",
-            "## 4. Volumen de referencia",
-            `Lluvia efectiva total: ${Number.isFinite(peTotalMm) ? peTotalMm.toFixed(2) + " mm" : "—"}`,
-            `Volumen esperado: ${volumenEsperadoM3 ? volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 }) + " m³" : "—"}`,
-            "Fórmula: Pe(mm) × Área(km²) × 1000.",
+            ...construirLineasVolumenReferenciaExpediente({
+              peTotalMm,
+              volumenEsperadoM3
+            }),
             "",
                 "## 5. Escenario Q-Tr activo — control de trazabilidad",
                 `Estado: ${estadoQTrActivoExpediente?.estado ?? "no_publicado"}`,

--- a/07_TOOLBOX/validaciones/aplicar_ot0158_sustitucion_volumen_referencia.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0158_sustitucion_volumen_referencia.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+let texto = fs.readFileSync(rutaComparador, "utf8");
+
+assert.equal(
+  texto.includes("construirLineasVolumenReferenciaExpediente"),
+  true,
+  "Debe existir el import/uso de construirLineasVolumenReferenciaExpediente"
+);
+
+const patronManual =
+  /            "## 4\. Volumen de referencia",\r?\n            `Lluvia efectiva total: \$\{Number\.isFinite\(peTotalMm\) \? peTotalMm\.toFixed\(2\) \+ " mm" : "—"\}`,\r?\n            `Volumen esperado: \$\{volumenEsperadoM3 \? volumenEsperadoM3\.toLocaleString\("es-CO", \{ maximumFractionDigits: 0 \}\) \+ " m³" : "—"\}`,\r?\n            "Fórmula: Pe\(mm\) × Área\(km²\) × 1000\.",/;
+
+const coincidencias = texto.match(patronManual);
+
+assert.notEqual(
+  coincidencias,
+  null,
+  "Debe existir el bloque manual operativo ## 4 para sustituir"
+);
+
+assert.equal(
+  (texto.match(patronManual) || []).length,
+  1,
+  "Debe existir exactamente un bloque manual operativo ## 4"
+);
+
+const bloqueDelegado = `            ...construirLineasVolumenReferenciaExpediente({
+              peTotalMm,
+              volumenEsperadoM3
+            }),`;
+
+texto = texto.replace(patronManual, bloqueDelegado);
+
+fs.writeFileSync(rutaComparador, texto.trimEnd() + "\n", "utf8");
+
+console.log("APLICACION_OT_0158_SUSTITUCION_VOLUMEN_REFERENCIA_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0158_sustitucion_volumen_referencia.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0158_sustitucion_volumen_referencia.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const patronManual =
+  /            "## 4\. Volumen de referencia",\r?\n            `Lluvia efectiva total: \$\{Number\.isFinite\(peTotalMm\) \? peTotalMm\.toFixed\(2\) \+ " mm" : "—"\}`,\r?\n            `Volumen esperado: \$\{volumenEsperadoM3 \? volumenEsperadoM3\.toLocaleString\("es-CO", \{ maximumFractionDigits: 0 \}\) \+ " m³" : "—"\}`,\r?\n            "Fórmula: Pe\(mm\) × Área\(km²\) × 1000\.",/;
+
+assert.equal(texto.includes("const textoExpediente = ["), true, "Debe mantenerse textoExpediente");
+
+assert.equal(
+  texto.includes("...construirLineasVolumenReferenciaExpediente({"),
+  true,
+  "El bloque Volumen de referencia debe usar expansión delegada"
+);
+
+assert.equal(texto.includes("peTotalMm"), true, "La sustitución delegada debe pasar peTotalMm");
+assert.equal(texto.includes("volumenEsperadoM3"), true, "La sustitución delegada debe pasar volumenEsperadoM3");
+
+assert.equal(
+  patronManual.test(texto),
+  false,
+  "No debe reaparecer el bloque manual antiguo de Volumen de referencia"
+);
+
+assert.equal(texto.includes("areaTexto.value = textoExpediente"), true, "El portapapeles debe seguir usando textoExpediente");
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente"
+);
+
+assert.equal(texto.includes("navigator.clipboard"), false, "No debe introducirse navigator.clipboard");
+assert.equal(texto.includes("writeText"), false, "No debe introducirse writeText");
+
+assert.equal(texto.includes("## 1. Identificación"), true, "Debe conservarse bloque Identificación");
+assert.equal(texto.includes("## 2. Parámetros hidrológicos base"), true, "Debe conservarse bloque Parámetros base");
+assert.equal(texto.includes("## 3. Tiempo de concentración y roles Tc"), true, "Debe conservarse bloque Tiempo de concentración");
+
+console.log("VALIDACION_OT_0158_SUSTITUCION_VOLUMEN_REFERENCIA_OK");


### PR DESCRIPTION
## Objetivo

Sustituir únicamente el bloque operativo `## 4. Volumen de referencia` dentro de `textoExpediente` por el helper delegado `construirLineasVolumenReferenciaExpediente(...)`.

## Antecedente

La sustitución se realiza después de una secuencia controlada:

- OT-0154 implementó el helper puro;
- OT-0155 reforzó su validación aislada;
- OT-0156 integró el helper como diagnóstico no invasivo;
- OT-0157 confirmó coincidencia textual estricta 4/4 entre bloque delegado y referencia operativa.

## Cambio aplicado

Las líneas manuales del bloque:

```text
## 4. Volumen de referencia
Lluvia efectiva total
Volumen esperado
Fórmula: Pe(mm) × Área(km²) × 1000.