### PR TITLE
OT-0180 — Registro consolidado adopción Resumen Q-5 auditado

### DIFF
--- a/00_ADMIN/bitacora/OT-0180/OT-0180A_registro_consolidado_resumen_q5_auditado.md
+++ b/00_ADMIN/bitacora/OT-0180/OT-0180A_registro_consolidado_resumen_q5_auditado.md
@@ -1,0 +1,110 @@
+# OT-0180A — Registro consolidado adopción bloque Resumen Q-5 auditado
+
+## Objetivo
+
+Dejar un corte documental único del ciclo de adopción del bloque `## 6. Resumen Q-5 auditado` dentro del expediente hidrológico mínimo.
+
+## Alcance
+
+Esta OT es exclusivamente documental.
+
+No modifica código operativo.
+
+No modifica helpers.
+
+No modifica validadores.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+## Secuencia consolidada
+
+| OT | Resultado | Estado |
+|---|---|---|
+| OT-0170 | Auditoría del bloque `## 6. Resumen Q-5 auditado` | Cerrada |
+| OT-0170C | Saneamiento documental de la auditoría | Cerrada |
+| OT-0171 | Contrato documental del bloque | Cerrada |
+| OT-0172 | Extracción exacta operativa | Cerrada |
+| OT-0173 | Diseño de función pura | Cerrada |
+| OT-0174 | Implementación helper puro | Cerrada |
+| OT-0175 | Validación aislada reforzada | Cerrada |
+| OT-0176 | Comparación controlada helper vs operativo | Cerrada |
+| OT-0177 | Integración diagnóstica no invasiva | Cerrada |
+| OT-0178 | Sustitución parcial controlada dentro de `textoExpediente` | Cerrada |
+| OT-0179 | Validación post-adopción | Cerrada |
+
+## Estado final adoptado
+
+El bloque `## 6. Resumen Q-5 auditado` ya no se arma manualmente dentro de `textoExpediente`.
+
+El bloque queda delegado al helper:
+
+```javascript
+...construirLineasResumenQ5AuditadoExpediente({
+  tablaQ5Markdown
+}),
+```
+
+## Helper adoptado
+
+`construirLineasResumenQ5AuditadoExpediente(...)` está implementado en:
+
+`01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+## Validadores relevantes
+
+- `07_TOOLBOX/validaciones/validar_ot0174_helper_resumen_q5_auditado.mjs`;
+- `07_TOOLBOX/validaciones/validar_ot0175_helper_resumen_q5_auditado_reforzada.mjs`;
+- `07_TOOLBOX/validaciones/comparar_ot0176_resumen_q5_auditado_helper_operativo.mjs`;
+- `07_TOOLBOX/validaciones/validar_ot0177_diagnostico_resumen_q5_auditado.mjs`;
+- `07_TOOLBOX/validaciones/validar_ot0178_sustitucion_resumen_q5_auditado.mjs`;
+- `07_TOOLBOX/validaciones/validar_ot0179_post_adopcion_resumen_q5_auditado.mjs`.
+
+## Validaciones finales conocidas
+
+- `VALIDACION_OT_0179_POST_ADOPCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0178_SUSTITUCION_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0177_DIAGNOSTICA_RESUMEN_Q5_AUDITADO_OK`;
+- `COMPARACION_OT_0176_RESUMEN_Q5_AUDITADO_OK`;
+- `VALIDACION_OT_0175_HELPER_RESUMEN_Q5_AUDITADO_REFORZADA_OK`;
+- `VALIDACION_OT_0174_HELPER_RESUMEN_Q5_AUDITADO_OK`;
+- Build Vite aprobado.
+
+## Restricciones mantenidas durante el ciclo
+
+No se modificó:
+
+- Q-5 operativo;
+- Qp;
+- Tp;
+- volumen;
+- hidrogramas;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico;
+- botón de copiado;
+- portapapeles.
+
+## Estado funcional
+
+`textoExpediente` sigue siendo la fuente del copiado.
+
+`areaTexto.value = textoExpediente` sigue intacto.
+
+`window.prompt(..., textoExpediente)` sigue intacto.
+
+No se introdujo `navigator.clipboard`.
+
+No se introdujo `writeText`.
+
+## Decisión consolidada
+
+El bloque `## 6. Resumen Q-5 auditado` queda adoptado mediante helper puro representacional, validado y documentado.
+
+No se recomienda seguir sustituyendo otros bloques inmediatamente sin un nuevo ciclo equivalente de auditoría, contrato, extracción, diseño, helper, validación, comparac
+ión, diagnóstico, sustitución y post-adopción.
+
+## Próximo frente recomendado
+
+`OT-0181 — Selección prudente del siguiente bloque candidato del expediente`


### PR DESCRIPTION
## Objetivo

Dejar un corte documental único del ciclo de adopción del bloque `## 6. Resumen Q-5 auditado` dentro del expediente hidrológico mínimo.

## Alcance

Esta OT es exclusivamente documental.

No modifica código operativo.
No modifica helpers.
No modifica validadores.
No modifica `ComparadorMultiMetodo.jsx`.
No modifica `construirExpedienteHidrologicoMinimo.js`.

## Secuencia consolidada

| OT | Resultado | Estado |
|---|---|---|
| OT-0170 | Auditoría del bloque `## 6. Resumen Q-5 auditado` | Cerrada |
| OT-0170C | Saneamiento documental de la auditoría | Cerrada |
| OT-0171 | Contrato documental del bloque | Cerrada |
| OT-0172 | Extracción exacta operativa | Cerrada |
| OT-0173 | Diseño de función pura | Cerrada |
| OT-0174 | Implementación helper puro | Cerrada |
| OT-0175 | Validación aislada reforzada | Cerrada |
| OT-0176 | Comparación controlada helper vs operativo | Cerrada |
| OT-0177 | Integración diagnóstica no invasiva | Cerrada |
| OT-0178 | Sustitución parcial controlada dentro de `textoExpediente` | Cerrada |
| OT-0179 | Validación post-adopción | Cerrada |

## Estado final adoptado

El bloque `## 6. Resumen Q-5 auditado` ya no se arma manualmente dentro de `textoExpediente`.

El bloque queda delegado al helper:

```javascript
...construirLineasResumenQ5AuditadoExpediente({
  tablaQ5Markdown
}),
