### PR TITLE
OT-0200 — Revisión bloques reales textoExpediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0200/OT-0200A_apertura_revision_estructural_bloques_texto_expediente.md
+++ b/00_ADMIN/bitacora/OT-0200/OT-0200A_apertura_revision_estructural_bloques_texto_expediente.md
@@ -1,0 +1,51 @@
+# OT-0200A — Apertura revisión estructural de bloques reales dentro de textoExpediente
+
+## Objetivo
+
+Inventariar la estructura real de bloques que componen `textoExpediente` dentro de `ComparadorMultiMetodo.jsx`, para evitar seguir seleccionando candidatos no integrados.
+
+## Antecedente
+
+OT-0196 confirmó que el helper `Sello técnico auxiliar` existe pero no está integrado en `textoExpediente`.
+
+OT-0199 confirmó que el candidato `Restricciones o advertencias técnicas` no aparece integrado con las rutas buscadas.
+
+## Alcance
+
+Esta OT solo inventaría y documenta.
+
+No implementa helper.
+
+No sustituye contenido.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica validadores existentes.
+
+No modifica botón ni portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- `construirExpedienteHidrologicoMinimo.js`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Preguntas de revisión
+
+- ¿Existe `textoExpediente`?
+- ¿Dónde cierra `textoExpediente`?
+- ¿Qué helpers se expanden dentro de `textoExpediente`?
+- ¿Qué encabezados literales `## ...` aparecen dentro de `textoExpediente`?
+- ¿Qué bloques parecen candidatos reales para próximas auditorías?

--- a/00_ADMIN/bitacora/OT-0200/OT-0200B_revision_estructural_bloques_texto_expediente.md
+++ b/00_ADMIN/bitacora/OT-0200/OT-0200B_revision_estructural_bloques_texto_expediente.md
@@ -1,0 +1,168 @@
+# OT-0200B — Revisión estructural de bloques reales dentro de textoExpediente
+
+## Resumen
+
+```json
+{
+  "textoExpedienteDetectado": true,
+  "cierreTextoExpedienteDetectado": true,
+  "totalLineasSegmento": 88,
+  "totalHelpersDetectados": 6,
+  "totalEncabezadosLiteralesDetectados": 5,
+  "helpersDetectados": [
+    {
+      "helperNombre": "construirLineasIdentificacionExpediente",
+      "pasaContextoBase": true,
+      "lineaInicio": 7,
+      "lineaFin": 11
+    },
+    {
+      "helperNombre": "construirLineasParametrosHidrologicosBaseExpediente",
+      "pasaContextoBase": true,
+      "lineaInicio": 13,
+      "lineaFin": 15
+    },
+    {
+      "helperNombre": "construirLineasTiempoConcentracionRolesTcExpediente",
+      "pasaContextoBase": false,
+      "lineaInicio": 17,
+      "lineaFin": 20
+    },
+    {
+      "helperNombre": "construirLineasVolumenReferenciaExpediente",
+      "pasaContextoBase": false,
+      "lineaInicio": 22,
+      "lineaFin": 25
+    },
+    {
+      "helperNombre": "construirLineasEscenarioQTrActivoExpediente",
+      "pasaContextoBase": false,
+      "lineaInicio": 27,
+      "lineaFin": 32
+    },
+    {
+      "helperNombre": "construirLineasResumenQ5AuditadoExpediente",
+      "pasaContextoBase": false,
+      "lineaInicio": 34,
+      "lineaFin": 36
+    }
+  ],
+  "encabezadosLiteralesDetectados": [
+    {
+      "linea": 2,
+      "encabezado": "# Expediente hidrológico mínimo — Cuenca activa"
+    },
+    {
+      "linea": 37,
+      "encabezado": "## 7. Método Racional — contraste global independiente"
+    },
+    {
+      "linea": 63,
+      "encabezado": "## 8. Contraste Q-5 vs Método Racional"
+    },
+    {
+      "linea": 69,
+      "encabezado": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5"
+    },
+    {
+      "linea": 83,
+      "encabezado": "## Diagnóstico temporal Q(t) no adoptivo"
+    }
+  ],
+  "candidatosPrudentes": [
+    "construirLineasIdentificacionExpediente",
+    "construirLineasParametrosHidrologicosBaseExpediente",
+    "construirLineasTiempoConcentracionRolesTcExpediente"
+  ],
+  "decisionPreliminar": "usar inventario real para seleccionar siguiente bloque integrado"
+}
+```
+
+## Helpers expandidos dentro de textoExpediente
+
+### construirLineasIdentificacionExpediente
+
+```javascript
+            ...construirLineasIdentificacionExpediente({
+              contextoBase,
+              fuenteFallback: "HidroFlow",
+              estacionIdfFallback: estacionIdfExpediente
+            }),
+```
+
+### construirLineasParametrosHidrologicosBaseExpediente
+
+```javascript
+            ...construirLineasParametrosHidrologicosBaseExpediente({
+              contextoBase
+            }),
+```
+
+### construirLineasTiempoConcentracionRolesTcExpediente
+
+```javascript
+            ...construirLineasTiempoConcentracionRolesTcExpediente({
+              Tc_final,
+              trDisenoActivoExpediente
+            }),
+```
+
+### construirLineasVolumenReferenciaExpediente
+
+```javascript
+            ...construirLineasVolumenReferenciaExpediente({
+              peTotalMm,
+              volumenEsperadoM3
+            }),
+```
+
+### construirLineasEscenarioQTrActivoExpediente
+
+```javascript
+                ...construirLineasEscenarioQTrActivoExpediente({
+                  estadoQTrActivoExpediente,
+                  qTrActivoExpediente,
+                  faltantesQTrActivoExpediente,
+                  formatearValorQTrExpediente
+                }),
+```
+
+### construirLineasResumenQ5AuditadoExpediente
+
+```javascript
+            ...construirLineasResumenQ5AuditadoExpediente({
+              tablaQ5Markdown
+            }),
+```
+
+## Encabezados literales detectados
+
+- Línea 2: # Expediente hidrológico mínimo — Cuenca activa
+- Línea 37: ## 7. Método Racional — contraste global independiente
+- Línea 63: ## 8. Contraste Q-5 vs Método Racional
+- Línea 69: ## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+- Línea 83: ## Diagnóstico temporal Q(t) no adoptivo
+
+## Candidatos prudentes derivados del inventario
+
+- construirLineasIdentificacionExpediente
+- construirLineasParametrosHidrologicosBaseExpediente
+- construirLineasTiempoConcentracionRolesTcExpediente
+
+## Lectura técnica
+
+- La revisión se limita al segmento `textoExpediente` dentro de `ComparadorMultiMetodo.jsx`.
+- No se modificó ningún archivo operativo.
+- El inventario debe usarse como base para seleccionar el próximo bloque, evitando candidatos no integrados.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0200/OT-0200C_cierre_revision_estructural_bloques_texto_expediente.md
+++ b/00_ADMIN/bitacora/OT-0200/OT-0200C_cierre_revision_estructural_bloques_texto_expediente.md
@@ -1,0 +1,45 @@
+# OT-0200C — Cierre revisión estructural de bloques reales dentro de textoExpediente
+
+## Resultado
+
+Se inventarió la estructura real de bloques que componen `textoExpediente` dentro de `ComparadorMultiMetodo.jsx`.
+
+## Evidencia principal
+
+La revisión quedó documentada en:
+
+`00_ADMIN/bitacora/OT-0200/OT-0200B_revision_estructural_bloques_texto_expediente.md`
+
+## Validación ejecutada
+
+`REVISION_OT_0200_BLOQUES_REALES_TEXTO_EXPEDIENTE_OK`
+
+## Alcance mantenido
+
+No se implementó helper.
+
+No se sustituyó contenido.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron validadores existentes.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Decisión
+
+Cualquier avance posterior debe basarse en los bloques reales inventariados en OT-0200B.

--- a/07_TOOLBOX/validaciones/revisar_ot0200_bloques_reales_texto_expediente.mjs
+++ b/07_TOOLBOX/validaciones/revisar_ot0200_bloques_reales_texto_expediente.mjs
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const rutaComparador = path.resolve(
+  "01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx"
+);
+
+const rutaReporte = path.resolve(
+  "00_ADMIN/bitacora/OT-0200/OT-0200B_revision_estructural_bloques_texto_expediente.md"
+);
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+
+const indiceTextoExpediente = textoComparador.indexOf("const textoExpediente = [");
+
+const cierreTextoExpediente =
+  indiceTextoExpediente === -1
+    ? -1
+    : textoComparador.indexOf('].join("\\n")', indiceTextoExpediente);
+
+const segmentoTextoExpediente =
+  indiceTextoExpediente === -1 || cierreTextoExpediente === -1
+    ? ""
+    : textoComparador.slice(
+        indiceTextoExpediente,
+        cierreTextoExpediente + '].join("\\n")'.length
+      );
+
+const lineasSegmento = segmentoTextoExpediente.split(/\r?\n/u);
+
+const helperRegex = /\.\.\.(construirLineas[A-Za-z0-9_]+Expediente)\s*\(\s*\{/u;
+
+const helpers = [];
+
+lineasSegmento.forEach((linea, indice) => {
+  const coincidencia = linea.match(helperRegex);
+
+  if (!coincidencia) {
+    return;
+  }
+
+  const helperNombre = coincidencia[1];
+
+  const indiceFin = lineasSegmento.findIndex((lineaCierre, indiceCierre) =>
+    indiceCierre > indice && lineaCierre.includes("}),")
+  );
+
+  const rutaOperativa =
+    indiceFin === -1
+      ? linea
+      : lineasSegmento.slice(indice, indiceFin + 1).join("\n");
+
+  helpers.push({
+    helperNombre,
+    lineaInicio: indice + 1,
+    lineaFin: indiceFin === -1 ? null : indiceFin + 1,
+    pasaContextoBase: rutaOperativa.includes("contextoBase"),
+    rutaOperativa
+  });
+});
+
+const encabezados = [];
+
+lineasSegmento.forEach((linea, indice) => {
+  const coincidencias = Array.from(
+    linea.matchAll(/["'`](#{1,3}\s+[^"'`]+)["'`]/gu)
+  );
+
+  coincidencias.forEach((coincidencia) => {
+    encabezados.push({
+      linea: indice + 1,
+      encabezado: coincidencia[1].trim()
+    });
+  });
+});
+
+const helpersUnicos = Array.from(
+  new Map(helpers.map((item) => [item.helperNombre, item])).values()
+);
+
+const encabezadosUnicos = Array.from(
+  new Map(encabezados.map((item) => [item.encabezado, item])).values()
+);
+
+const terminosSensibles = [
+  "q5",
+  "q_5",
+  "racional",
+  "hidrogram",
+  "diagnostico",
+  "diagnóstico",
+  "volumen",
+  "caudal",
+  "qt"
+];
+
+const candidatosPrudentes = helpersUnicos
+  .filter((item) => {
+    const nombre = item.helperNombre.toLowerCase();
+    return !terminosSensibles.some((termino) => nombre.includes(termino));
+  })
+  .map((item) => item.helperNombre);
+
+const resumen = {
+  textoExpedienteDetectado: indiceTextoExpediente !== -1,
+  cierreTextoExpedienteDetectado: cierreTextoExpediente !== -1,
+  totalLineasSegmento: lineasSegmento.length,
+  totalHelpersDetectados: helpersUnicos.length,
+  totalEncabezadosLiteralesDetectados: encabezadosUnicos.length,
+  helpersDetectados: helpersUnicos.map((item) => ({
+    helperNombre: item.helperNombre,
+    pasaContextoBase: item.pasaContextoBase,
+    lineaInicio: item.lineaInicio,
+    lineaFin: item.lineaFin
+  })),
+  encabezadosLiteralesDetectados: encabezadosUnicos,
+  candidatosPrudentes,
+  decisionPreliminar:
+    helpersUnicos.length > 0
+      ? "usar inventario real para seleccionar siguiente bloque integrado"
+      : "requiere revisión manual adicional de textoExpediente"
+};
+
+const bloquesHelpers =
+  helpersUnicos.length > 0
+    ? helpersUnicos.flatMap((item) => [
+        `### ${item.helperNombre}`,
+        "",
+        "```javascript",
+        item.rutaOperativa,
+        "```",
+        ""
+      ])
+    : [
+        "No se detectaron helpers expandidos dentro de `textoExpediente`.",
+        ""
+      ];
+
+const bloquesEncabezados =
+  encabezadosUnicos.length > 0
+    ? encabezadosUnicos.map((item) => `- Línea ${item.linea}: ${item.encabezado}`)
+    : ["No se detectaron encabezados literales `## ...` dentro de `textoExpediente`."];
+
+const lineasReporte = [
+  "# OT-0200B — Revisión estructural de bloques reales dentro de textoExpediente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Helpers expandidos dentro de textoExpediente",
+  "",
+  ...bloquesHelpers,
+  "## Encabezados literales detectados",
+  "",
+  ...bloquesEncabezados,
+  "",
+  "## Candidatos prudentes derivados del inventario",
+  "",
+  candidatosPrudentes.length > 0
+    ? candidatosPrudentes.map((item) => `- ${item}`).join("\n")
+    : "No se identificaron candidatos prudentes automáticos.",
+  "",
+  "## Lectura técnica",
+  "",
+  "- La revisión se limita al segmento `textoExpediente` dentro de `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó ningún archivo operativo.",
+  "- El inventario debe usarse como base para seleccionar el próximo bloque, evitando candidatos no integrados.",
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó `construirExpedienteHidrologicoMinimo.js`.",
+  "- No se modificó `textoExpediente`.",
+  "- No se modificó botón de copiado.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5 operativo.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("REVISION_OT_0200_BLOQUES_REALES_TEXTO_EXPEDIENTE_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Inventariar la estructura real de bloques que componen `textoExpediente` dentro de `ComparadorMultiMetodo.jsx`, para evitar seguir seleccionando candidatos no integrados.

## Antecedente

OT-0196 confirmó que el helper `Sello técnico auxiliar` existe pero no está integrado en `textoExpediente`.

OT-0199 confirmó que el candidato `Restricciones o advertencias técnicas` no aparece integrado con las rutas buscadas.

## Alcance

Esta OT solo inventaría y documenta.

No implementa helper.
No sustituye contenido.
No modifica `textoExpediente`.
No modifica `ComparadorMultiMetodo.jsx`.
No modifica `construirExpedienteHidrologicoMinimo.js`.
No modifica validadores existentes.
No modifica botón ni portapapeles.

## Validación ejecutada

```text
REVISION_OT_0200_BLOQUES_REALES_TEXTO_EXPEDIENTE_OK