### PR TITLE
OT-0175 — Validación reforzada helper Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0175/OT-0175A_apertura_validacion_reforzada_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0175/OT-0175A_apertura_validacion_reforzada_resumen_q5_auditado.md
@@ -1,0 +1,53 @@
+# OT-0175A — Apertura validación reforzada helper Resumen Q-5 auditado
+
+## Objetivo
+
+Validar de forma aislada y reforzada el helper puro `construirLineasResumenQ5AuditadoExpediente(...)` antes de cualquier integración diagnóstica o sustitución.
+
+## Antecedente
+
+OT-0174 implementó el helper puro representacional para el bloque `## 6. Resumen Q-5 auditado`.
+
+La validación inicial confirmó tabla completa, sin entrada, entrada `null`, tabla vacía, tabla con residuos, estructura básica y ausencia de residuos técnicos.
+
+## Alcance
+
+Esta OT solo refuerza la validación aislada.
+
+No modifica el helper.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No integra en UI.
+
+No sustituye `textoExpediente`.
+
+## Casos borde a validar
+
+- entrada `string`;
+- entrada `array`;
+- `tablaQ5Markdown` como string;
+- `tablaQ5Markdown` como objeto;
+- `tablaQ5Markdown` con números;
+- `tablaQ5Markdown` con booleanos;
+- `tablaQ5Markdown` con objetos;
+- `tablaQ5Markdown` con strings vacíos;
+- `tablaQ5Markdown` con `NaN`;
+- `tablaQ5Markdown` con mezcla de filas válidas e inválidas;
+- preservación de dos líneas vacías finales;
+- ausencia de residuos técnicos.
+
+## Restricciones
+
+No se modifica:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0175/OT-0175B_cierre_validacion_reforzada_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0175/OT-0175B_cierre_validacion_reforzada_resumen_q5_auditado.md
@@ -1,0 +1,45 @@
+# OT-0175B — Cierre validación reforzada helper Resumen Q-5 auditado
+
+## Resultado
+
+Se reforzó la validación aislada del helper `construirLineasResumenQ5AuditadoExpediente(...)`.
+
+## Casos validados
+
+- entrada `string`;
+- entrada `array`;
+- `tablaQ5Markdown` como string;
+- `tablaQ5Markdown` como objeto;
+- `tablaQ5Markdown` con números;
+- `tablaQ5Markdown` con booleanos;
+- `tablaQ5Markdown` con objetos;
+- `tablaQ5Markdown` con strings vacíos;
+- `tablaQ5Markdown` con `NaN`;
+- `tablaQ5Markdown` con mezcla de filas válidas e inválidas;
+- preservación de dos líneas vacías finales;
+- ausencia de residuos técnicos.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+El helper de Resumen Q-5 auditado queda reforzado frente a casos borde, manteniendo comportamiento estrictamente representacional.

--- a/00_ADMIN/bitacora/OT-0175/OT-0175C_correccion_validacion_reforzada_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0175/OT-0175C_correccion_validacion_reforzada_resumen_q5_auditado.md
@@ -1,0 +1,40 @@
+# OT-0175C — Corrección validación reforzada helper Resumen Q-5 auditado
+
+## Hallazgo
+
+La primera versión del script `validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.
+
+El error observado fue:
+
+```text
+SyntaxError: missing ) after argument list
+```
+
+## Corrección aplicada
+
+Se reescribió el validador reforzado con matriz completa de casos borde para entrada y `tablaQ5Markdown`.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- helper documental;
+- `ComparadorMultiMetodo.jsx`;
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0175 queda corregida y validada como validación aislada reforzada real del helper Resumen Q-5 auditado.

--- a/07_TOOLBOX/validaciones/validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs
@@ -33,7 +33,54 @@ function validarCaso(nombreCaso, entrada, esperados) {
   const texto = lineas.join("\n");
 
   validarEstructura(nombreCaso, lineas);
-  validarSinResiduos(nombreC "tabla con booleanos",
+  validarSinResiduos(nombreCaso, texto);
+
+  for (const esperado of esperados) {
+    assert.equal(
+      texto.includes(esperado),
+      true,
+      `${nombreCaso}: debe incluir ${esperado}`
+    );
+  }
+
+  console.log(`OK ${nombreCaso}`);
+  console.log(texto);
+}
+
+const casos = [
+  {
+    nombre: "entrada string",
+    entrada: "no valido",
+    esperados: ["sin tabla Q-5 disponible"]
+  },
+  {
+    nombre: "entrada array",
+    entrada: [],
+    esperados: ["sin tabla Q-5 disponible"]
+  },
+  {
+    nombre: "tabla como string",
+    entrada: {
+      tablaQ5Markdown: "| Método | Qp |"
+    },
+    esperados: ["sin tabla Q-5 disponible"]
+  },
+  {
+    nombre: "tabla como objeto",
+    entrada: {
+      tablaQ5Markdown: { fila: "| SCS | 184.03 |" }
+    },
+    esperados: ["sin tabla Q-5 disponible"]
+  },
+  {
+    nombre: "tabla con numeros",
+    entrada: {
+      tablaQ5Markdown: [1, 2, 3]
+    },
+    esperados: ["1", "2", "3"]
+  },
+  {
+    nombre: "tabla con booleanos",
     entrada: {
       tablaQ5Markdown: [true, false, "fila válida"]
     },

--- a/07_TOOLBOX/validaciones/validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { construirLineasResumenQ5AuditadoExpediente } from "../../01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+const residuos = ["undefined", "null", "NaN", "[object Object]"];
+
+function validarSinResiduos(nombreCaso, texto) {
+  const detectados = residuos.filter((token) => texto.includes(token));
+
+  assert.equal(
+    detectados.length,
+    0,
+    `${nombreCaso}: no debe contener residuos técnicos: ${detectados.join(", ")}`
+  );
+}
+
+function validarEstructura(nombreCaso, lineas) {
+  assert.equal(Array.isArray(lineas), true, `${nombreCaso}: debe retornar arreglo`);
+  assert.equal(lineas[0], "## 6. Resumen Q-5 auditado", `${nombreCaso}: encabezado exacto`);
+  assert.equal(lineas[1], "Estado general: diagnóstico no adoptivo.", `${nombreCaso}: estado general exacto`);
+  assert.equal(lineas[2], "SCS Unit Hydrograph: candidato principal de referencia.", `${nombreCaso}: SCS exacto`);
+  assert.equal(lineas[3], "SCS Mod.: variante ajustable.", `${nombreCaso}: SCS Mod exacto`);
+  assert.equal(lineas[4], "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.", `${nombreCaso}: métodos exactos`);
+  assert.equal(lineas[5], "Masa y volumen: controlados frente a referencia física.", `${nombreCaso}: masa volumen exacto`);
+  assert.equal(lineas[6], "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.", `${nombreCaso}: Qp Tp exacto`);
+  assert.equal(lineas[7], "", `${nombreCaso}: línea vacía interna`);
+  assert.equal(lineas[8], "Tabla Q-5 auditada:", `${nombreCaso}: encabezado tabla exacto`);
+  assert.equal(lineas.at(-1), "", `${nombreCaso}: última línea vacía`);
+  assert.equal(lineas.at(-2), "", `${nombreCaso}: penúltima línea vacía`);
+}
+
+function validarCaso(nombreCaso, entrada, esperados) {
+  const lineas = construirLineasResumenQ5AuditadoExpediente(entrada);
+  const texto = lineas.join("\n");
+
+  validarEstructura(nombreCaso, lineas);
+  validarSinResiduos(nombreC "tabla con booleanos",
+    entrada: {
+      tablaQ5Markdown: [true, false, "fila válida"]
+    },
+    esperados: ["fila válida"]
+  },
+  {
+    nombre: "tabla con objetos",
+    entrada: {
+      tablaQ5Markdown: [{ valor: 1 }, { valor: 2 }, "fila válida"]
+    },
+    esperados: ["fila válida"]
+  },
+  {
+    nombre: "tabla con strings vacios",
+    entrada: {
+      tablaQ5Markdown: ["", "   ", "fila válida"]
+    },
+    esperados: ["fila válida"]
+  },
+  {
+    nombre: "tabla con NaN",
+    entrada: {
+      tablaQ5Markdown: [Number.NaN, "fila válida"]
+    },
+    esperados: ["fila válida"]
+  },
+  {
+    nombre: "tabla mixta",
+    entrada: {
+      tablaQ5Markdown: [
+        "",
+        null,
+        undefined,
+        Number.NaN,
+        { valor: 1 },
+        true,
+        false,
+        "| Método | Qp | Tp | Volumen |",
+        "| SCS | 184.03 | 210 | 2654250.90 |"
+      ]
+    },
+    esperados: [
+      "| Método | Qp | Tp | Volumen |",
+      "| SCS | 184.03 | 210 | 2654250.90 |"
+    ]
+  }
+];
+
+for (const caso of casos) {
+  validarCaso(caso.nombre, caso.entrada, caso.esperados);
+}
+
+console.log("VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK");


### PR DESCRIPTION
## Objetivo

Validar de forma aislada y reforzada el helper puro `construirLineasResumenQ5AuditadoExpediente(...)` antes de cualquier integración diagnóstica o sustitución.

## Antecedente

OT-0174 implementó el helper puro representacional para el bloque `## 6. Resumen Q-5 auditado`.

La validación inicial confirmó:

- tabla completa;
- sin entrada;
- entrada `null`;
- tabla vacía;
- tabla con residuos;
- estructura básica;
- ausencia de residuos técnicos.

## Corrección aplicada

La primera versión del script `validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs` quedó corrupta por corte de pegado y produjo error de sintaxis.

El error observado fue:

```text
SyntaxError: missing ) after argument list