### PR TITLE
OT-0201 — Auditoría trazabilidad roles Tc

### DIFF
--- a/00_ADMIN/bitacora/OT-0201/OT-0201A_apertura_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0201/OT-0201A_apertura_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,60 @@
+# OT-0201A — Apertura auditoría/trazabilidad bloque Tiempo de concentración y roles Tc
+
+## Objetivo
+
+Auditar y trazar la composición real del bloque `Tiempo de concentración y roles Tc` dentro de `textoExpediente`.
+
+## Antecedente
+
+OT-0200 inventarió los bloques reales dentro de `textoExpediente` y confirmó que `construirLineasTiempoConcentracionRolesTcExpediente(...)` está expandido como helper integrado.
+
+La ruta operativa detectada fue:
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente
+}),
+```
+
+## Alcance
+
+Esta OT solo audita y traza.
+
+No implementa helper.
+
+No sustituye contenido.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica validadores existentes.
+
+No modifica botón ni portapapeles.
+
+## Restricciones
+
+No se modifica:
+
+- `textoExpediente`;
+- `ComparadorMultiMetodo.jsx`;
+- `construirExpedienteHidrologicoMinimo.js`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Preguntas de auditoría
+
+- ¿Existe `textoExpediente`?
+- ¿La ruta operativa usa `construirLineasTiempoConcentracionRolesTcExpediente(...)`?
+- ¿Qué argumentos recibe la ruta operativa?
+- ¿El helper se exporta correctamente?
+- ¿Puede importarse y ejecutarse en escenario controlado?
+- ¿La salida controlada contiene residuos `undefined`, `null`, `NaN` o `[object Object]`?
+- ¿El bloque es apto para validación aislada posterior?

--- a/00_ADMIN/bitacora/OT-0201/OT-0201B_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0201/OT-0201B_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,69 @@
+# OT-0201B — Auditoría/trazabilidad bloque Tiempo de concentración y roles Tc
+
+## Resumen
+
+```json
+{
+  "textoExpedienteDetectado": true,
+  "cierreTextoExpedienteDetectado": true,
+  "rutaOperativaLocalizada": true,
+  "rutaOperativaUsaHelperTiempoConcentracionRolesTc": true,
+  "rutaOperativaUsaTcFinal": true,
+  "rutaOperativaUsaTrDisenoActivo": true,
+  "helperExportadoEnModulo": true,
+  "helperImportable": true,
+  "lineasSalidaControlada": 10,
+  "residuos": [],
+  "errorHelper": "",
+  "decisionPreliminar": "candidato apto para validación aislada posterior"
+}
+```
+
+## Ruta operativa detectada en textoExpediente
+
+```javascript
+            ...construirLineasTiempoConcentracionRolesTcExpediente({
+              Tc_final,
+              trDisenoActivoExpediente
+            }),
+```
+
+## Salida controlada del helper
+
+```text
+## 3. Tiempo de concentración y roles Tc
+Tc comparador: 114.2 min
+Tr global activo: 100 años
+Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.
+Roles Tc:
+- Tc global Índice: referencia hidrológica general.
+- Tc operativo Q(t): ruta interna del hidrograma.
+- Duración evento: 3 h para almacenamiento/regulación.
+- Lag / forma SCS: parámetro derivado para forma temporal.
+- Tc comparador: referencia especializada para coherencia Q-5.
+```
+
+## Lectura técnica
+
+- La ruta operativa de `textoExpediente` usa el helper `construirLineasTiempoConcentracionRolesTcExpediente(...)`.
+- La ruta operativa pasa `Tc_final` al helper.
+- La ruta operativa pasa `trDisenoActivoExpediente` al helper.
+- El helper se importa correctamente como función.
+- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada.
+- No se registró error al ejecutar el helper en escenario controlado.
+
+## Decisión preliminar
+
+candidato apto para validación aislada posterior
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se modificó botón de copiado.
+- No se modificó portapapeles.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+- No se tocó motor hidrológico.

--- a/00_ADMIN/bitacora/OT-0201/OT-0201C_cierre_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
+++ b/00_ADMIN/bitacora/OT-0201/OT-0201C_cierre_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md
@@ -1,0 +1,45 @@
+# OT-0201C — Cierre auditoría/trazabilidad bloque Tiempo de concentración y roles Tc
+
+## Resultado
+
+Se auditó y trazó la composición real del bloque `Tiempo de concentración y roles Tc` dentro de `textoExpediente`.
+
+## Evidencia principal
+
+La auditoría quedó documentada en:
+
+`00_ADMIN/bitacora/OT-0201/OT-0201B_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md`
+
+## Validación ejecutada
+
+`AUDITORIA_OT_0201_TRAZABILIDAD_TIEMPO_CONCENTRACION_ROLES_TC_OK`
+
+## Alcance mantenido
+
+No se implementó helper.
+
+No se sustituyó contenido.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron validadores existentes.
+
+## Restricciones mantenidas
+
+No se modificó:
+
+- `textoExpediente`;
+- botón de copiado;
+- portapapeles;
+- Q-5 operativo;
+- Método Racional;
+- diagnóstico Q(t);
+- motor hidrológico.
+
+## Decisión
+
+Cualquier avance posterior debe basarse en la ruta real y el resultado documentado en OT-0201B.

--- a/07_TOOLBOX/validaciones/auditar_ot0201_trazabilidad_tiempo_concentracion_roles_tc.mjs
+++ b/07_TOOLBOX/validaciones/auditar_ot0201_trazabilidad_tiempo_concentracion_roles_tc.mjs
@@ -1,0 +1,173 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const rutaComparador = path.resolve("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx");
+const rutaModulo = path.resolve("01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js");
+const rutaReporte = path.resolve("00_ADMIN/bitacora/OT-0201/OT-0201B_auditoria_trazabilidad_tiempo_concentracion_roles_tc.md");
+
+const helperNombre = "construirLineasTiempoConcentracionRolesTcExpediente";
+
+const textoComparador = fs.readFileSync(rutaComparador, "utf8");
+const textoModulo = fs.readFileSync(rutaModulo, "utf8");
+
+const indiceTextoExpediente = textoComparador.indexOf("const textoExpediente = [");
+const cierreTextoExpediente =
+  indiceTextoExpediente === -1
+    ? -1
+    : textoComparador.indexOf('].join("\\n")', indiceTextoExpediente);
+
+const segmentoTextoExpediente =
+  indiceTextoExpediente === -1 || cierreTextoExpediente === -1
+    ? ""
+    : textoComparador.slice(
+        indiceTextoExpediente,
+        cierreTextoExpediente + '].join("\\n")'.length
+      );
+
+const lineasSegmento = segmentoTextoExpediente.split(/\r?\n/u);
+
+const indiceRutaHelper = lineasSegmento.findIndex((linea) =>
+  linea.includes(`...${helperNombre}({`)
+);
+
+const indiceFinRutaHelper =
+  indiceRutaHelper === -1
+    ? -1
+    : lineasSegmento.findIndex((linea, indice) =>
+        indice > indiceRutaHelper && linea.includes("}),")
+      );
+
+const rutaOperativa =
+  indiceRutaHelper === -1 || indiceFinRutaHelper === -1
+    ? ""
+    : lineasSegmento.slice(indiceRutaHelper, indiceFinRutaHelper + 1).join("\n");
+
+const rutaOperativaUsaHelper = rutaOperativa.includes(`...${helperNombre}({`);
+const rutaOperativaUsaTcFinal = rutaOperativa.includes("Tc_final");
+const rutaOperativaUsaTrDisenoActivo = rutaOperativa.includes("trDisenoActivoExpediente");
+const helperExportadoEnModulo = textoModulo.includes(`export function ${helperNombre}`);
+
+let helperImportable = false;
+let salidaControlada = [];
+let errorHelper = "";
+let residuos = [];
+
+const residuosProhibidos = ["undefined", "null", "NaN", "[object Object]"];
+
+try {
+  const modulo = await import(pathToFileURL(rutaModulo).href);
+  const helper = modulo[helperNombre];
+
+  helperImportable = typeof helper === "function";
+
+  if (helperImportable) {
+    const resultado = helper({
+      Tc_final: 114.23,
+      trDisenoActivoExpediente: 100
+    });
+
+    salidaControlada = Array.isArray(resultado)
+      ? resultado
+      : [`SALIDA_NO_ARREGLO: ${String(resultado)}`];
+
+    const textoSalida = salidaControlada.join("\n");
+
+    residuos = residuosProhibidos.filter((token) => textoSalida.includes(token));
+  }
+} catch (error) {
+  errorHelper = error instanceof Error ? error.message : String(error);
+}
+
+const textoSalidaControlada = Array.isArray(salidaControlada)
+  ? salidaControlada.join("\n")
+  : String(salidaControlada);
+
+const decisionPreliminar =
+  rutaOperativaUsaHelper &&
+  helperImportable &&
+  residuos.length === 0
+    ? "candidato apto para validación aislada posterior"
+    : "requiere revisión antes de avanzar";
+
+const resumen = {
+  textoExpedienteDetectado: indiceTextoExpediente !== -1,
+  cierreTextoExpedienteDetectado: cierreTextoExpediente !== -1,
+  rutaOperativaLocalizada: rutaOperativa.length > 0,
+  rutaOperativaUsaHelperTiempoConcentracionRolesTc: rutaOperativaUsaHelper,
+  rutaOperativaUsaTcFinal,
+  rutaOperativaUsaTrDisenoActivo,
+  helperExportadoEnModulo,
+  helperImportable,
+  lineasSalidaControlada: salidaControlada.length,
+  residuos,
+  errorHelper,
+  decisionPreliminar
+};
+
+const lineasReporte = [
+  "# OT-0201B — Auditoría/trazabilidad bloque Tiempo de concentración y roles Tc",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Ruta operativa detectada en textoExpediente",
+  "",
+  rutaOperativa.length > 0
+    ? "```javascript"
+    : "No se localizó ruta operativa del helper dentro de `textoExpediente`.",
+  ...(rutaOperativa.length > 0 ? [rutaOperativa, "```"] : []),
+  "",
+  "## Salida controlada del helper",
+  "",
+  "```text",
+  textoSalidaControlada.length > 0
+    ? textoSalidaControlada
+    : "No se obtuvo salida controlada del helper.",
+  "```",
+  "",
+  "## Lectura técnica",
+  "",
+  rutaOperativaUsaHelper
+    ? "- La ruta operativa de `textoExpediente` usa el helper `construirLineasTiempoConcentracionRolesTcExpediente(...)`."
+    : "- No se confirmó uso del helper dentro de `textoExpediente`.",
+  rutaOperativaUsaTcFinal
+    ? "- La ruta operativa pasa `Tc_final` al helper."
+    : "- No se confirmó que la ruta operativa pase `Tc_final` al helper.",
+  rutaOperativaUsaTrDisenoActivo
+    ? "- La ruta operativa pasa `trDisenoActivoExpediente` al helper."
+    : "- No se confirmó que la ruta operativa pase `trDisenoActivoExpediente` al helper.",
+  helperImportable
+    ? "- El helper se importa correctamente como función."
+    : "- El helper no pudo importarse como función.",
+  residuos.length === 0
+    ? "- No se detectaron residuos `undefined`, `null`, `NaN` ni `[object Object]` en la salida controlada."
+    : `- Se detectaron residuos en la salida controlada: ${residuos.join(", ")}.`,
+  errorHelper.length === 0
+    ? "- No se registró error al ejecutar el helper en escenario controlado."
+    : `- Error al ejecutar helper en escenario controlado: ${errorHelper}.`,
+  "",
+  "## Decisión preliminar",
+  "",
+  decisionPreliminar,
+  "",
+  "## Restricciones mantenidas",
+  "",
+  "- No se modificó `ComparadorMultiMetodo.jsx`.",
+  "- No se modificó `construirExpedienteHidrologicoMinimo.js`.",
+  "- No se modificó `textoExpediente`.",
+  "- No se modificó botón de copiado.",
+  "- No se modificó portapapeles.",
+  "- No se tocó Q-5 operativo.",
+  "- No se tocó Método Racional.",
+  "- No se tocó diagnóstico Q(t).",
+  "- No se tocó motor hidrológico."
+];
+
+fs.writeFileSync(rutaReporte, lineasReporte.join("\n"), "utf8");
+
+console.log("AUDITORIA_OT_0201_TRAZABILIDAD_TIEMPO_CONCENTRACION_ROLES_TC_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Auditar y trazar la composición real del bloque `Tiempo de concentración y roles Tc` dentro de `textoExpediente`.

## Antecedente

OT-0200 inventarió los bloques reales dentro de `textoExpediente` y confirmó que `construirLineasTiempoConcentracionRolesTcExpediente(...)` está expandido como helper integrado.

La ruta operativa detectada fue:

```javascript
...construirLineasTiempoConcentracionRolesTcExpediente({
  Tc_final,
  trDisenoActivoExpediente
}),