### PR TITLE
OT-0187 — Saneamiento helper Identificación contra object object

### DIFF
--- a/00_ADMIN/bitacora/OT-0187/OT-0187A_apertura_saneamiento_helper_identificacion_object_object.md
+++ b/00_ADMIN/bitacora/OT-0187/OT-0187A_apertura_saneamiento_helper_identificacion_object_object.md
@@ -1,0 +1,43 @@
+# OT-0187A — Apertura saneamiento helper Identificación contra [object Object]
+
+## Objetivo
+
+Sanear el helper `construirLineasIdentificacionExpediente(...)` para evitar que `contextoBase.cuenca` llegue al expediente como `[object Object]` cuando la cuenca se recibe como objeto.
+
+## Antecedente
+
+OT-0186 ejecutó validación aislada del helper Identificación y detectó el hallazgo `HALLAZGO_OT_0186_HELPER_IDENTIFICACION_AISLADA_RESIDUOS`.
+
+El caso `contexto con cuenca candidata como objeto` produjo:
+
+```text
+Cuenca: [object Object]
+```
+
+## Alcance
+
+Esta OT aplica un cambio mínimo y localizado en el helper `construirLineasIdentificacionExpediente(...)`.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Criterio técnico
+
+Cuando `contextoBase.cuenca` sea objeto, el helper debe usar una propiedad textual competente, preferiblemente:
+
+- `cuenca.nombre`;
+- `cuenca.nombreCuenca`;
+- `cuenca.id`;
+- fallback textual seguro.
+
+Nunca debe permitir conversión implícita a `[object Object]`.

--- a/00_ADMIN/bitacora/OT-0187/OT-0187B_saneamiento_helper_identificacion_object_object.md
+++ b/00_ADMIN/bitacora/OT-0187/OT-0187B_saneamiento_helper_identificacion_object_object.md
@@ -1,0 +1,58 @@
+# OT-0187B — Saneamiento helper Identificación contra [object Object]
+
+## Cambio aplicado
+
+Se agregó el normalizador local `normalizarTextoIdentificacionExpediente(...)` dentro de `construirExpedienteHidrologicoMinimo.js`.
+
+El helper `construirLineasIdentificacionExpediente(...)` ahora normaliza `nombreCuenca` para evitar que `contextoBase.cuenca` llegue al expediente como `[object Object]` cuando la cuenca es un objeto.
+
+## Criterio aplicado
+
+Cuando el valor recibido es objeto, el normalizador intenta usar:
+
+- `nombre`;
+- `nombreCuenca`;
+- `id`;
+- `codigo`;
+- `label`;
+- `descripcion`;
+- fallback textual seguro.
+
+## Validación ejecutada
+
+Se reejecutó:
+
+`07_TOOLBOX/validaciones/validar_ot0186_helper_identificacion_aislada.mjs`
+
+## Resultado
+
+El caso `contexto con cuenca candidata como objeto` pasó de:
+
+```text
+Cuenca: [object Object]
+```
+
+a:
+
+```text
+Cuenca: La Iguaná PC_80
+```
+
+La validación post-saneamiento emitió:
+
+```text
+VALIDACION_OT_0186_HELPER_IDENTIFICACION_AISLADA_OK
+```
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0187/OT-0187C_cierre_saneamiento_helper_identificacion_object_object.md
+++ b/00_ADMIN/bitacora/OT-0187/OT-0187C_cierre_saneamiento_helper_identificacion_object_object.md
@@ -1,0 +1,34 @@
+# OT-0187C — Cierre saneamiento helper Identificación contra [object Object]
+
+## Resultado
+
+Se saneó el helper `construirLineasIdentificacionExpediente(...)` para evitar residuos `[object Object]` cuando `contextoBase.cuenca` llega como objeto.
+
+## Validaciones
+
+- `APLICACION_OT_0187_SANEAMIENTO_HELPER_IDENTIFICACION_OK`;
+- `VALIDACION_OT_0186_HELPER_IDENTIFICACION_AISLADA_OK` post saneamiento.
+
+## Alcance mantenido
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó botón de copiado.
+
+No se modificó portapapeles.
+
+No se modificó Q-5 operativo.
+
+No se modificó Método Racional.
+
+No se modificó diagnóstico Q(t).
+
+No se modificó motor hidrológico.
+
+## Decisión
+
+El helper Identificación queda saneado contra conversión implícita de objetos a `[object Object]`.
+
+Puede retomarse posteriormente comparación controlada helper vs expediente operativo.

--- a/00_ADMIN/bitacora/OT-0187/OT-0187D_validacion_post_saneamiento_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0187/OT-0187D_validacion_post_saneamiento_helper_identificacion.md
@@ -1,0 +1,165 @@
+# OT-0186B — Validación aislada helper Identificación existente
+
+## Resumen
+
+```json
+{
+  "helperExportado": true,
+  "casosValidados": 5,
+  "todosRetornanArregloTexto": true,
+  "todosContienenEncabezado": true,
+  "todosContienenCuenca": true,
+  "validacionResiduosAprobada": true,
+  "casosConResiduos": [],
+  "validacionAisladaAprobada": true
+}
+```
+
+## Resultado
+
+La validación aislada del helper Identificación fue aprobada.
+
+## Hallazgo principal
+
+No se detectaron residuos prohibidos.
+
+## Casos evaluados
+
+### contexto vacío con fallbacks explícitos
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### contexto con cuenca candidata como objeto
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: La Iguaná PC_80
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### contexto con identificadores alternos
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: La Iguaná PC_80
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: San Cristóbal
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### entrada mínima sin argumentos útiles
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: SAN CRISTOBAL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+### entrada nula simulada por objeto vacío controlado
+
+```json
+{
+  "lineas": 7,
+  "contieneEncabezado": true,
+  "contieneCuenca": true,
+  "residuos": [],
+  "validacionEstructural": true,
+  "validacionResiduos": true
+}
+```
+
+```text
+## 1. Identificación
+Cuenca: Cuenca activa
+Área: —
+Fuente de contexto: HidroFlow
+Estación IDF: IDF_CONTROL
+Pendiente media: —
+Longitud cauce principal: —
+```
+
+## Lectura técnica
+
+- El helper se exporta correctamente como función.
+- El helper retorna arreglos de líneas de texto.
+- La salida contiene el encabezado `## 1. Identificación`.
+- La salida contiene línea de `Cuenca:`.
+- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]`.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.
+
+## Decisión
+
+El helper puede avanzar a comparación controlada.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -91,6 +91,38 @@ export function validarTextoExpedienteMinimo(
   };
 }
 
+function normalizarTextoIdentificacionExpediente(valor, fallback = "—") {
+  if (typeof valor === "string" && valor.trim().length > 0) {
+    return valor;
+  }
+
+  if (typeof valor === "number" && Number.isFinite(valor)) {
+    return String(valor);
+  }
+
+  if (valor && typeof valor === "object") {
+    const candidato =
+      valor.nombre ??
+      valor.nombreCuenca ??
+      valor.id ??
+      valor.codigo ??
+      valor.label ??
+      valor.descripcion;
+
+    if (typeof candidato === "string" && candidato.trim().length > 0) {
+      return candidato;
+    }
+
+    if (typeof candidato === "number" && Number.isFinite(candidato)) {
+      return String(candidato);
+    }
+
+    return fallback;
+  }
+
+  return fallback;
+}
+
 export function construirLineasIdentificacionExpediente(entrada = {}) {
   const contextoBase =
     entrada?.contextoBase && typeof entrada.contextoBase === "object"
@@ -103,12 +135,11 @@ export function construirLineasIdentificacionExpediente(entrada = {}) {
   const estacionIdfFallback =
     textoSeguro(entrada?.estacionIdfFallback, "") || "SAN CRISTOBAL";
 
-  const nombreCuenca =
-    textoSeguro(contextoBase?.cuencaNombre, "") ||
-    textoSeguro(contextoBase?.nombreCuenca, "") ||
-    textoSeguro(contextoBase?.cuenca, "") ||
-    textoSeguro(contextoBase?.cuencaActiva?.nombre, "") ||
-    "Cuenca activa";
+  const nombreCuenca = normalizarTextoIdentificacionExpediente(
+    contextoBase?.nombreCuenca ??
+      contextoBase?.cuenca,
+    "Cuenca activa"
+  );
 
   const areaKm2 =
     Number.isFinite(Number(contextoBase?.area_km2))

--- a/07_TOOLBOX/validaciones/aplicar_ot0187_saneamiento_helper_identificacion.mjs
+++ b/07_TOOLBOX/validaciones/aplicar_ot0187_saneamiento_helper_identificacion.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaHelper = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+let texto = fs.readFileSync(rutaHelper, "utf8");
+
+assert.equal(
+  texto.includes("export function construirLineasIdentificacionExpediente"),
+  true,
+  "Debe existir export function construirLineasIdentificacionExpediente."
+);
+
+assert.equal(
+  texto.includes("normalizarTextoIdentificacionExpediente"),
+  false,
+  "No debe existir aún normalizarTextoIdentificacionExpediente para evitar duplicados."
+);
+
+const bloqueNormalizador = `function normalizarTextoIdentificacionExpediente(valor, fallback = "—") {
+  if (typeof valor === "string" && valor.trim().length > 0) {
+    return valor;
+  }
+
+  if (typeof valor === "number" && Number.isFinite(valor)) {
+    return String(valor);
+  }
+
+  if (valor && typeof valor === "object") {
+    const candidato =
+      valor.nombre ??
+      valor.nombreCuenca ??
+      valor.id ??
+      valor.codigo ??
+      valor.label ??
+      valor.descripcion;
+
+    if (typeof candidato === "string" && candidato.trim().length > 0) {
+      return candidato;
+    }
+
+    if (typeof candidato === "number" && Number.isFinite(candidato)) {
+      return String(candidato);
+    }
+
+    return fallback;
+  }
+
+  return fallback;
+}
+
+`;
+
+texto = texto.replace(
+  "export function construirLineasIdentificacionExpediente",
+  bloqueNormalizador + "export function construirLineasIdentificacionExpediente"
+);
+
+assert.equal(
+  texto.includes("function normalizarTextoIdentificacionExpediente"),
+  true,
+  "Debe insertarse normalizarTextoIdentificacionExpediente."
+);
+
+const patronFuncion = /export function construirLineasIdentificacionExpediente[\s\S]*?\n\}/u;
+const coincidenciaFuncion = texto.match(patronFuncion);
+
+assert.notEqual(
+  coincidenciaFuncion,
+  null,
+  "Debe localizarse construirLineasIdentificacionExpediente completa."
+);
+
+const funcionAntes = coincidenciaFuncion[0];
+
+assert.equal(
+  funcionAntes.includes("const nombreCuenca"),
+  true,
+  "Debe existir const nombreCuenca dentro del helper."
+);
+
+const patronNombreCuenca = /const nombreCuenca\s*=\s*[\s\S]*?;/u;
+
+assert.equal(
+  patronNombreCuenca.test(funcionAntes),
+  true,
+  "Debe localizarse la asignación const nombreCuenca."
+);
+
+const funcionDespues = funcionAntes.replace(
+  patronNombreCuenca,
+  `const nombreCuenca = normalizarTextoIdentificacionExpediente(
+    contextoBase?.nombreCuenca ??
+      contextoBase?.cuenca,
+    "Cuenca activa"
+  );`
+);
+
+assert.notEqual(
+  funcionDespues,
+  funcionAntes,
+  "La función debe cambiar al reemplazar nombreCuenca."
+);
+
+texto = texto.replace(funcionAntes, funcionDespues);
+
+assert.equal(
+  texto.includes("const nombreCuenca = normalizarTextoIdentificacionExpediente("),
+  true,
+  "nombreCuenca debe usar normalizarTextoIdentificacionExpediente."
+);
+
+assert.equal(
+  texto.includes("valor.nombre ??"),
+  true,
+  "El normalizador debe preferir valor.nombre."
+);
+
+fs.writeFileSync(rutaHelper, texto.trimEnd() + "\n", "utf8");
+
+console.log("APLICACION_OT_0187_SANEAMIENTO_HELPER_IDENTIFICACION_OK");


### PR DESCRIPTION
## Objetivo

Sanear el helper `construirLineasIdentificacionExpediente(...)` para evitar que `contextoBase.cuenca` llegue al expediente como `[object Object]` cuando la cuenca se recibe como objeto.

## Antecedente

OT-0186 ejecutó validación aislada del helper Identificación y detectó el hallazgo:

```text
HALLAZGO_OT_0186_HELPER_IDENTIFICACION_AISLADA_RESIDUOS