### PR TITLE
OT-0177 — Integración diagnóstica Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0177/OT-0177A_apertura_integracion_diagnostica_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177A_apertura_integracion_diagnostica_resumen_q5_auditado.md
@@ -1,0 +1,43 @@
+# OT-0177A — Apertura integración diagnóstica Resumen Q-5 auditado
+
+## Objetivo
+
+Integrar de forma diagnóstica no invasiva el helper `construirLineasResumenQ5AuditadoExpediente(...)` dentro de `ComparadorMultiMetodo.jsx`, sin sustituir el bloque operativo.
+
+## Antecedente
+
+OT-0174 implementó el helper puro.
+
+OT-0175 reforzó su validación aislada.
+
+OT-0176 confirmó coincidencia textual estricta 14/14 entre helper y referencia operativa controlada.
+
+## Alcance
+
+Esta OT solo importa y ejecuta el helper como diagnóstico interno.
+
+No sustituye `textoExpediente`.
+
+No modifica el botón de copiado.
+
+No modifica portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica
+
+- El helper se ejecuta solo como comparación diagnóstica.
+- Si hay brecha, se emite `console.warn`.
+- Si no hay brecha, no se altera el comportamiento operativo.
+- El bloque `## 6. Resumen Q-5 auditado` sigue armado operativamente como antes.

--- a/00_ADMIN/bitacora/OT-0177/OT-0177B_integracion_diagnostica_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177B_integracion_diagnostica_resumen_q5_auditado.md
@@ -1,0 +1,39 @@
+# OT-0177B — Integración diagnóstica Resumen Q-5 auditado
+
+## Cambio aplicado
+
+Se importó y ejecutó el helper `construirLineasResumenQ5AuditadoExpediente(...)` dentro de `ComparadorMultiMetodo.jsx` solo como diagnóstico interno.
+
+## Comportamiento
+
+Se compara:
+
+- bloque delegado generado por el helper;
+- bloque operativo actual armado con `tablaQ5Markdown`.
+
+Si hay diferencias, se emite:
+
+```javascript
+console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", ...)
+```
+
+## Alcance del cambio
+
+No se sustituyó el bloque operativo.
+
+No se modificó `textoExpediente` como fuente del copiado.
+
+No se modificó botón ni portapapeles.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0177/OT-0177C_cierre_integracion_diagnostica_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177C_cierre_integracion_diagnostica_resumen_q5_auditado.md
@@ -1,0 +1,44 @@
+# OT-0177C — Cierre integración diagnóstica Resumen Q-5 auditado
+
+## Resultado
+
+Se integró el helper `construirLineasResumenQ5AuditadoExpediente(...)` como diagnóstico no invasivo dentro de `ComparadorMultiMetodo.jsx`.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se sustituyó:
+
+- bloque operativo `## 6. Resumen Q-5 auditado`;
+- `textoExpediente`.
+
+No se modificó:
+
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Verificaciones clave
+
+- `areaTexto.value = textoExpediente` sigue intacto.
+- `window.prompt(..., textoExpediente)` sigue intacto.
+- No se introdujo `navigator.clipboard`.
+- No se introdujo `writeText`.
+- No se usa `...construirLineasResumenQ5AuditadoExpediente(...)` dentro de `textoExpediente`.
+
+## Conclusión
+
+El helper Resumen Q-5 auditado queda integrado como diagnóstico interno no invasivo.
+
+La sustitución parcial del bloque operativo queda reservada para una OT posterior.

--- a/00_ADMIN/bitacora/OT-0177/OT-0177D_correccion_integracion_diagnostica_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177D_correccion_integracion_diagnostica_resumen_q5_auditado.md
@@ -1,0 +1,39 @@
+# OT-0177D — Corrección integración diagnóstica Resumen Q-5 auditado
+
+## Hallazgo
+
+La primera aplicación de OT-0177 no modificó `ComparadorMultiMetodo.jsx` porque el script de aplicación quedó corrupto inicialmente y luego falló al buscar un import específico.
+
+## Corrección aplicada
+
+Se reescribió el script de aplicación para insertar de forma segura el import del helper y el bloque diagnóstico antes de `textoExpediente`.
+
+## Validaciones aprobadas
+
+- `APLICACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se sustituyó:
+
+- bloque operativo `## 6. Resumen Q-5 auditado`;
+- `textoExpediente`.
+
+No se modificó:
+
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0177 queda corregida y validada como integración diagnóstica no invasiva real.

--- a/00_ADMIN/bitacora/OT-0177/OT-0177E_aplicacion_real_integracion_diagnostica_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177E_aplicacion_real_integracion_diagnostica_resumen_q5_auditado.md
@@ -1,0 +1,40 @@
+# OT-0177E — Aplicación real integración diagnóstica Resumen Q-5 auditado
+
+## Hallazgo
+
+El correctivo anterior de OT-0177 no modificó `ComparadorMultiMetodo.jsx` porque el punto de inserción antes de `textoExpediente` fue buscado con una cadena rígida de indentación.
+
+## Corrección aplicada
+
+Se reescribió el script de aplicación para localizar `const textoExpediente = [` con indentación flexible y aplicar realmente la integración diagnóstica.
+
+## Validaciones aprobadas
+
+- `APLICACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se sustituyó:
+
+- bloque operativo `## 6. Resumen Q-5 auditado`;
+- `textoExpediente`.
+
+No se modificó:
+
+- helper documental;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0177 queda aplicada realmente como integración diagnóstica no invasiva dentro de `ComparadorMultiMetodo.jsx`.

--- a/00_ADMIN/bitacora/OT-0177/OT-0177F_correccion_entidad_html_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0177/OT-0177F_correccion_entidad_html_resumen_q5_auditado.md
@@ -1,0 +1,52 @@
+# OT-0177F — Corrección entidad HTML diagnóstico Resumen Q-5 auditado
+
+## Hallazgo
+
+La integración diagnóstica real del bloque `## 6. Resumen Q-5 auditado` quedó aplicada, pero la línea de métodos comparativos fue insertada con entidad HTML duplicada `&amp;amp;`.
+
+Esto podía producir una brecha diagnóstica artificial frente al helper, que usa `&amp;`.
+
+## Corrección aplicada
+
+Se corrigió la línea diagnóstica operativa de:
+
+```text
+Snyder, Williams &amp;amp; Hann y Clark IUH: métodos comparativos/referenciales.
+```
+
+a:
+
+```text
+Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.
+```
+
+## Validaciones aprobadas
+
+- `CORRECCION_OT_0177_ENTIDAD_HTML_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se sustituyó:
+
+- bloque operativo `## 6. Resumen Q-5 auditado`;
+- `textoExpediente`.
+
+No se modificó:
+
+- helper documental;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Conclusión
+
+OT-0177 queda corregida y validada como integración diagnóstica no invasiva real, sin brecha artificial por entidad HTML duplicada.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -1,3 +1,4 @@
+import { construirLineasResumenQ5AuditadoExpediente } from "../services/documentos/construirExpedienteHidrologicoMinimo.js";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { setTcState } from "../agents/tcAgent";
@@ -2044,6 +2045,41 @@ const handleClickSeguro = (accion) => () => {
               errorDiagnosticoHelperExpediente
             );
           }
+          const lineasResumenQ5AuditadoDelegadoDiagnostico =
+            construirLineasResumenQ5AuditadoExpediente({
+              tablaQ5Markdown
+            });
+
+          const lineasResumenQ5AuditadoOperativoDiagnostico = [
+            "## 6. Resumen Q-5 auditado",
+            "Estado general: diagnóstico no adoptivo.",
+            "SCS Unit Hydrograph: candidato principal de referencia.",
+            "SCS Mod.: variante ajustable.",
+            "Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.",
+            "Masa y volumen: controlados frente a referencia física.",
+            "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+            "",
+            "Tabla Q-5 auditada:",
+            ...tablaQ5Markdown,
+            "",
+            ""
+          ];
+
+          const hayBrechaResumenQ5AuditadoDiagnostico =
+            lineasResumenQ5AuditadoDelegadoDiagnostico.length !==
+              lineasResumenQ5AuditadoOperativoDiagnostico.length ||
+            lineasResumenQ5AuditadoDelegadoDiagnostico.some(
+              (linea, indice) =>
+                linea !== lineasResumenQ5AuditadoOperativoDiagnostico[indice]
+            );
+
+          if (hayBrechaResumenQ5AuditadoDiagnostico) {
+            console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", {
+              delegado: lineasResumenQ5AuditadoDelegadoDiagnostico,
+              operativo: lineasResumenQ5AuditadoOperativoDiagnostico
+            });
+          }
+
           const textoExpediente = [
             "# Expediente hidrológico mínimo — Cuenca activa",
             "Estado técnico del expediente: CONSISTENTE CON ADVERTENCIAS.",

--- a/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+let texto = fs.readFileSync(rutaComparador, "utf8");
+
+const nombreHelper = "construirLineasResumenQ5AuditadoExpediente";
+const rutaImport = "../services/documentos/construirExpedienteHidrologicoMinimo.js";
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe existir textoExpediente."
+);
+
+assert.equal(
+  texto.includes("## 6. Resumen Q-5 auditado"),
+  true,
+  "Debe existir el bloque operativo ## 6."
+);
+
+assert.equal(
+  texto.includes("...tablaQ5Markdown"),
+  true,
+  "Debe existir tablaQ5Markdown operativo."
+);
+
+const marcadorDiagnostico = "lineasResumenQ5AuditadoDelegadoDiagnostico";
+
+assert.equal(
+  texto.includes(marcadorDiagnostico),
+  false,
+  "La integración diagnóstica Resumen Q-5 auditado ya existe. No duplicar."
+);
+
+const patronImport =
+  /import\s*\{([\s\S]*?)\}\s*from\s*["']\.\.\/services\/documentos\/construirExpedienteHidrologicoMinimo\.js["'];/u;
+
+const coincidenciaImport = texto.match(patronImport);
+
+assert.notEqual(
+  coincidenciaImport,
+  null,
+  "Debe existir import desde construirExpedienteHidrologicoMinimo.js."
+);
+
+if (!texto.includes(nombreHelper)) {
+  const importActual = coincidenciaImport[0];
+  const cuerpoImport = coincidenciaImport[1];
+
+  const nombresImportados = cuerpoImport
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+  assert.equal(
+    nombresImportados.includes(nombreHelper),
+    false,
+    "El helper no debe estar duplicado en el import."
+  );
+
+  nombresImportados.push(nombreHelper);
+
+  const importActualizado = `import {
+  ${nombresImportados.join(",\n  ")}
+} from "${rutaImport}";`;
+
+  texto = texto.replace(importActual, importActualizado);
+}
+
+const patronTextoExpediente = "            const textoExpediente = [";
+
+assert.equal(
+  texto.includes(patronTextoExpediente),
+  true,
+  "Debe encontrarse el punto de inserción antes de textoExpediente."
+);
+
+const bloqueDiagnostico = `            const lineasResumenQ5AuditadoDelegadoDiagnostico =
+              construirLineasResumenQ5AuditadoExpediente({
+                tablaQ5Markdown
+              });
+
+            const lineasResumenQ5AuditadoOperativoDiagnostico = [
+              "## 6. Resumen Q-5 auditado",
+              "Estado general: diagnóstico no adoptivo.",
+              "SCS Unit Hydrograph: candidato principal de referencia.",
+              "SCS Mod.: variante ajustable.",
+              "Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.",
+              "Masa y volumen: controlados frente a referencia física.",
+              "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+              "",
+              "Tabla Q-5 auditada:",
+              ...tablaQ5Markdown,
+              "",
+              ""
+            ];
+
+            const hayBrechaResumenQ5AuditadoDiagnostico =
+              lineasResumenQ5AuditadoDelegadoDiagnostico.length !==
+                lineasResumenQ5AuditadoOperativoDiagnostico.length ||
+              lineasResumenQ5AuditadoDelegadoDiagnostico.some(
+                (linea, indice) =>
+                  linea !== lineasResumenQ5AuditadoOperativoDiagnostico[indice]
+              );
+
+            if (hayBrechaResumenQ5AuditadoDiagnostico) {
+              console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", {
+                delegado: lineasResumenQ5AuditadoDelegadoDiagnostico,
+                operativo: lineasResumenQ5AuditadoOperativoDiagnostico
+              });
+            }
+
+`;
+
+texto = texto.replace(
+  patronTextoExpediente,
+  bloqueDiagnostico + patronTextoExpediente
+);
+
+fs.writeFileSync(rutaComparador, texto.trimEnd() + "\n", "utf8");
+
+console.log("APLICACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK");

--- a/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -9,7 +9,8 @@ const rutaComparador = path.resolve(
 let texto = fs.readFileSync(rutaComparador, "utf8");
 
 const nombreHelper = "construirLineasResumenQ5AuditadoExpediente";
-const importStandalone = `import { construirLineasResumenQ5AuditadoExpediente } from "../services/documentos/construirExpedienteHidrologicoMinimo.js";\n`;
+const importStandalone =
+  'import { construirLineasResumenQ5AuditadoExpediente } from "../services/documentos/construirExpedienteHidrologicoMinimo.js";\n';
 
 assert.equal(
   texto.includes("const textoExpediente = ["),
@@ -41,56 +42,62 @@ if (!texto.includes(nombreHelper)) {
   texto = importStandalone + texto;
 }
 
-const patronTextoExpediente = "            const textoExpediente = [";
+const patronTextoExpediente = /^(\s*)const textoExpediente = \[/m;
+const coincidenciaTextoExpediente = texto.match(patronTextoExpediente);
 
-assert.equal(
-  texto.includes(patronTextoExpediente),
-  true,
-  "Debe encontrarse el punto de inserción antes de textoExpediente."
+assert.notEqual(
+  coincidenciaTextoExpediente,
+  null,
+  "Debe encontrarse la línea const textoExpediente = [ con indentación flexible."
 );
 
-const bloqueDiagnostico = `            const lineasResumenQ5AuditadoDelegadoDiagnostico =
-              construirLineasResumenQ5AuditadoExpediente({
-                tablaQ5Markdown
-              });
+const indent = coincidenciaTextoExpediente[1];
+const lineaTextoExpediente = `${indent}const textoExpediente = [`;
 
-            const lineasResumenQ5AuditadoOperativoDiagnostico = [
-              "## 6. Resumen Q-5 auditado",
-              "Estado general: diagnóstico no adoptivo.",
-              "SCS Unit Hydrograph: candidato principal de referencia.",
-              "SCS Mod.: variante ajustable.",
-              "Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.",
-              "Masa y volumen: controlados frente a referencia física.",
-              "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
-              "",
-              "Tabla Q-5 auditada:",
-              ...tablaQ5Markdown,
-              "",
-              ""
-            ];
+const bloqueDiagnostico = `${indent}const lineasResumenQ5AuditadoDelegadoDiagnostico =
+${indent}  construirLineasResumenQ5AuditadoExpediente({
+${indent}    tablaQ5Markdown
+${indent}  });
 
-            const hayBrechaResumenQ5AuditadoDiagnostico =
-              lineasResumenQ5AuditadoDelegadoDiagnostico.length !==
-                lineasResumenQ5AuditadoOperativoDiagnostico.length ||
-              lineasResumenQ5AuditadoDelegadoDiagnostico.some(
-                (linea, indice) =>
-                  linea !== lineasResumenQ5AuditadoOperativoDiagnostico[indice]
-              );
+${indent}const lineasResumenQ5AuditadoOperativoDiagnostico = [
+${indent}  "## 6. Resumen Q-5 auditado",
+${indent}  "Estado general: diagnóstico no adoptivo.",
+${indent}  "SCS Unit Hydrograph: candidato principal de referencia.",
+${indent}  "SCS Mod.: variante ajustable.",
+${indent}  "Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.",
+${indent}  "Masa y volumen: controlados frente a referencia física.",
+${indent}  "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
+${indent}  "",
+${indent}  "Tabla Q-5 auditada:",
+${indent}  ...tablaQ5Markdown,
+${indent}  "",
+${indent}  ""
+${indent}];
 
-            if (hayBrechaResumenQ5AuditadoDiagnostico) {
-              console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", {
-                delegado: lineasResumenQ5AuditadoDelegadoDiagnostico,
-                operativo: lineasResumenQ5AuditadoOperativoDiagnostico
-              });
-            }
+${indent}const hayBrechaResumenQ5AuditadoDiagnostico =
+${indent}  lineasResumenQ5AuditadoDelegadoDiagnostico.length !==
+${indent}    lineasResumenQ5AuditadoOperativoDiagnostico.length ||
+${indent}  lineasResumenQ5AuditadoDelegadoDiagnostico.some(
+${indent}    (linea, indice) =>
+${indent}      linea !== lineasResumenQ5AuditadoOperativoDiagnostico[indice]
+${indent}  );
+
+${indent}if (hayBrechaResumenQ5AuditadoDiagnostico) {
+${indent}  console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", {
+${indent}    delegado: lineasResumenQ5AuditadoDelegadoDiagnostico,
+${indent}    operativo: lineasResumenQ5AuditadoOperativoDiagnostico
+${indent}  });
+${indent}}
 
 `;
 
-texto = texto.replace(
-  patronTextoExpediente,
-  bloqueDiagnostico + patronTextoExpediente
-);
+texto = texto.replace(lineaTextoExpediente, bloqueDiagnostico + lineaTextoExpediente);
 
 fs.writeFileSync(rutaComparador, texto.trimEnd() + "\n", "utf8");
 
 console.log("APLICACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK");
+console.log(JSON.stringify({
+  importHelperPresente: texto.includes(nombreHelper),
+  diagnosticoPresente: texto.includes(marcadorDiagnostico),
+  textoExpedientePresente: texto.includes("const textoExpediente = [")
+}, null, 2));

--- a/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -9,7 +9,7 @@ const rutaComparador = path.resolve(
 let texto = fs.readFileSync(rutaComparador, "utf8");
 
 const nombreHelper = "construirLineasResumenQ5AuditadoExpediente";
-const rutaImport = "../services/documentos/construirExpedienteHidrologicoMinimo.js";
+const importStandalone = `import { construirLineasResumenQ5AuditadoExpediente } from "../services/documentos/construirExpedienteHidrologicoMinimo.js";\n`;
 
 assert.equal(
   texto.includes("const textoExpediente = ["),
@@ -37,39 +37,8 @@ assert.equal(
   "La integración diagnóstica Resumen Q-5 auditado ya existe. No duplicar."
 );
 
-const patronImport =
-  /import\s*\{([\s\S]*?)\}\s*from\s*["']\.\.\/services\/documentos\/construirExpedienteHidrologicoMinimo\.js["'];/u;
-
-const coincidenciaImport = texto.match(patronImport);
-
-assert.notEqual(
-  coincidenciaImport,
-  null,
-  "Debe existir import desde construirExpedienteHidrologicoMinimo.js."
-);
-
 if (!texto.includes(nombreHelper)) {
-  const importActual = coincidenciaImport[0];
-  const cuerpoImport = coincidenciaImport[1];
-
-  const nombresImportados = cuerpoImport
-    .split(",")
-    .map((item) => item.trim())
-    .filter((item) => item.length > 0);
-
-  assert.equal(
-    nombresImportados.includes(nombreHelper),
-    false,
-    "El helper no debe estar duplicado en el import."
-  );
-
-  nombresImportados.push(nombreHelper);
-
-  const importActualizado = `import {
-  ${nombresImportados.join(",\n  ")}
-} from "${rutaImport}";`;
-
-  texto = texto.replace(importActual, importActualizado);
+  texto = importStandalone + texto;
 }
 
 const patronTextoExpediente = "            const textoExpediente = [";

--- a/07_TOOLBOX/validaciones/corregir_ot0177_entidad_html_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/corregir_ot0177_entidad_html_resumen_q5_auditado.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+let texto = fs.readFileSync(rutaComparador, "utf8");
+
+const erroneo = "Snyder, Williams &amp;amp; Hann y Clark IUH: métodos comparativos/referenciales.";
+const correcto = "Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales.";
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe existir integración diagnóstica Resumen Q-5 auditado."
+);
+
+assert.equal(
+  texto.includes(erroneo),
+  true,
+  "Debe existir la entidad HTML duplicada &amp;amp; para corregirla."
+);
+
+texto = texto.replace(erroneo, correcto);
+
+assert.equal(
+  texto.includes(erroneo),
+  false,
+  "No debe quedar &amp;amp; en el diagnóstico Resumen Q-5 auditado."
+);
+
+assert.equal(
+  texto.includes(correcto),
+  true,
+  "Debe quedar la línea corregida con &amp;."
+);
+
+fs.writeFileSync(rutaComparador, texto.trimEnd() + "\n", "utf8");
+
+console.log("CORRECCION_OT_0177_ENTIDAD_HTML_RESUMEN_Q5_AUDITADO_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+assert.equal(
+  texto.includes("construirLineasResumenQ5AuditadoExpediente"),
+  true,
+  "Debe importarse/usarse construirLineasResumenQ5AuditadoExpediente."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe existir bloque delegado diagnóstico."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoOperativoDiagnostico"),
+  true,
+  "Debe existir bloque operativo diagnóstico."
+);
+
+assert.equal(
+  texto.includes("hayBrechaResumenQ5AuditadoDiagnostico"),
+  true,
+  "Debe existir comparación de brecha diagnóstica."
+);
+
+assert.equal(
+  texto.includes('console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo"'),
+  true,
+  "Debe existir console.warn diagnóstico."
+);
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe mantenerse textoExpediente."
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard."
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText."
+);
+
+assert.equal(
+  texto.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  false,
+  "No debe sustituirse el bloque operativo por expansión del helper."
+);
+
+assert.equal(
+  texto.includes('"## 6. Resumen Q-5 auditado"'),
+  true,
+  "Debe conservarse encabezado operativo."
+);
+
+assert.equal(
+  texto.includes("...tablaQ5Markdown"),
+  true,
+  "Debe conservarse tablaQ5Markdown operativo."
+);
+
+console.log("VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -39,6 +39,18 @@ assert.equal(
 );
 
 assert.equal(
+  texto.includes("Snyder, Williams &amp;amp; Hann y Clark IUH: métodos comparativos/referenciales."),
+  false,
+  "No debe quedar &amp;amp; en Resumen Q-5 auditado."
+);
+
+assert.equal(
+  texto.includes("Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales."),
+  true,
+  "Debe conservarse la entidad correcta &amp;."
+);
+
+assert.equal(
   texto.includes("const textoExpediente = ["),
   true,
   "Debe mantenerse textoExpediente."


### PR DESCRIPTION
## Objetivo

Integrar de forma diagnóstica no invasiva el helper `construirLineasResumenQ5AuditadoExpediente(...)` dentro de `ComparadorMultiMetodo.jsx`, sin sustituir el bloque operativo.

## Antecedente

OT-0174 implementó el helper puro.

OT-0175 reforzó su validación aislada.

OT-0176 confirmó coincidencia textual estricta 14/14 entre helper y referencia operativa controlada.

## Cambio aplicado

Se importó y ejecutó el helper `construirLineasResumenQ5AuditadoExpediente(...)` dentro de `ComparadorMultiMetodo.jsx` solo como diagnóstico interno.

Se compara:

- bloque delegado generado por el helper;
- bloque operativo actual armado con `tablaQ5Markdown`.

Si hay diferencias, se emite:

```javascript
console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo", ...)