### PR TITLE
OT-0179 — Validación post-adopción Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0179/OT-0179A_apertura_validacion_post_adopcion_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0179/OT-0179A_apertura_validacion_post_adopcion_resumen_q5_auditado.md
@@ -1,0 +1,34 @@
+# OT-0179A — Apertura validación post-adopción Resumen Q-5 auditado
+
+## Objetivo
+
+Validar el estado posterior a la sustitución parcial del bloque `## 6. Resumen Q-5 auditado` por el helper `construirLineasResumenQ5AuditadoExpediente(...)`.
+
+## Antecedente
+
+OT-0178 sustituyó correctamente el bloque manual dentro de `textoExpediente` por la expansión del helper.
+
+La validación histórica de OT-0177 quedó desactualizada porque todavía exigía que no existiera expansión del helper dentro de `textoExpediente`.
+
+## Alcance
+
+Esta OT ajusta la validación al estado post-adopción.
+
+No sustituye nuevos bloques.
+
+No modifica Q-5 operativo.
+
+No modifica botón ni portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- bloque `## 1` a `## 5`;
+- bloques posteriores;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0179/OT-0179B_cierre_validacion_post_adopcion_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0179/OT-0179B_cierre_validacion_post_adopcion_resumen_q5_auditado.md
@@ -1,0 +1,38 @@
+# OT-0179B — Cierre validación post-adopción Resumen Q-5 auditado
+
+## Resultado
+
+Se validó el estado posterior a OT-0178, donde el bloque `## 6. Resumen Q-5 auditado` ya fue sustituido dentro de `textoExpediente` por la expansión del helper.
+
+## Ajuste aplicado
+
+Se actualizó la validación de OT-0177 para que no falle por la sustitución adoptada en OT-0178.
+
+La regla anterior `No debe sustituirse el bloque operativo por expansión del helper` dejó de aplicar después de OT-0178.
+
+## Validaciones aprobadas
+
+- `VALIDACION_OT_0179_POST_ADOPCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `ComparadorMultiMetodo.jsx`;
+- `construirExpedienteHidrologicoMinimo.js`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Conclusión
+
+El estado post-adopción del bloque `## 6. Resumen Q-5 auditado` queda validado y la cadena de validadores queda nuevamente consistente.

--- a/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs
@@ -39,18 +39,6 @@ assert.equal(
 );
 
 assert.equal(
-  texto.includes("Snyder, Williams &amp;amp; Hann y Clark IUH: métodos comparativos/referenciales."),
-  false,
-  "No debe quedar &amp;amp; en Resumen Q-5 auditado."
-);
-
-assert.equal(
-  texto.includes("Snyder, Williams &amp; Hann y Clark IUH: métodos comparativos/referenciales."),
-  true,
-  "Debe conservarse la entidad correcta &amp;."
-);
-
-assert.equal(
   texto.includes("const textoExpediente = ["),
   true,
   "Debe mantenerse textoExpediente."
@@ -81,21 +69,15 @@ assert.equal(
 );
 
 assert.equal(
-  texto.includes("...construirLineasResumenQ5AuditadoExpediente({"),
-  false,
-  "No debe sustituirse el bloque operativo por expansión del helper."
-);
-
-assert.equal(
   texto.includes('"## 6. Resumen Q-5 auditado"'),
   true,
-  "Debe conservarse encabezado operativo."
+  "Debe conservarse encabezado operativo en referencia diagnóstica."
 );
 
 assert.equal(
   texto.includes("...tablaQ5Markdown"),
   true,
-  "Debe conservarse tablaQ5Markdown operativo."
+  "Debe conservarse tablaQ5Markdown en referencia diagnóstica o flujo del expediente."
 );
 
 console.log("VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK");

--- a/07_TOOLBOX/validaciones/validar_ot0179_post_adopcion_resumen_q5_auditado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0179_post_adopcion_resumen_q5_auditado.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const texto = fs.readFileSync(rutaComparador, "utf8");
+
+const indiceTextoExpediente = texto.indexOf("const textoExpediente = [");
+
+assert.notEqual(
+  indiceTextoExpediente,
+  -1,
+  "Debe existir textoExpediente."
+);
+
+const desdeTextoExpediente = texto.slice(indiceTextoExpediente);
+
+assert.equal(
+  texto.includes("construirLineasResumenQ5AuditadoExpediente"),
+  true,
+  "Debe importarse/usarse construirLineasResumenQ5AuditadoExpediente."
+);
+
+assert.equal(
+  desdeTextoExpediente.includes("...construirLineasResumenQ5AuditadoExpediente({"),
+  true,
+  "Después de OT-0178, textoExpediente debe usar expansión del helper para Resumen Q-5 auditado."
+);
+
+assert.equal(
+  desdeTextoExpediente.includes("tablaQ5Markdown"),
+  true,
+  "La expansión del helper debe recibir tablaQ5Markdown."
+);
+
+const bloqueManualCompletoAunPresente =
+  desdeTextoExpediente.includes('"Estado general: diagnóstico no adoptivo."') &&
+  desdeTextoExpediente.includes('"SCS Unit Hydrograph: candidato principal de referencia."') &&
+  desdeTextoExpediente.includes('"SCS Mod.: variante ajustable."') &&
+  desdeTextoExpediente.includes('"Tabla Q-5 auditada:"') &&
+  desdeTextoExpediente.includes("...tablaQ5Markdown");
+
+assert.equal(
+  bloqueManualCompletoAunPresente,
+  false,
+  "No debe quedar el bloque manual completo ## 6 dentro de textoExpediente."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoDelegadoDiagnostico"),
+  true,
+  "Debe conservarse diagnóstico delegado."
+);
+
+assert.equal(
+  texto.includes("lineasResumenQ5AuditadoOperativoDiagnostico"),
+  true,
+  "Debe conservarse referencia diagnóstica operativa."
+);
+
+assert.equal(
+  texto.includes("hayBrechaResumenQ5AuditadoDiagnostico"),
+  true,
+  "Debe conservarse comparación diagnóstica."
+);
+
+assert.equal(
+  texto.includes('console.warn("[expediente] Brecha diagnóstico Resumen Q-5 auditado delegado vs operativo"'),
+  true,
+  "Debe conservarse console.warn diagnóstico."
+);
+
+assert.equal(
+  texto.includes("## 1. Identificación"),
+  true,
+  "Debe conservarse bloque ## 1."
+);
+
+assert.equal(
+  texto.includes("## 2. Parámetros hidrológicos base"),
+  true,
+  "Debe conservarse bloque ## 2."
+);
+
+assert.equal(
+  texto.includes("## 3. Tiempo de concentración y roles Tc"),
+  true,
+  "Debe conservarse bloque ## 3."
+);
+
+assert.equal(
+  texto.includes("## 4. Volumen de referencia"),
+  true,
+  "Debe conservarse bloque ## 4."
+);
+
+assert.equal(
+  texto.includes("## 5. Escenario Q-Tr activo"),
+  true,
+  "Debe conservarse bloque ## 5."
+);
+
+assert.equal(
+  texto.includes("## 7."),
+  true,
+  "Debe conservarse bloque posterior ## 7."
+);
+
+assert.equal(
+  texto.includes("areaTexto.value = textoExpediente"),
+  true,
+  "El portapapeles debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("window.prompt(\"No fue posible copiar automáticamente. Copie manualmente el expediente hidrológico mínimo:\", textoExpediente)"),
+  true,
+  "El fallback manual debe seguir usando textoExpediente."
+);
+
+assert.equal(
+  texto.includes("navigator.clipboard"),
+  false,
+  "No debe introducirse navigator.clipboard."
+);
+
+assert.equal(
+  texto.includes("writeText"),
+  false,
+  "No debe introducirse writeText."
+);
+
+console.log("VALIDACION_OT_0179_POST_ADOPCION_RESUMEN_Q5_AUDITADO_OK");


### PR DESCRIPTION
## Objetivo

Validar el estado posterior a la sustitución parcial del bloque `## 6. Resumen Q-5 auditado` por el helper `construirLineasResumenQ5AuditadoExpediente(...)`.

## Antecedente

OT-0178 sustituyó correctamente el bloque manual dentro de `textoExpediente` por la expansión del helper.

La validación histórica de OT-0177 quedó desactualizada porque todavía exigía que no existiera expansión del helper dentro de `textoExpediente`.

## Ajuste aplicado

Se actualizó la validación de OT-0177 para que no falle por la sustitución adoptada en OT-0178.

La regla anterior:

```text
No debe sustituirse el bloque operativo por expansión del helper