### PR TITLE
OT-0170C — Saneamiento documental auditoría Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0170/OT-0170B_auditoria_bloque_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0170/OT-0170B_auditoria_bloque_resumen_q5_auditado.md
@@ -2,7 +2,7 @@
 
 ## Resumen
 
-`json
+```json
 {
   "bloqueEncontrado": true,
   "lineaInicio": 2080,
@@ -15,11 +15,11 @@
   "comparadorModificado": false,
   "decisionPreliminar": "No delegar todavía. Conviene definir contrato documental separando texto fijo, resultados Q-5, Qp/Tp/Volumen, restricciones y lectura técnica."
 }
-`",
-  ",
-  
+```
 
-`jsx
+## Bloque auditado
+
+```jsx
  2080 |             "## 6. Resumen Q-5 auditado",
  2081 |             "Estado general: diagnóstico no adoptivo.",
  2082 |             "SCS Unit Hydrograph: candidato principal de referencia.",
@@ -32,9 +32,9 @@
  2089 |             ...tablaQ5Markdown,
  2090 |             "",
  2091 |             "",
-`",
-  ",
-  
+```
+
+## Clasificación general
 
 | Tipo | Cantidad |
 |---|---:|
@@ -55,8 +55,8 @@ No delegar todavía. Conviene definir contrato documental separando texto fijo, 
 
 ## Restricciones mantenidas
 
-- No se modificó ComparadorMultiMetodo.jsx.
-- No se sustituyó 	extoExpediente.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se sustituyó `textoExpediente`.
 - No se modificó botón.
 - No se modificó portapapeles.
 - No se tocó Q-5 operativo.
@@ -67,4 +67,4 @@ No delegar todavía. Conviene definir contrato documental separando texto fijo, 
 
 ## Siguiente paso recomendado
 
-Abrir una OT posterior para definir el contrato documental del bloque ## 6. Resumen Q-5 auditado.
+Abrir una OT posterior para definir el contrato documental del bloque `## 6. Resumen Q-5 auditado`.

--- a/00_ADMIN/bitacora/OT-0170/OT-0170C_saneamiento_auditoria_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0170/OT-0170C_saneamiento_auditoria_resumen_q5_auditado.md
@@ -1,0 +1,33 @@
+# OT-0170C — Saneamiento documental auditoría Resumen Q-5 auditado
+
+## Hallazgo
+
+Después del merge de OT-0170, la bitácora `OT-0170B_auditoria_bloque_resumen_q5_auditado.md` quedó con formato Markdown corrupto en los bloques JSON/JSX y con una línea de restricción alterada.
+
+## Corrección aplicada
+
+Se reescribió `OT-0170B` conservando el resultado técnico de la auditoría:
+
+- bloque encontrado;
+- líneas 2080 a 2091;
+- 12 líneas auditadas;
+- 8 líneas técnicamente sensibles o dependientes de Q-5;
+- decisión preliminar de no delegar sin contrato documental previo.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0170 queda documentalmente saneada y lista para servir como base de OT-0171.


### PR DESCRIPTION
## Objetivo

Sanear documentalmente la bitácora `OT-0170B_auditoria_bloque_resumen_q5_auditado.md`.

## Hallazgo

Después del merge de OT-0170, la bitácora quedó con formato Markdown corrupto en los bloques JSON/JSX y una línea de restricción alterada.

## Corrección aplicada

Se reescribió `OT-0170B` conservando el resultado técnico de la auditoría:

- bloque encontrado;
- líneas 2080 a 2091;
- 12 líneas auditadas;
- 8 líneas técnicamente sensibles o dependientes de Q-5;
- decisión preliminar de no delegar sin contrato documental previo.

## Restricciones mantenidas

No se modificó:

- `ComparadorMultiMetodo.jsx`;
- `textoExpediente`;
- botón de copiado;
- portapapeles;
- Q-5 operativo;
- Método Racional;
- diagnóstico Q(t);
- validadores finales;
- motor hidrológico.

## Conclusión

OT-0170 queda documentalmente saneada y lista para servir como base de OT-0171.