### PR TITLE
OT-0178 — Sustitución parcial Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0178/OT-0178A_apertura_sustitucion_parcial_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0178/OT-0178A_apertura_sustitucion_parcial_resumen_q5_auditado.md
@@ -1,0 +1,43 @@
+# OT-0178A — Apertura sustitución parcial Resumen Q-5 auditado
+
+## Objetivo
+
+Sustituir de forma parcial y controlada el bloque operativo `## 6. Resumen Q-5 auditado` dentro de `textoExpediente`, usando el helper `construirLineasResumenQ5AuditadoExpediente(...)`.
+
+## Antecedente
+
+OT-0174 implementó el helper puro.
+
+OT-0175 reforzó su validación aislada.
+
+OT-0176 confirmó coincidencia textual estricta 14/14 entre helper y referencia operativa controlada.
+
+OT-0177 integró el helper como diagnóstico no invasivo.
+
+## Alcance
+
+Esta OT sustituye únicamente el bloque `## 6. Resumen Q-5 auditado` dentro de `textoExpediente`.
+
+No modifica bloques `## 1` a `## 5`.
+
+No modifica bloques posteriores.
+
+## Restricciones
+
+No se modifica:
+
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- validadores finales;
+- motor hidrológico.
+
+## Regla técnica
+
+- `textoExpediente` sigue siendo la fuente del copiado.
+- El bloque se sustituye por expansión controlada del helper.
+- No se recalcula Q-5.
+- No se modifica `tablaQ5Markdown`.
+- No se altera el diagnóstico previo salvo que siga siendo útil como control interno.

--- a/00_ADMIN/bitacora/OT-0178/OT-0178B_sustitucion_parcial_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0178/OT-0178B_sustitucion_parcial_resumen_q5_auditado.md
@@ -1,0 +1,32 @@
+# OT-0178B — Sustitución parcial Resumen Q-5 auditado
+
+## Cambio aplicado
+
+Se sustituyó dentro de `textoExpediente` el bloque manual `## 6. Resumen Q-5 auditado` por:
+
+```javascript
+...construirLineasResumenQ5AuditadoExpediente({
+  tablaQ5Markdown
+}),
+```
+
+## Alcance
+
+La sustitución fue parcial y limitada al bloque `## 6`.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- bloques `## 1` a `## 5`;
+- bloques posteriores;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Regla conservada
+
+`textoExpediente` sigue siendo la fuente del copiado.

--- a/00_ADMIN/bitacora/OT-0178/OT-0178C_cierre_sustitucion_parcial_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0178/OT-0178C_cierre_sustitucion_parcial_resumen_q5_auditado.md
@@ -1,0 +1,40 @@
+# OT-0178C — Cierre sustitución parcial Resumen Q-5 auditado
+
+## Resultado
+
+Se sustituyó parcialmente el bloque `## 6. Resumen Q-5 auditado` dentro de `textoExpediente` por la expansión del helper `construirLineasResumenQ5AuditadoExpediente(...)`.
+
+## Validaciones aprobadas
+
+- `APLICACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- bloques `## 1` a `## 5`;
+- bloques posteriores;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Verificaciones clave
+
+- `textoExpediente` sigue siendo la fuente del copiado.
+- `areaTexto.value = textoExpediente` sigue intacto.
+- `window.prompt(..., textoExpediente)` sigue intacto.
+- No se introdujo `navigator.clipboard`.
+- No se introdujo `writeText`.
+
+## Conclusión
+
+El bloque `## 6. Resumen Q-5 auditado` queda sustituido de forma controlada por helper, sin alterar los flujos operativos de copiado ni el motor hidrológico.

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -2113,18 +2113,9 @@ const handleClickSeguro = (accion) => () => {
                   formatearValorQTrExpediente
                 }),
                 "",
-            "## 6. Resumen Q-5 auditado",
-            "Estado general: diagnóstico no adoptivo.",
-            "SCS Unit Hydrograph: candidato principal de referencia.",
-            "SCS Mod.: variante ajustable.",
-            "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
-            "Masa y volumen: controlados frente a referencia física.",
-            "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
-            "",
-            "Tabla Q-5 auditada:",
-            ...tablaQ5Markdown,
-            "",
-            "",
+            ...construirLineasResumenQ5AuditadoExpediente({
+              tablaQ5Markdown
+            }),
             "## 7. Método Racional — contraste global independiente",
             "Uso: contraste global independiente de caudal pico.",
             "Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.",

--- a/07_TOOLBOX/validaciones/aplicar_ot0178_sustitucion_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0178_sustitucion_resumen_q5_auditado.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+let texto = fs.readFileSync(rutaComparador, "utf8");
+
+const nombreHelper = "construirLineasResumenQ5AuditadoExpediente";
+
+assert.equal(
+  texto.includes(nombreHelper),
+  true,
+  "Debe existir import/uso previo del helper."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe existir integración diagnóstica previa."
+);
+
+assert.equal(
+  texto.includes("const textoExpediente = ["),
+  true,
+  "Debe existir textoExpediente."
+);
+
+assert.equal(
+  texto.includes('"## 6. Resumen Q-5 auditado"'),
+  true,
+  "Debe existir el bloque manual operativo Resumen Q-5 auditado antes de sustituir."
+);
+
+assert.equal(
+  texto.includes("...tablaQ5Markdown"),
+  true,
+  "Debe existir tablaQ5Markdown."
+);
+
+assert.equal(
+  texto.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  false,
+  "El bloque ## 6 no debe estar ya sustituido."
+);
+
+const indiceTextoExpediente = texto.indexOf("const textoExpediente = [");
+
+assert.notEqual(
+  indiceTextoExpediente,
+  -1,
+  "Debe localizarse textoExpediente."
+);
+
+const antesTextoExpediente = texto.slice(0, indiceTextoExpediente);
+const desdeTextoExpediente = texto.slice(indiceTextoExpediente);
+
+const lineas = desdeTextoExpediente.split(/\r?\n/u);
+
+const indiceInicioBloque = lineas.findIndex((linea) =>
+  linea.includes('"## 6. Resumen Q-5 auditado"')
+);
+
+assert.notEqual(
+  indiceInicioBloque,
+  -1,
+  "Debe encontrarse el inicio del bloque ## 6 dentro de textoExpediente."
+);
+
+const indiceTabla = lineas.findIndex((linea, indice) =>
+  indice > indiceInicioBloque && linea.includes('"Tabla Q-5 auditada:"')
+);
+
+assert.notEqual(
+  indiceTabla,
+  -1,
+  "Debe encontrarse la línea Tabla Q-5 auditada dentro del bloque ## 6."
+);
+
+const indiceSpreadTabla = lineas.findIndex((linea, indice) =>
+  indice > indiceTabla && linea.includes("...tablaQ5Markdown")
+);
+
+assert.notEqual(
+  indiceSpreadTabla,
+  -1,
+  "Debe encontrarse ...tablaQ5Markdown dentro del bloque ## 6."
+);
+
+let indiceFinBloque = indiceSpreadTabla + 1;
+
+while (
+  indiceFinBloque < lineas.length &&
+  lineas[indiceFinBloque].trim().match(/^"",?$/u)
+) {
+  indiceFinBloque += 1;
+}
+
+assert.equal(
+  indiceFinBloque > indiceSpreadTabla + 1,
+  true,
+  "Deben existir líneas vacías finales después de ...tablaQ5Markdown."
+);
+
+const indentMatch = lineas[indiceInicioBloque].match(/^(\s*)/u);
+const indent = indentMatch ? indentMatch[1] : "";
+
+const bloqueDelegado = [
+  `${indent}...construirLineasResumenQ5AuditadoExpediente({`,
+  `${indent}  tablaQ5Markdown`,
+  `${indent}}),`
+];
+
+const lineasActualizadas = [
+  ...lineas.slice(0, indiceInicioBloque),
+  ...bloqueDelegado,
+  ...lineas.slice(indiceFinBloque)
+];
+
+texto = antesTextoExpediente + lineasActualizadas.join("\n");
+
+const desdeTextoActualizado = texto.slice(texto.indexOf("const textoExpediente = ["));
+
+assert.equal(
+  desdeTextoActualizado.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  true,
+  "Debe quedar el bloque ## 6 sustituido por expansión del helper dentro de textoExpediente."
+);
+
+const bloqueManualCompletoAunPresente =
+  desdeTextoActualizado.includes('"Estado general: diagnóstico no adoptivo."') &&
+  desdeTextoActualizado.includes('"SCS Unit Hydrograph: candidato principal de referencia."') &&
+  desdeTextoActualizado.includes('"SCS Mod.: variante ajustable."') &&
+  desdeTextoActualizado.includes('"Tabla Q-5 auditada:"') &&
+  desdeTextoActualizado.includes("...tablaQ5Markdown");
+
+assert.equal(
+  bloqueManualCompletoAunPresente,
+  false,
+  "No debe quedar el bloque manual completo ## 6 dentro de textoExpediente."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe conservarse diagnóstico no invasivo."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoOperativoDiagnostico"),
+  true,
+  "Debe conservarse referencia diagnóstica operativa."
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard."
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText."
+);
+
+fs.writeFileSync(rutaComparador, texto.trimEnd() + "\n", "utf8");
+
+console.log("APLICACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK");
+console.log(JSON.stringify({
+  indiceInicioBloque,
+  indiceTabla,
+  indiceSpreadTabla,
+  indiceFinBloque,
+  lineasSustituidas: indiceFinBloque - indiceInicioBloque,
+  delegadoPresente: texto.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  textoExpedientePresente: texto.includes("const textoExpediente = ["),
+  portapapelesIntacto: texto.includes("areaTexto.value = textoExpediente")
+}, null, 2));

--- a/07_TOOLBOX/validaciones/validar_ot0178_sustitucion_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0178_sustitucion_resumen_q5_auditado.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const indiceTextoExpediente = texto.indexOf("const textoExpediente = [");
+
+assert.notEqual(
+  indiceTextoExpediente,
+  -1,
+  "Debe existir textoExpediente."
+);
+
+const desdeTextoExpediente = texto.slice(indiceTextoExpediente);
+
+assert.equal(
+  desdeTextoExpediente.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  true,
+  "textoExpediente debe usar expansión del helper para Resumen Q-5 auditado."
+);
+
+assert.equal(
+  desdeTextoExpediente.includes("tablaQ5Markdown"),
+  true,
+  "La sustitución debe pasar tablaQ5Markdown."
+);
+
+const bloqueManualCompletoAunPresente =
+  desdeTextoExpediente.includes('"Estado general: diagnóstico no adoptivo."') &&
+  desdeTextoExpediente.includes('"SCS Unit Hydrograph: candidato principal de referencia."') &&
+  desdeTextoExpediente.includes('"SCS Mod.: variante ajustable."') &&
+  desdeTextoExpediente.includes('"Tabla Q-5 auditada:"') &&
+  desdeTextoExpediente.includes("...tablaQ5Markdown");
+
+assert.equal(
+  bloqueManualCompletoAunPresente,
+  false,
+  "Dentro de textoExpediente no debe quedar el bloque manual completo ## 6."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe conservarse diagnóstico no invasivo."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoOperativoDiagnostico"),
+  true,
+  "Debe conservarse referencia diagnóstica operativa."
+);
+
+assert.equal(
+  texto.includes("hayBrechaResumenQ5AuditadoDiagnostico"),
+  true,
+  "Debe conservarse comparación diagnóstica."
+);
+
+assert.equal(
+  texto.includes('console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo"'),
+  true,
+  "Debe conservarse console.warn diagnóstico."
+);
+
+assert.equal(
+  texto.includes("## 1. Identificación"),
+  true,
+  "Debe conservarse bloque ## 1."
+);
+
+assert.equal(
+  texto.includes("## 2. Parámetros hidrológicos base"),
+  true,
+  "Debe conservarse bloque ## 2."
+);
+
+assert.equal(
+  texto.includes("## 3. Tiempo de concentración y roles Tc"),
+  true,
+  "Debe conservarse bloque ## 3."
+);
+
+assert.equal(
+  texto.includes("## 4. Volumen de referencia"),
+  true,
+  "Debe conservarse bloque ## 4."
+);
+
+assert.equal(
+  texto.includes("## 5. Escenario Q-Tr activo"),
+  true,
+  "Debe conservarse bloque ## 5."
+);
+
+assert.equal(
+  texto.includes("## 7."),
+  true,
+  "Debe conservarse bloque posterior ## 7."
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard."
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText."
+);
+
+console.log("VALIDACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK");


### PR DESCRIPTION
## Objetivo

Sustituir de forma parcial y controlada el bloque operativo `## 6. Resumen Q-5 auditado` dentro de `textoExpediente`, usando el helper `construirLineasResumenQ5AuditadoExpediente(...)`.

## Antecedente

OT-0174 implementó el helper puro.

OT-0175 reforzó su validación aislada.

OT-0176 confirmó coincidencia textual estricta 14/14 entre helper y referencia operativa controlada.

OT-0177 integró el helper como diagnóstico no invasivo.

## Cambio aplicado

Se sustituyó dentro de `textoExpediente` el bloque manual:

```text
## 6. Resumen Q-5 auditado
Estado general: diagnóstico no adoptivo.
SCS Unit Hydrograph: candidato principal de referencia.
SCS Mod.: variante ajustable.
Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.
Masa y volumen: controlados frente a referencia física.
Qp y Tp: sujetos a revisión temporal antes de adopción técnica.

Tabla Q-5 auditada:
...tablaQ5Markdown
