### PR TITLE
OT-0196 — Auditoría trazabilidad Sello técnico auxiliar

### DIFF
--- a/00_ADMIN/bitacora/OT-0196/OT-0196A_apertura_auditoria_trazabilidad_sello_tecnico_auxiliar.md
+++ b/00_ADMIN/bitacora/OT-0196/OT-0196A_apertura_auditoria_trazabilidad_sello_tecnico_auxiliar.md
@@ -1,0 +1,50 @@
+# OT-0196A — Apertura auditoría/trazabilidad bloque Sello técnico auxiliar
+
+## Objetivo
+
+Auditar y trazar la composición real del bloque `Sello técnico auxiliar` dentro del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0195 seleccionó el bloque `Sello técnico auxiliar` como siguiente candidato representacional preferente, condicionado a confirmar primero su ruta real de composición.
+
+## Alcance
+
+Esta OT solo audita y traza.
+
+No implementa helper.
+
+No sustituye contenido.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica validadores existentes.
+
+No modifica botón ni portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- `construirExpedienteHidrologicoMinimo.js`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Preguntas de auditoría
+
+- ¿Existe el bloque `Sello técnico auxiliar` como texto literal o por helper?
+- ¿La ruta operativa usa `construirLineasSelloTecnicoAuxiliarExpediente(...)`?
+- ¿La invocación operativa pasa `contextoBase` u otros argumentos?
+- ¿El helper se exporta correctamente?
+- ¿La salida controlada contiene residuos `undefined`, `null`, `NaN` o `[object Object]`?
+- ¿El bloque es apto para validación aislada posterior sin tocar cálculos ni motor?

--- a/00_ADMIN/bitacora/OT-0196/OT-0196B_auditoria_trazabilidad_sello_tecnico_auxiliar.md
+++ b/00_ADMIN/bitacora/OT-0196/OT-0196B_auditoria_trazabilidad_sello_tecnico_auxiliar.md
@@ -1,0 +1,60 @@
+# OT-0196B — Auditoría/trazabilidad bloque Sello técnico auxiliar
+
+## Resumen
+
+```json
+{
+  "textoExpedienteDetectado": true,
+  "cierreTextoExpedienteDetectado": true,
+  "mencionaSelloTecnico": false,
+  "rutaOperativaUsaHelperSelloTecnico": false,
+  "rutaOperativaLocalizada": false,
+  "rutaOperativaPasaContextoBase": false,
+  "helperExportadoEnModulo": true,
+  "helperImportable": true,
+  "lineasSalidaControlada": 3,
+  "residuos": [],
+  "errorHelper": "",
+  "decisionPreliminar": "requiere revisión antes de avanzar"
+}
+```
+
+## Ruta operativa detectada en textoExpediente
+
+No se localizó ruta operativa del helper dentro de `textoExpediente`.
+
+## Salida controlada del helper
+
+```text
+Versión auxiliar helper expediente: expediente_hidrologico_minimo_v0_1.
+Estado auxiliar helper expediente: helper_no_integrado.
+Tipo auxiliar helper expediente: expediente_hidrologico_minimo.
+```
+
+## Lectura técnica
+
+- No se confirmó uso del helper `construirLineasSelloTecnicoAuxiliarExpediente(...)` dentro de `textoExpediente`.
+
+- No se confirmó que la ruta operativa pase `contextoBase` al helper.
+
+- El helper se importa correctamente como función.
+
+- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada.
+
+- No se registró error al ejecutar el helper en escenario controlado.
+
+## Decisión preliminar
+
+requiere revisión antes de avanzar
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0196/OT-0196C_cierre_auditoria_trazabilidad_sello_tecnico_auxiliar.md
+++ b/00_ADMIN/bitacora/OT-0196/OT-0196C_cierre_auditoria_trazabilidad_sello_tecnico_auxiliar.md
@@ -1,0 +1,67 @@
+# OT-0196C — Cierre auditoría/trazabilidad bloque Sello técnico auxiliar
+
+## Resultado
+
+Se auditó y trazó la composición real del bloque `Sello técnico auxiliar` dentro del expediente hidrológico mínimo.
+
+## Evidencia principal
+
+La auditoría quedó documentada en:
+
+`00_ADMIN/bitacora/OT-0196/OT-0196B_auditoria_trazabilidad_sello_tecnico_auxiliar.md`
+
+## Validación ejecutada
+
+`AUDITORIA_OT_0196_TRAZABILIDAD_SELLO_TECNICO_AUXILIAR_OK`
+
+## Hallazgo principal
+
+El helper `construirLineasSelloTecnicoAuxiliarExpediente(...)` existe y se importa correctamente como función.
+
+Sin embargo, no se confirmó su uso dentro de `textoExpediente`.
+
+No se localizó ruta operativa del helper dentro del arreglo de composición del expediente.
+
+La salida controlada del helper indica explícitamente:
+
+```text
+Estado auxiliar helper expediente: helper_no_integrado.
+```
+
+## Lectura técnica
+
+El bloque `Sello técnico auxiliar` no debe avanzar todavía a validación aislada como bloque operativo integrado.
+
+Antes de cualquier validación posterior debe definirse una OT específica de revisión o decisión sobre integración, manteniendo el principio de no sustitución prematura.
+
+## Alcance mantenido
+
+No se implementó helper.
+
+No se sustituyó contenido.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron validadores existentes.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Decisión
+
+No avanzar todavía a validación aislada operativa del bloque `Sello técnico auxiliar`.
+
+El siguiente frente debe ser una revisión/decisión específica sobre el helper auxiliar no integrado, sin tocar todavía `textoExpediente` ni flujo operativo.

--- a/07_TOOLBOX/validaciones/auditar_ot0196_trazabilidad_sello_tecnico_auxiliar.mjs
+++ b/07_TOOLBOX/validaciones/auditar_ot0196_trazabilidad_sello_tecnico_auxiliar.mjs
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const rutaModulo = path.resolve(
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0196/OT-0196B_auditoria_trazabilidad_sello_tecnico_auxiliar.md"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+const textoModulo = fs.readFileSync(rutaModulo, "utf8");
+
+const indiceTextoExpediente = textoComparador.indexOf("const textoExpediente = [");
+
+const cierreTextoExpediente =
+  indiceTextoExpediente === -1
+    ? -1
+    : textoComparador.indexOf('].join("\\n")', indiceTextoExpediente);
+
+const segmentoTextoExpediente =
+  indiceTextoExpediente === -1 || cierreTextoExpediente === -1
+    ? ""
+    : textoComparador.slice(
+        indiceTextoExpediente,
+        cierreTextoExpediente + '].join("\\n")'.length
+      );
+
+const helperNombre = "construirLineasSelloTecnicoAuxiliarExpediente";
+
+const lineasSegmento = segmentoTextoExpediente.split(/\r?\n/u);
+
+const indiceRutaHelper = lineasSegmento.findIndex((linea) =>
+  linea.includes(`...${helperNombre}({`)
+);
+
+const indiceFinRutaHelper =
+  indiceRutaHelper === -1
+    ? -1
+    : lineasSegmento.findIndex((linea, indice) =>
+        indice > indiceRutaHelper && linea.includes("}),")
+      );
+
+const rutaOperativa =
+  indiceRutaHelper === -1 || indiceFinRutaHelper === -1
+    ? ""
+    : lineasSegmento.slice(indiceRutaHelper, indiceFinRutaHelper + 1).join("\n");
+
+const mencionaSelloTecnico =
+  segmentoTextoExpediente.includes("Sello técnico") ||
+  segmentoTextoExpediente.includes("sello técnico") ||
+  segmentoTextoExpediente.includes("Sello tecnico") ||
+  segmentoTextoExpediente.includes("sello tecnico");
+
+const usaHelperSelloTecnico =
+  segmentoTextoExpediente.includes(`...${helperNombre}({`);
+
+const pasaContextoBase =
+  rutaOperativa.includes("contextoBase");
+
+const helperExportadoEnModulo =
+  textoModulo.includes(`export function ${helperNombre}`);
+
+let helperImportable = false;
+let salidaControlada = [];
+let errorHelper = "";
+let residuos = [];
+
+const residuosProhibidos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+try {
+  const modulo = await import(pathToFileURL(rutaModulo).href);
+  const helper = modulo[helperNombre];
+
+  helperImportable = typeof helper === "function";
+
+  if (helperImportable) {
+    const resultado = helper({
+      contextoBase: {
+        fuente: "Control OT-0196",
+        cuenca: {
+          nombre: "La Iguaná PC_80"
+        }
+      }
+    });
+
+    salidaControlada = Array.isArray(resultado)
+      ? resultado
+      : [`SALIDA_NO_ARREGLO: ${String(resultado)}`];
+
+    const textoSalida = salidaControlada.join("\n");
+
+    residuos = residuosProhibidos.filter((token) =>
+      textoSalida.includes(token)
+    );
+  }
+} catch (error) {
+  errorHelper = error instanceof Error ? error.message : String(error);
+}
+
+const textoSalidaControlada = Array.isArray(salidaControlada)
+  ? salidaControlada.join("\n")
+  : String(salidaControlada);
+
+const resumen = {
+  textoExpedienteDetectado: indiceTextoExpediente !== -1,
+  cierreTextoExpedienteDetectado: cierreTextoExpediente !== -1,
+  mencionaSelloTecnico,
+  rutaOperativaUsaHelperSelloTecnico: usaHelperSelloTecnico,
+  rutaOperativaLocalizada: rutaOperativa.length > 0,
+  rutaOperativaPasaContextoBase: pasaContextoBase,
+  helperExportadoEnModulo,
+  helperImportable,
+  lineasSalidaControlada: Array.isArray(salidaControlada) ? salidaControlada.length : 0,
+  residuos,
+  errorHelper,
+  decisionPreliminar:
+    usaHelperSelloTecnico && helperImportable && residuos.length === 0
+      ? "candidato apto para validación aislada posterior"
+      : "requiere revisión antes de avanzar"
+};
+
+const lineasReporte = [
+  "# OT-0196B — Auditoría/trazabilidad bloque Sello técnico auxiliar",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Ruta operativa detectada en textoExpediente",
+  "",
+  rutaOperativa.length > 0
+    ? "```javascript"
+    : "No se localizó ruta operativa del helper dentro de `textoExpediente`.",
+  ...(rutaOperativa.length > 0 ? [rutaOperativa, "```"] : []),
+  "",
+  "## Salida controlada del helper",
+  "",
+  "```text",
+  textoSalidaControlada.length > 0
+    ? textoSalidaControlada
+    : "No se obtuvo salida controlada del helper.",
+  "```",
+  "",
+  "## Lectura técnica",
+  "",
+  usaHelperSelloTecnico
+    ? "- La ruta operativa de `textoExpediente` usa el helper `construirLineasSelloTecnicoAuxiliarExpediente(...)`."
+    : "- No se confirmó uso del helper `construirLineasSelloTecnicoAuxiliarExpediente(...)` dentro de `textoExpediente`.",
+  "",
+  pasaContextoBase
+    ? "- La ruta operativa pasa `contextoBase` al helper."
+    : "- No se confirmó que la ruta operativa pase `contextoBase` al helper.",
+  "",
+  helperImportable
+    ? "- El helper se importa correctamente como función."
+    : "- El helper no pudo importarse como función.",
+  "",
+  residuos.length === 0
+    ? "- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada."
+    : `- Se detectaron residuos en la salida controlada: ${residuos.join(", ")}.`,
+  "",
+  errorHelper.length === 0
+    ? "- No se registró error al ejecutar el helper en escenario controlado."
+    : `- Error al ejecutar helper en escenario controlado: ${errorHelper}.`,
+  "",
+  "## Decisión preliminar",
+  "",
+  resumen.decisionPreliminar,
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó `construirExpedienteHidrologicoMinimo.js`.",
+  "- No se modificó `textoExpediente`.",
+  "- No se modificó botón de copiado.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5 operativo.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("AUDITORIA_OT_0196_TRAZABILIDAD_SELLO_TECNICO_AUXILIAR_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Auditar y trazar la composición real del bloque `Sello técnico auxiliar` dentro del expediente hidrológico mínimo.

## Antecedente

OT-0195 seleccionó el bloque `Sello técnico auxiliar` como siguiente candidato representacional preferente, condicionado a confirmar primero su ruta real de composición.

## Alcance

Esta OT solo audita y traza.

No implementa helper.
No sustituye contenido.
No modifica `textoExpediente`.
No modifica `ComparadorMultiMetodo.jsx`.
No modifica `construirExpedienteHidrologicoMinimo.js`.
No modifica validadores existentes.
No modifica botón ni portapapeles.

## Validación ejecutada

```text
AUDITORIA_OT_0196_TRAZABILIDAD_SELLO_TECNICO_AUXILIAR_OK