### PR TITLE
OT-0193 — Comparación helper Parámetros base vs ruta operativa

### DIFF
--- a/00_ADMIN/bitacora/OT-0193/OT-0193A_apertura_comparacion_helper_parametros_base_ruta_operativa.md
+++ b/00_ADMIN/bitacora/OT-0193/OT-0193A_apertura_comparacion_helper_parametros_base_ruta_operativa.md
@@ -1,0 +1,52 @@
+# OT-0193A — Apertura comparación helper Parámetros base vs ruta operativa
+
+## Objetivo
+
+Comparar de forma controlada el helper validado `construirLineasParametrosHidrologicosBaseExpediente(...)` contra su ruta operativa de composición dentro de `textoExpediente`.
+
+## Antecedente
+
+OT-0191 auditó y trazó la composición real del bloque `## 2. Parámetros hidrológicos base`.
+
+OT-0192 validó en aislamiento el helper `construirLineasParametrosHidrologicosBaseExpediente(...)` y obtuvo `VALIDACION_OT_0192_HELPER_PARAMETROS_BASE_AISLADA_OK`.
+
+## Alcance
+
+Esta OT solo compara y documenta.
+
+No sustituye contenido.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica botón ni portapapeles.
+
+No modifica validadores existentes.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- `construirExpedienteHidrologicoMinimo.js`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Criterios de comparación
+
+La comparación debe confirmar:
+
+- que `textoExpediente` existe;
+- que la ruta operativa usa `...construirLineasParametrosHidrologicosBaseExpediente(...)`;
+- que la invocación operativa pasa `contextoBase`;
+- que el helper retorna encabezado `## 2. Parámetros hidrológicos base`;
+- que el helper conserva etiquetas `CN:`, `CN base:`, `CN efectivo:` y `AMC:`;
+- que la salida controlada no emite `undefined`, `null`, `NaN` ni `[object Object]`.

--- a/00_ADMIN/bitacora/OT-0193/OT-0193B_comparacion_helper_parametros_base_ruta_operativa.md
+++ b/00_ADMIN/bitacora/OT-0193/OT-0193B_comparacion_helper_parametros_base_ruta_operativa.md
@@ -1,0 +1,54 @@
+# OT-0193B — Comparación helper Parámetros base vs ruta operativa
+
+## Resumen
+
+```json
+{
+  "textoExpedienteDetectado": true,
+  "cierreTextoExpedienteDetectado": true,
+  "rutaOperativaUsaHelperParametrosBase": true,
+  "rutaOperativaPasaContextoBase": true,
+  "helperExportado": true,
+  "lineasHelper": 5,
+  "etiquetasFaltantes": [],
+  "residuos": [],
+  "comparacionControladaAprobada": true
+}
+```
+
+## Ruta operativa detectada en textoExpediente
+
+```javascript
+            ...construirLineasParametrosHidrologicosBaseExpediente({
+              contextoBase
+            }),
+```
+
+## Salida controlada del helper validado
+
+```text
+## 2. Parámetros hidrológicos base
+CN: 83
+CN base: —
+CN efectivo: —
+AMC: III
+```
+
+## Lectura técnica
+
+- La ruta operativa de `textoExpediente` usa la expansión del helper `construirLineasParametrosHidrologicosBaseExpediente(...)`.
+- La ruta operativa pasa `contextoBase` al helper.
+- El helper conserva el encabezado `## 2. Parámetros hidrológicos base` y las etiquetas mínimas esperadas.
+- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0193/OT-0193C_cierre_comparacion_helper_parametros_base_ruta_operativa.md
+++ b/00_ADMIN/bitacora/OT-0193/OT-0193C_cierre_comparacion_helper_parametros_base_ruta_operativa.md
@@ -1,0 +1,51 @@
+# OT-0193C — Cierre comparación helper Parámetros base vs ruta operativa
+
+## Resultado
+
+Se comparó de forma controlada el helper validado `construirLineasParametrosHidrologicosBaseExpediente(...)` contra su ruta operativa de composición dentro de `textoExpediente`.
+
+## Evidencia principal
+
+La comparación quedó documentada en:
+
+`00_ADMIN/bitacora/OT-0193/OT-0193B_comparacion_helper_parametros_base_ruta_operativa.md`
+
+## Validación ejecutada
+
+`COMPARACION_OT_0193_HELPER_PARAMETROS_BASE_RUTA_OPERATIVA_OK`
+
+## Resultado técnico
+
+La ruta operativa usa `...construirLineasParametrosHidrologicosBaseExpediente(...)` dentro de `textoExpediente`.
+
+La ruta operativa pasa `contextoBase` al helper.
+
+El helper validado conserva encabezado, etiquetas mínimas y no emite residuos prohibidos.
+
+## Alcance mantenido
+
+No se sustituyó contenido.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron validadores existentes.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Decisión
+
+El helper Parámetros base queda comparado de forma controlada contra su ruta operativa. Cualquier avance posterior debe ser registro consolidado del ciclo o selección prudente de siguiente bloque, no sustitución.

--- a/07_TOOLBOX/validaciones/comparar_ot0193_helper_parametros_base_ruta_operativa.mjs
+++ b/07_TOOLBOX/validaciones/comparar_ot0193_helper_parametros_base_ruta_operativa.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const rutaModulo = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0193/OT-0193B_comparacion_helper_parametros_base_ruta_operativa.md"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+
+const indiceTextoExpediente = textoComparador.indexOf("const textoExpediente = [");
+
+assert.notEqual(
+  indiceTextoExpediente,
+  -1,
+  "Debe existir const textoExpediente = [."
+);
+
+const cierreTextoExpediente = textoComparador.indexOf(
+  '].join("\\n")',
+  indiceTextoExpediente
+);
+
+assert.notEqual(
+  cierreTextoExpediente,
+  -1,
+  "Debe existir cierre ].join(\"\\n\") de textoExpediente."
+);
+
+const segmentoTextoExpediente = textoComparador.slice(
+  indiceTextoExpediente,
+  cierreTextoExpediente + '].join("\\n")'.length
+);
+
+const helperNombre = "construirLineasParametrosHidrologicosBaseExpediente";
+
+const lineasSegmentoExpediente = segmentoTextoExpediente.split(/\r?\n/u);
+
+const indiceRutaHelper = lineasSegmentoExpediente.findIndex((linea) =>
+  linea.includes(`...${helperNombre}({`)
+);
+
+assert.notEqual(
+  indiceRutaHelper,
+  -1,
+  "Debe localizarse la expansión operativa del helper Parámetros base."
+);
+
+const indiceFinRutaHelper = lineasSegmentoExpediente.findIndex((linea, indice) =>
+  indice > indiceRutaHelper && linea.includes("}),")
+);
+
+assert.notEqual(
+  indiceFinRutaHelper,
+  -1,
+  "Debe localizarse el cierre de la expansión del helper Parámetros base."
+);
+
+const rutaOperativaFiltrada = lineasSegmentoExpediente
+  .slice(indiceRutaHelper, indiceFinRutaHelper + 1)
+  .join("\n");
+
+const rutaOperativaUsaHelper =
+  rutaOperativaFiltrada.includes(`...${helperNombre}({`);
+
+const rutaOperativaPasaContextoBase =
+  rutaOperativaFiltrada.includes("contextoBase");
+
+assert.equal(
+  rutaOperativaUsaHelper,
+  true,
+  "La ruta operativa debe usar el helper Parámetros base."
+);
+
+assert.equal(
+  rutaOperativaPasaContextoBase,
+  true,
+  "La ruta operativa debe pasar contextoBase."
+);
+
+const modulo = await import(pathToFileURL(rutaModulo).href);
+
+const { construirLineasParametrosHidrologicosBaseExpediente } = modulo;
+
+assert.equal(
+  typeof construirLineasParametrosHidrologicosBaseExpediente,
+  "function",
+  "Debe exportarse construirLineasParametrosHidrologicosBaseExpediente como función."
+);
+
+const lineasHelper = construirLineasParametrosHidrologicosBaseExpediente({
+  contextoBase: {
+    CN: 83,
+    cn_base: 80,
+    cn_efectivo: 87,
+    AMC: "III",
+    fuente: "Control OT-0193"
+  }
+});
+
+assert.equal(
+  Array.isArray(lineasHelper),
+  true,
+  "El helper debe retornar arreglo."
+);
+
+assert.equal(
+  lineasHelper.every((linea) => typeof linea === "string"),
+  true,
+  "Todas las líneas del helper deben ser texto."
+);
+
+const textoHelper = lineasHelper.join("\n");
+
+const etiquetasEsperadas = [
+  "## 2. Parámetros hidrológicos base",
+  "CN:",
+  "CN base:",
+  "CN efectivo:",
+  "AMC:"
+];
+
+const etiquetasFaltantes = etiquetasEsperadas.filter((etiqueta) =>
+  !textoHelper.includes(etiqueta)
+);
+
+const residuosProhibidos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+const residuos = residuosProhibidos.filter((token) =>
+  textoHelper.includes(token)
+);
+
+assert.deepEqual(
+  etiquetasFaltantes,
+  [],
+  "El helper debe conservar encabezado y etiquetas mínimas."
+);
+
+assert.deepEqual(
+  residuos,
+  [],
+  "El helper no debe emitir residuos prohibidos."
+);
+
+const resumen = {
+  textoExpedienteDetectado: indiceTextoExpediente !== -1,
+  cierreTextoExpedienteDetectado: cierreTextoExpediente !== -1,
+  rutaOperativaUsaHelperParametrosBase: rutaOperativaUsaHelper,
+  rutaOperativaPasaContextoBase,
+  helperExportado: typeof construirLineasParametrosHidrologicosBaseExpediente === "function",
+  lineasHelper: lineasHelper.length,
+  etiquetasFaltantes,
+  residuos,
+  comparacionControladaAprobada:
+    rutaOperativaUsaHelper &&
+    rutaOperativaPasaContextoBase &&
+    etiquetasFaltantes.length === 0 &&
+    residuos.length === 0
+};
+
+const lineasReporte = [
+  "# OT-0193B — Comparación helper Parámetros base vs ruta operativa",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Ruta operativa detectada en textoExpediente",
+  "",
+  "```javascript",
+  rutaOperativaFiltrada,
+  "```",
+  "",
+  "## Salida controlada del helper validado",
+  "",
+  "```text",
+  textoHelper,
+  "```",
+  "",
+  "## Lectura técnica",
+  "",
+  "- La ruta operativa de `textoExpediente` usa la expansión del helper `construirLineasParametrosHidrologicosBaseExpediente(...)`.",
+  "- La ruta operativa pasa `contextoBase` al helper.",
+  "- El helper conserva el encabezado `## 2. Parámetros hidrológicos base` y las etiquetas mínimas esperadas.",
+  "- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada.",
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó `construirExpedienteHidrologicoMinimo.js`.",
+  "- No se modificó `textoExpediente`.",
+  "- No se modificó botón de copiado.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5 operativo.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("COMPARACION_OT_0193_HELPER_PARAMETROS_BASE_RUTA_OPERATIVA_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Comparar de forma controlada el helper validado `construirLineasParametrosHidrologicosBaseExpediente(...)` contra su ruta operativa de composición dentro de `textoExpediente`.

## Antecedente

OT-0191 auditó y trazó la composición real del bloque `## 2. Parámetros hidrológicos base`.

OT-0192 validó en aislamiento el helper `construirLineasParametrosHidrologicosBaseExpediente(...)` y obtuvo:

```text
VALIDACION_OT_0192_HELPER_PARAMETROS_BASE_AISLADA_OK