### PR TITLE
OT-0186 — Validación aislada helper Identificación

### DIFF
--- a/00_ADMIN/bitacora/OT-0186/OT-0186A_apertura_validacion_aislada_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0186/OT-0186A_apertura_validacion_aislada_helper_identificacion.md
@@ -1,0 +1,49 @@
+# OT-0186A — Apertura validación aislada helper Identificación existente
+
+## Objetivo
+
+Validar en aislamiento el helper existente `construirLineasIdentificacionExpediente(...)`, ya adoptado dentro de `textoExpediente` para el bloque `## 1. Identificación`.
+
+## Antecedente
+
+OT-0184 confirmó que el bloque `## 1. Identificación` aparece dentro de `textoExpediente` mediante expansión del helper `construirLineasIdentificacionExpediente(...)`.
+
+OT-0185 registró formalmente esa adopción existente.
+
+## Alcance
+
+Esta OT solo valida el helper en aislamiento.
+
+No sustituye contenido.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica botón ni portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico;
+- helper documental existente.
+
+## Criterios de validación
+
+El helper debe:
+
+- exportarse correctamente;
+- retornar un arreglo de líneas;
+- generar el encabezado `## 1. Identificación`;
+- incluir información de cuenca;
+- no emitir `undefined`, `null`, `NaN` ni `[object Object]`;
+- conservar salida textual apta para expediente.

--- a/00_ADMIN/bitacora/OT-0186/OT-0186B_validacion_aislada_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0186/OT-0186B_validacion_aislada_helper_identificacion.md
@@ -1,0 +1,174 @@
+# OT-0186B — Validación aislada helper Identificación existente
+
+## Resumen
+
+```json
+{
+  "helperExportado": true,
+  "casosValidados": 5,
+  "todosRetornanArregloTexto": true,
+  "todosContienenEncabezado": true,
+  "todosContienenCuenca": true,
+  "validacionResiduosAprobada": false,
+  "casosConResiduos": [
+    {
+      "nombre": "contexto con cuenca candidata como objeto",
+      "residuos": [
+        "[object Object]"
+      ]
+    }
+  ],
+  "validacionAisladaAprobada": false
+}
+```
+
+## Resultado
+
+La validación aislada del helper Identificación detectó hallazgos y no debe considerarse aprobada.
+
+## Hallazgo principal
+
+- Caso `contexto con cuenca candidata como objeto`: residuos detectados [object Object].
+
+## Casos evaluados
+
+### contexto vacío con fallbacks explícitos
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### contexto con cuenca candidata como objeto
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [
+    "[object Object]"
+  ],
+  "validacionEstructural": true,
+  "validacionResiduos": false
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: [object Object]
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### contexto con identificadores alternos
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: La Iguaná PC_80
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: San Cristóbal
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### entrada mínima sin argumentos útiles
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: SAN CRISTOBAL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### entrada nula simulada por objeto vacío controlado
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+## Lectura técnica
+
+- El helper se exporta correctamente como función.
+- El helper retorna arreglos de líneas de texto.
+- La salida contiene el encabezado `## 1. Identificación`.
+- La salida contiene línea de `Cuenca:`.
+- Se detectó al menos un residuo prohibido. El helper requiere saneamiento antes de considerarse plenamente validado.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.
+
+## Decisión
+
+No avanzar a comparación controlada todavía. Primero debe abrirse una OT específica de saneamiento del helper Identificación.

--- a/00_ADMIN/bitacora/OT-0186/OT-0186C_cierre_validacion_aislada_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0186/OT-0186C_cierre_validacion_aislada_helper_identificacion.md
@@ -1,0 +1,52 @@
+# OT-0186C — Cierre validación aislada helper Identificación existente
+
+## Resultado
+
+Se ejecutó la validación aislada del helper `construirLineasIdentificacionExpediente(...)`, ya adoptado dentro de `textoExpediente` para el bloque `## 1. Identificación`.
+
+## Evidencia principal
+
+La validación quedó documentada en:
+
+`00_ADMIN/bitacora/OT-0186/OT-0186B_validacion_aislada_helper_identificacion.md`
+
+## Validación ejecutada
+
+`HALLAZGO_OT_0186_HELPER_IDENTIFICACION_AISLADA_RESIDUOS`
+
+## Hallazgo
+
+El helper se exporta correctamente y retorna líneas de texto con encabezado `## 1. Identificación` y línea `Cuenca:`.
+
+Sin embargo, la validación aislada detectó residuo prohibido `[object Object]` en el caso donde `contextoBase.cuenca` es un objeto con propiedad `nombre`.
+
+## Alcance mantenido
+
+No se sustituyó contenido.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron validadores existentes.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico;
+- helper documental existente.
+
+## Decisión
+
+No avanzar todavía a comparación controlada helper vs expediente operativo.
+
+El siguiente frente debe ser una OT específica de saneamiento del helper Identificación para evitar `[object Object]` cuando la cuenca llega como objeto.

--- a/07_TOOLBOX/validaciones/validar_ot0186_helper_identificacion_aislada.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0186_helper_identificacion_aislada.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const rutaModulo = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0186/OT-0186B_validacion_aislada_helper_identificacion.md"
+);
+
+const modulo = await import(pathToFileURL(rutaModulo).href);
+
+const { construirLineasIdentificacionExpediente } = modulo;
+
+assert.equal(
+  typeof construirLineasIdentificacionExpediente,
+  "function",
+  "Debe exportarse construirLineasIdentificacionExpediente como función."
+);
+
+const casos = [
+  {
+    nombre: "contexto vacío con fallbacks explícitos",
+    entrada: {
+      contextoBase: {},
+      fuenteFallback: "HidroFlow",
+      estacionIdfFallback: "IDF_CONTROL"
+    }
+  },
+  {
+    nombre: "contexto con cuenca candidata como objeto",
+    entrada: {
+      contextoBase: {
+        cuenca: {
+          nombre: "La Iguaná PC_80"
+        }
+      },
+      fuenteFallback: "HidroFlow",
+      estacionIdfFallback: "IDF_CONTROL"
+    }
+  },
+  {
+    nombre: "contexto con identificadores alternos",
+    entrada: {
+      contextoBase: {
+        nombreCuenca: "La Iguaná PC_80",
+        estacionIdf: "San Cristóbal"
+      },
+      fuenteFallback: "HidroFlow",
+      estacionIdfFallback: "IDF_CONTROL"
+    }
+  },
+  {
+    nombre: "entrada mínima sin argumentos útiles",
+    entrada: {}
+  },
+  {
+    nombre: "entrada nula simulada por objeto vacío controlado",
+    entrada: {
+      contextoBase: null,
+      fuenteFallback: "HidroFlow",
+      estacionIdfFallback: "IDF_CONTROL"
+    }
+  }
+];
+
+const residuosProhibidos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+const resultados = casos.map((caso) => {
+  const lineas = construirLineasIdentificacionExpediente(caso.entrada);
+
+  assert.equal(
+    Array.isArray(lineas),
+    true,
+    `El caso "${caso.nombre}" debe retornar un arreglo.`
+  );
+
+  assert.equal(
+    lineas.every((linea) => typeof linea === "string"),
+    true,
+    `Todas las líneas del caso "${caso.nombre}" deben ser texto.`
+  );
+
+  const texto = lineas.join("\n");
+
+  const residuos = residuosProhibidos.filter((token) => texto.includes(token));
+
+  return {
+    nombre: caso.nombre,
+    lineas: lineas.length,
+    contieneEncabezado: texto.includes("## 1. Identificación"),
+    contieneCuenca: texto.includes("Cuenca:"),
+    residuos,
+    validacionEstructural:
+      Array.isArray(lineas) &&
+      lineas.every((linea) => typeof linea === "string") &&
+      texto.includes("## 1. Identificación") &&
+      texto.includes("Cuenca:"),
+    validacionResiduos: residuos.length === 0,
+    salida: lineas
+  };
+});
+
+const casosConResiduos = resultados.filter((item) => item.residuos.length > 0);
+
+const resumen = {
+  helperExportado: typeof construirLineasIdentificacionExpediente === "function",
+  casosValidados: resultados.length,
+  todosRetornanArregloTexto: resultados.every((item) => item.validacionEstructural),
+  todosContienenEncabezado: resultados.every((item) => item.contieneEncabezado),
+  todosContienenCuenca: resultados.every((item) => item.contieneCuenca),
+  validacionResiduosAprobada: casosConResiduos.length === 0,
+  casosConResiduos: casosConResiduos.map((item) => ({
+    nombre: item.nombre,
+    residuos: item.residuos
+  })),
+  validacionAisladaAprobada: casosConResiduos.length === 0
+};
+
+const lineasReporte = [
+  "# OT-0186B — Validación aislada helper Identificación existente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Resultado",
+  "",
+  resumen.validacionAisladaAprobada
+    ? "La validación aislada del helper Identificación fue aprobada."
+    : "La validación aislada del helper Identificación detectó hallazgos y no debe considerarse aprobada.",
+  "",
+  "## Hallazgo principal",
+  "",
+  casosConResiduos.length === 0
+    ? "No se detectaron residuos prohibidos."
+    : casosConResiduos.map((item) => `- Caso \`${item.nombre}\`: residuos detectados ${item.residuos.join(", ")}.`).join("\n"),
+  "",
+  "## Casos evaluados",
+  "",
+  ...resultados.flatMap((resultado) => [
+    `### ${resultado.nombre}`,
+    "",
+    "```json",
+    JSON.stringify(
+      {
+        lineas: resultado.lineas,
+        contieneEncabezado: resultado.contieneEncabezado,
+        contieneCuenca: resultado.contieneCuenca,
+        residuos: resultado.residuos,
+        validacionEstructural: resultado.validacionEstructural,
+        validacionResiduos: resultado.validacionResiduos
+      },
+      null,
+      2
+    ),
+    "```",
+    "",
+    "```text",
+    resultado.salida.join("\n"),
+    "```",
+    ""
+  ]),
+  "## Lectura técnica",
+  "",
+  "- El helper se exporta correctamente como función.",
+  "- El helper retorna arreglos de líneas de texto.",
+  "- La salida contiene el encabezado `## 1. Identificación`.",
+  "- La salida contiene línea de `Cuenca:`.",
+  casosConResiduos.length === 0
+    ? "- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]`."
+    : "- Se detectó al menos un residuo prohibido. El helper requiere saneamiento antes de considerarse plenamente validado.",
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó `construirExpedienteHidrologicoMinimo.js`.",
+  "- No se modificó `textoExpediente`.",
+  "- No se modificó botón de copiado.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5 operativo.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico.",
+  "",
+  "## Decisión",
+  "",
+  resumen.validacionAisladaAprobada
+    ? "El helper puede avanzar a comparación controlada."
+    : "No avanzar a comparación controlada todavía. Primero debe abrirse una OT específica de saneamiento del helper Identificación."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log(
+  resumen.validacionAisladaAprobada
+    ? "VALIDACION_OT_0186_HELPER_IDENTIFICACION_AISLADA_OK"
+    : "HALLAZGO_OT_0186_HELPER_IDENTIFICACION_AISLADA_RESIDUOS"
+);
+
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Validar en aislamiento el helper existente `construirLineasIdentificacionExpediente(...)`, ya adoptado dentro de `textoExpediente` para el bloque `## 1. Identificación`.

## Antecedente

OT-0184 confirmó que el bloque `## 1. Identificación` aparece dentro de `textoExpediente` mediante expansión del helper `construirLineasIdentificacionExpediente(...)`.

OT-0185 registró formalmente esa adopción existente.

## Validación ejecutada

```text
HALLAZGO_OT_0186_HELPER_IDENTIFICACION_AISLADA_RESIDUOS