### PR TITLE
OT-0159 — Validación post-adopción Volumen de referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0159/OT-0159A_apertura_validacion_post_adopcion_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0159/OT-0159A_apertura_validacion_post_adopcion_volumen_referencia.md
@@ -1,0 +1,40 @@
+# OT-0159A — Apertura validación post-adopción Volumen de referencia
+
+## Objetivo
+
+Validar que, después de OT-0158, el expediente operativo mantiene correctamente adoptado el bloque `## 4. Volumen de referencia` desde el helper delegado.
+
+## Antecedente
+
+OT-0158 sustituyó parcialmente las líneas manuales del bloque `## 4. Volumen de referencia` dentro de `textoExpediente` por:
+
+```javascript
+...construirLineasVolumenReferenciaExpediente({
+  peTotalMm,
+  volumenEsperadoM3
+}),
+```
+
+## Alcance
+
+Esta OT solo valida post-adopción.
+
+No sustituye nuevos bloques.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0159/OT-0159B_cierre_validacion_post_adopcion_volumen_referencia.md
+++ b/00_ADMIN/bitacora/OT-0159/OT-0159B_cierre_validacion_post_adopcion_volumen_referencia.md
@@ -1,0 +1,48 @@
+# OT-0159B — Cierre validación post-adopción Volumen de referencia
+
+## Resultado
+
+Se validó que el expediente operativo mantiene correctamente adoptado el bloque `## 4. Volumen de referencia` desde el helper delegado.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0159_POST_ADOPCION_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0158_SUSTITUCION_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0156_DIAGNOSTICA_VOLUMEN_REFERENCIA_OK`;
+- `VALIDACION_OT_0155_HELPER_VOLUMEN_REFERENCIA_REFORZADA_OK`;
+- `VALIDACION_OT_0154_HELPER_VOLUMEN_REFERENCIA_OK`;
+- Build Vite aprobado.
+
+## Verificaciones confirmadas
+
+- `textoExpediente` sigue existiendo;
+- el bloque Volumen de referencia se arma mediante `construirLineasVolumenReferenciaExpediente(...)`;
+- no reaparece el bloque manual antiguo;
+- el bloque `## 1. Identificación` sigue presente;
+- el bloque `## 2. Parámetros hidrológicos base` sigue presente;
+- el bloque `## 3. Tiempo de concentración y roles Tc` sigue presente;
+- el bloque siguiente `## 5.` sigue presente;
+- `areaTexto.value = textoExpediente` sigue intacto;
+- `window.prompt(..., textoExpediente)` sigue intacto;
+- no se introdujo `navigator.clipboard`;
+- no se introdujo `writeText`.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0159 confirma que la adopción parcial del bloque Volumen de referencia quedó operativamente estable.
+
+No se sustituyen nuevos bloques en esta OT.

--- a/07_TOOLBOX/validaciones/validar_ot0159_post_adopcion_volumen_referencia.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0159_post_adopcion_volumen_referencia.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const patronBloqueManual =
+  /            "## 4\. Volumen de referencia",\r?\n            `Lluvia efectiva total: \$\{Number\.isFinite\(peTotalMm\) \? peTotalMm\.toFixed\(2\) \+ " mm" : "—"\}`,\r?\n            `Volumen esperado: \$\{volumenEsperadoM3 \? volumenEsperadoM3\.toLocaleString\("es-CO", \{ maximumFractionDigits: 0 \}\) \+ " m³" : "—"\}`,\r?\n            "Fórmula: Pe\(mm\) × Área\(km²\) × 1000\.",/;
+
+const resumen = {
+  tieneTextoExpediente: texto.includes("const textoExpediente = ["),
+  usaHelperVolumenReferencia: texto.includes("...construirLineasVolumenReferenciaExpediente({"),
+  pasaPeTotalMm: texto.includes("peTotalMm"),
+  pasaVolumenEsperadoM3: texto.includes("volumenEsperadoM3"),
+  bloqueIdentificacionPresente: texto.includes("## 1. Identificación"),
+  bloqueParametrosBasePresente: texto.includes("## 2. Parámetros hidrológicos base"),
+  bloqueTiempoConcentracionPresente: texto.includes("## 3. Tiempo de concentración y roles Tc"),
+  bloqueSiguientePresente: texto.includes("## 5."),
+  portapapelesIntacto: texto.includes("areaTexto.value = textoExpediente"),
+  fallbackManualIntacto: texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  sinNavigatorClipboard: !texto.includes("navigator.clipboard"),
+  sinWriteText: !texto.includes("writeText"),
+  bloqueManualAntiguoDetectado: patronBloqueManual.test(texto)
+};
+
+assert.equal(resumen.tieneTextoExpediente, true, "Debe existir textoExpediente");
+assert.equal(resumen.usaHelperVolumenReferencia, true, "Debe usarse helper delegado de Volumen de referencia");
+assert.equal(resumen.pasaPeTotalMm, true, "Debe pasarse peTotalMm");
+assert.equal(resumen.pasaVolumenEsperadoM3, true, "Debe pasarse volumenEsperadoM3");
+assert.equal(resumen.bloqueIdentificacionPresente, true, "Debe conservarse bloque Identificación");
+assert.equal(resumen.bloqueParametrosBasePresente, true, "Debe conservarse bloque Parámetros base");
+assert.equal(resumen.bloqueTiempoConcentracionPresente, true, "Debe conservarse bloque Tiempo de concentración");
+assert.equal(resumen.bloqueSiguientePresente, true, "Debe conservarse bloque siguiente");
+assert.equal(resumen.portapapelesIntacto, true, "Debe mantenerse areaTexto.value = textoExpediente");
+assert.equal(resumen.fallbackManualIntacto, true, "Debe mantenerse fallback manual con textoExpediente");
+assert.equal(resumen.sinNavigatorClipboard, true, "No debe introducirse navigator.clipboard");
+assert.equal(resumen.sinWriteText, true, "No debe introducirse writeText");
+assert.equal(resumen.bloqueManualAntiguoDetectado, false, "No debe reaparecer el bloque manual antiguo de Volumen de referencia");
+
+console.log("VALIDACION_OT_0159_POST_ADOPCION_VOLUMEN_REFERENCIA_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Validar que, después de OT-0158, el expediente operativo mantiene correctamente adoptado el bloque `## 4. Volumen de referencia` desde el helper delegado.

## Antecedente

OT-0158 sustituyó parcialmente las líneas manuales del bloque `## 4. Volumen de referencia` dentro de `textoExpediente` por:

```javascript
...construirLineasVolumenReferenciaExpediente({
  peTotalMm,
  volumenEsperadoM3
}),