### PR TITLE
OT-0174 — Implementación helper puro Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0174/OT-0174A_apertura_helper_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0174/OT-0174A_apertura_helper_resumen_q5_auditado.md
@@ -1,0 +1,49 @@
+# OT-0174A — Apertura implementación helper puro Resumen Q-5 auditado
+
+## Objetivo
+
+Implementar la función pura `construirLineasResumenQ5AuditadoExpediente(...)` en el helper documental del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0170 auditó el bloque `## 6. Resumen Q-5 auditado` y lo clasificó como técnicamente sensible / dependiente de Q-5.
+
+OT-0170C saneó documentalmente la auditoría.
+
+OT-0171 definió el contrato documental.
+
+OT-0172 extrajo la forma exacta operativa.
+
+OT-0173 diseñó la función pura futura.
+
+## Alcance
+
+Esta OT implementa únicamente el helper puro.
+
+No integra el helper en `ComparadorMultiMetodo.jsx`.
+
+No sustituye `textoExpediente`.
+
+## Restricciones
+
+No se modifica:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica
+
+- No recalcular Q-5.
+- No modificar Qp.
+- No modificar Tp.
+- No modificar volumen.
+- No modificar hidrogramas.
+- No consultar motor.
+- Solo representar texto fijo y `tablaQ5Markdown` ya existente.

--- a/00_ADMIN/bitacora/OT-0174/OT-0174B_implementacion_helper_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0174/OT-0174B_implementacion_helper_resumen_q5_auditado.md
@@ -1,0 +1,56 @@
+# OT-0174B — Implementación helper puro Resumen Q-5 auditado
+
+## Cambio aplicado
+
+Se implementó en el helper documental la función:
+
+```javascript
+construirLineasResumenQ5AuditadoExpediente(...)
+```
+
+Ubicación:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+## Comportamiento
+
+La función retorna el bloque:
+
+```text
+## 6. Resumen Q-5 auditado
+Estado general: diagnóstico no adoptivo.
+SCS Unit Hydrograph: candidato principal de referencia.
+SCS Mod.: variante ajustable.
+Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.
+Masa y volumen: controlados frente a referencia física.
+Qp y Tp: sujetos a revisión temporal antes de adopción técnica.
+
+Tabla Q-5 auditada:
+<tablaQ5Markdown | sin tabla Q-5 disponible>
+```
+
+## Reglas mantenidas
+
+- No recalcula Q-5.
+- No modifica Qp.
+- No modifica Tp.
+- No modifica volumen.
+- No modifica hidrogramas.
+- No consulta motor.
+- No modifica estado.
+- No toca DOM.
+- No usa portapapeles.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0174/OT-0174C_cierre_helper_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0174/OT-0174C_cierre_helper_resumen_q5_auditado.md
@@ -1,0 +1,47 @@
+# OT-0174C — Cierre implementación helper Resumen Q-5 auditado
+
+## Resultado
+
+Se implementó la función pura `construirLineasResumenQ5AuditadoExpediente(...)` en el helper documental.
+
+## Validación aprobada
+
+`VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`
+
+La validación confirmó:
+
+- tabla completa;
+- sin entrada;
+- entrada `null`;
+- tabla vacía;
+- tabla con residuos;
+- retorno tipo arreglo;
+- encabezado exacto;
+- textos fijos exactos;
+- encabezado `Tabla Q-5 auditada:` exacto;
+- dos líneas vacías finales;
+- ausencia de `undefined`, `null`, `NaN` y `[object Object]`.
+
+## Build
+
+Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El bloque `## 6. Resumen Q-5 auditado` ya cuenta con helper puro representacional implementado.
+
+No se integra todavía en `ComparadorMultiMetodo.jsx` y no se sustituye el bloque operativo.

--- a/00_ADMIN/bitacora/OT-0174/OT-0174D_correccion_helper_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0174/OT-0174D_correccion_helper_resumen_q5_auditado.md
@@ -1,0 +1,45 @@
+# OT-0174D — Corrección helper Resumen Q-5 auditado
+
+## Hallazgo
+
+La primera implementación del helper `construirLineasResumenQ5AuditadoExpediente(...)` dejó un literal `\n` inválido al final de `construirExpedienteHidrologicoMinimo.js`.
+
+El validador falló con:
+
+```text
+SyntaxError: Invalid or unexpected token
+```
+
+El build Vite falló con:
+
+```text
+Expected unicode escape
+```
+
+## Corrección aplicada
+
+Se eliminó el literal final `\n` del archivo helper y se preservó salto de línea final válido.
+
+## Validaciones aprobadas
+
+- `CORRECCION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0174 queda corregida y validada como implementación de helper puro, sin integración ni sustitución operativa.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -577,4 +577,3 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
-\n

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -530,3 +530,51 @@ export function construirLineasEscenarioQTrActivoExpediente(entrada = {}) {
     "Lectura técnica: bloque no adoptivo; no recalcula caudales, no modifica Q-5 y queda subordinado a validación hidrológica del expediente."
   ];
 }
+
+export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
+  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
+
+  const { tablaQ5Markdown = [] } = entradaSegura;
+
+  const normalizarLinea = (valor) => {
+    if (valor === undefined || valor === null) {
+      return "—";
+    }
+
+    if (typeof valor === "string") {
+      return valor;
+    }
+
+    if (typeof valor === "number" && Number.isFinite(valor)) {
+      return String(valor);
+    }
+
+    return "—";
+  };
+
+  const tabla = Array.isArray(tablaQ5Markdown)
+    ? tablaQ5Markdown
+        .map((linea) => normalizarLinea(linea))
+        .filter((linea) => linea.trim().length > 0)
+    : [];
+
+  const lineasTabla = tabla.length > 0
+    ? tabla
+    : ["sin tabla Q-5 disponible"];
+
+  return [
+    "## 6. Resumen Q-5 auditado",
+    "Estado general: diagnóstico no adoptivo.",
+    "SCS Unit Hydrograph: candidato principal de referencia.",
+    "SCS Mod.: variante ajustable.",
+    "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
+    "Masa y volumen: controlados frente a referencia física.",
+    "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+    "",
+    "Tabla Q-5 auditada:",
+    ...lineasTabla,
+    "",
+    ""
+  ];
+}
+\n

--- a/07_TOOLBOX/validaciones/aplicar_ot0174_helper_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0174_helper_resumen_q5_auditado.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaHelper = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+let texto = fs.readFileSync(rutaHelper, "utf8");
+
+const nombreFuncion = "export function construirLineasResumenQ5AuditadoExpediente";
+
+assert.equal(
+  texto.includes(nombreFuncion),
+  false,
+  "La función construirLineasResumenQ5AuditadoExpediente ya existe. No se debe duplicar."
+);
+
+const funcion = `
+
+export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
+  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
+
+  const { tablaQ5Markdown = [] } = entradaSegura;
+
+  const normalizarLinea = (valor) => {
+    if (valor === undefined || valor === null) {
+      return "—";
+    }
+
+    if (typeof valor === "string") {
+      return valor;
+    }
+
+    if (typeof valor === "number" && Number.isFinite(valor)) {
+      return String(valor);
+    }
+
+    return "—";
+  };
+
+  const tabla = Array.isArray(tablaQ5Markdown)
+    ? tablaQ5Markdown
+        .map((linea) => normalizarLinea(linea))
+        .filter((linea) => linea.trim().length > 0)
+    : [];
+
+  const lineasTabla = tabla.length > 0
+    ? tabla
+    : ["sin tabla Q-5 disponible"];
+
+  return [
+    "## 6. Resumen Q-5 auditado",
+    "Estado general: diagnóstico no adoptivo.",
+    "SCS Unit Hydrograph: candidato principal de referencia.",
+    "SCS Mod.: variante ajustable.",
+    "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
+    "Masa y volumen: controlados frente a referencia física.",
+    "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+    "",
+    "Tabla Q-5 auditada:",
+    ...lineasTabla,
+    "",
+    ""
+  ];
+}
+`;
+
+texto = texto.trimEnd() + funcion + "\\n";
+
+fs.writeFileSync(rutaHelper, texto, "utf8");
+
+console.log("APLICACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK");

--- a/07_TOOLBOX/validaciones/corregir_ot0174_helper_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/corregir_ot0174_helper_resumen_q5_auditado.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaHelper = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+let texto = fs.readFileSync(rutaHelper, "utf8");
+
+assert.equal(
+  texto.includes("export function construirLineasResumenQ5AuditadoExpediente"),
+  true,
+  "Debe existir la función construirLineasResumenQ5AuditadoExpediente."
+);
+
+const textoOriginal = texto;
+
+texto = texto.replace(/\\n\s*$/u, "");
+
+if (!texto.endsWith("\n")) {
+  texto += "\n";
+}
+
+assert.equal(
+  texto.includes("\\n\n"),
+  false,
+  "No debe quedar literal \\n antes del final del archivo."
+);
+
+fs.writeFileSync(rutaHelper, texto, "utf8");
+
+console.log("CORRECCION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK");
+console.log(JSON.stringify({
+  cambioAplicado: texto !== textoOriginal,
+  funcionPresente: texto.includes("export function construirLineasResumenQ5AuditadoExpediente"),
+  sinLiteralFinalBackslashN: !/\\n\s*$/u.test(texto)
+}, null, 2));

--- a/07_TOOLBOX/validaciones/validar_ot0174_helper_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0174_helper_resumen_q5_auditado.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { construirLineasResumenQ5AuditadoExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas[0], "## 6. Resumen Q-5 auditado", `${nombreCaso}: encabezado exacto`);
+  assert.equal(lineas[1], "Estado general: diagnóstico no adoptivo.", `${nombreCaso}: estado general exacto`);
+  assert.equal(lineas[2], "SCS Unit Hydrograph: candidato principal de referencia.", `${nombreCaso}: SCS exacto`);
+  assert.equal(lineas[3], "SCS Mod.: variante ajustable.", `${nombreCaso}: SCS Mod exacto`);
+  assert.equal(lineas[4], "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.", `${nombreCaso}: métodos exactos`);
+  assert.equal(lineas[5], "Masa y volumen: controlados frente a referencia física.", `${nombreCaso}: masa volumen exacto`);
+  assert.equal(lineas[6], "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.", `${nombreCaso}: Qp Tp exacto`);
+  assert.equal(lineas[7], "", `${nombreCaso}: línea vacía interna`);
+  assert.equal(lineas[8], "Tabla Q-5 auditada:", `${nombreCaso}: encabezado tabla exacto`);
+  assert.equal(lineas.at(-1), "", `${nombreCaso}: última línea vacía`);
+  assert.equal(lineas.at(-2), "", `${nombreCaso}: penúltima línea vacía`);
+}
+
+function validarCaso(nombreCaso, entrada, esperados) {
+  const lineas = construirLineasResumenQ5AuditadoExpediente(entrada);
+  const texto = lineas.join("\n");
+
+  validarEstructura(nombreCaso, lineas);
+  validarSinResiduos(nombreCaso, texto);
+
+  for (const esperado of esperados) {
+    assert.equal(texto.includes(esperado), true, `${nombreCaso}: debe incluir ${esperado}`);
+  }
+
+  console.log(`OK ${nombreCaso}`);
+  console.log(texto);
+}
+
+validarCaso(
+  "tabla completa",
+  {
+    tablaQ5Markdown: [
+      "| Método | Qp | Tp | Volumen |",
+      "|---|---:|---:|---:|",
+      "| SCS | 184.03 | 210 | 2654250.90 |"
+    ]
+  },
+  [
+    "| Método | Qp | Tp | Volumen |",
+    "| SCS | 184.03 | 210 | 2654250.90 |"
+  ]
+);
+
+validarCaso(
+  "sin entrada",
+  {},
+  [
+    "sin tabla Q-5 disponible"
+  ]
+);
+
+validarCaso(
+  "entrada null",
+  null,
+  [
+    "sin tabla Q-5 disponible"
+  ]
+);
+
+validarCaso(
+  "tabla vacia",
+  {
+    tablaQ5Markdown: []
+  },
+  [
+    "sin tabla Q-5 disponible"
+  ]
+);
+
+validarCaso(
+  "tabla con residuos",
+  {
+    tablaQ5Markdown: ["", null, undefined, Number.NaN, { valor: 1 }, "fila válida"]
+  },
+  [
+    "fila válida"
+  ]
+);
+
+console.log("VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK");


### PR DESCRIPTION
## Objetivo

Implementar la función pura `construirLineasResumenQ5AuditadoExpediente(...)` en el helper documental del expediente hidrológico mínimo.

## Antecedente

OT-0170 auditó el bloque `## 6. Resumen Q-5 auditado` y lo clasificó como técnicamente sensible / dependiente de Q-5.

OT-0170C saneó documentalmente la auditoría.

OT-0171 definió el contrato documental.

OT-0172 extrajo la forma exacta operativa.

OT-0173 diseñó la función pura futura.

## Cambio aplicado

Se implementó en:

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js