### PR TITLE
OT-0209 — Ajuste Markdown generador documental

### DIFF
--- a/00_ADMIN/bitacora/OT-0209/OT-0209A_apertura_ajuste_generador_documental_bloque_markdown.md
+++ b/00_ADMIN/bitacora/OT-0209/OT-0209A_apertura_ajuste_generador_documental_bloque_markdown.md
@@ -1,0 +1,58 @@
+# OT-0209A — Ajuste mínimo del generador documental por bloque Markdown
+
+## Objetivo
+
+Corregir de forma mínima el generador documental `Nueva-OTDocumentalHidroFlow` para evitar corrupción de formato Markdown en el documento de cierre generado.
+
+## Antecedente
+
+OT-0208 validó operativamente el generador documental y detectó un hallazgo controlado en el cierre generado.
+
+El cierre presentó corrupción de formato en el bloque Markdown asociado a la ruta de evidencia.
+
+El patrón observado fue compatible con uso de triple backtick dentro de strings PowerShell con comillas dobles.
+
+## Alcance
+
+Esta OT solo ajusta el generador documental mínimo.
+
+No modifica motor.
+
+No modifica UI.
+
+No modifica `textoExpediente`.
+
+No modifica `ComparadorMultiMetodo.jsx`.
+
+No modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No modifica helpers.
+
+No modifica validadores existentes.
+
+No modifica Q-5 operativo.
+
+No modifica Método Racional.
+
+No modifica diagnóstico Q(t).
+
+## Archivo objetivo
+
+```text
+07_TOOLBOX/powershell/hidroflow-ot-generator.ps1
+```
+
+## Ajuste previsto
+
+Reemplazar las líneas de bloque Markdown con triple backtick escritas como strings de comillas dobles por strings de comillas simples dentro del arreglo `$lineasC`.
+
+## Criterio de validación
+
+La validación debe confirmar:
+
+- que el generador carga correctamente;
+- que `Nueva-OTDocumentalHidroFlow` sigue disponible;
+- que una generación sandbox produce cierre con bloque Markdown legible;
+- que no quedan residuos de formato como `` `       ext ``;
+- que la prueba sandbox se elimina después de validar;
+- que no hay diff en archivos críticos de aplicación.

--- a/00_ADMIN/bitacora/OT-0209/OT-0209B_validacion_ajuste_generador_documental_bloque_markdown.md
+++ b/00_ADMIN/bitacora/OT-0209/OT-0209B_validacion_ajuste_generador_documental_bloque_markdown.md
@@ -1,0 +1,45 @@
+# OT-0209B — Validación ajuste generador documental por bloque Markdown
+
+## Resumen
+
+```json
+{
+  "generadorExiste": true,
+  "funcionDisponible": true,
+  "sandboxAperturaGenerada": true,
+  "sandboxCierreGenerado": true,
+  "cierreContieneFenceText": true,
+  "cierreContieneRutaApertura": true,
+  "cierreContieneResiduoExt": false,
+  "cierreContieneComillasResiduales": false,
+  "ajusteMarkdownAprobado": true,
+  "sandboxEliminado": true,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false
+}
+```
+
+## Resultado
+
+El ajuste mínimo del generador documental fue validado correctamente.
+
+## Ajuste aplicado
+
+Se reemplazaron los bloques Markdown con triple backtick escritos como strings de comillas dobles por strings de comillas simples dentro del generador documental.
+
+## Validación sandbox
+
+Se generó una OT temporal `OT-9999` para validar el cierre documental generado.
+
+La OT temporal fue eliminada después de la validación.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se tocó motor hidrológico.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0209/OT-0209C_cierre_ajuste_generador_documental_bloque_markdown.md
+++ b/00_ADMIN/bitacora/OT-0209/OT-0209C_cierre_ajuste_generador_documental_bloque_markdown.md
@@ -1,0 +1,39 @@
+# OT-0209C — Cierre ajuste generador documental por bloque Markdown
+
+## Resultado
+
+Se aplicó un ajuste mínimo al generador documental `Nueva-OTDocumentalHidroFlow` para corregir la escritura de bloques Markdown en el cierre generado.
+
+## Archivo modificado
+
+```text
+07_TOOLBOX/powershell/hidroflow-ot-generator.ps1
+```
+
+## Evidencia principal
+
+La validación quedó documentada en:
+
+```text
+00_ADMIN/bitacora/OT-0209/OT-0209B_validacion_ajuste_generador_documental_bloque_markdown.md
+```
+
+## Alcance mantenido
+
+No se modificó código de aplicación.
+
+No se modificó motor.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron helpers.
+
+No se modificaron validadores existentes.
+
+## Decisión
+
+El generador documental queda ajustado para una nueva validación operativa posterior.

--- a/07_TOOLBOX/powershell/hidroflow-ot-generator.ps1
+++ b/07_TOOLBOX/powershell/hidroflow-ot-generator.ps1
@@ -90,9 +90,9 @@ function Nueva-OTDocumentalHidroFlow {
     "",
     "Documento de apertura:",
     "",
-    "```text",
+    '```text',
     $rutaA,
-    "```",
+    '```',
     "",
     "## Alcance mantenido",
     "",
@@ -114,3 +114,4 @@ function Nueva-OTDocumentalHidroFlow {
   Write-Output "git add `"$rutaA`" `"$rutaC`""
   Write-Output "git commit -m `"docs(tools): documenta $slugSeguro`""
 }
+


### PR DESCRIPTION
## Objetivo

Corregir de forma mínima el generador documental `Nueva-OTDocumentalHidroFlow` para evitar corrupción de formato Markdown en el documento de cierre generado.

## Antecedente

OT-0208 validó operativamente el generador documental y detectó un hallazgo controlado en el cierre generado.

El cierre presentó corrupción de formato en el bloque Markdown asociado a la ruta de evidencia.

El patrón observado fue compatible con uso de triple backtick dentro de strings PowerShell con comillas dobles.

## Alcance

Esta OT solo ajusta el generador documental mínimo.

No modifica motor.
No modifica UI.
No modifica `textoExpediente`.
No modifica `ComparadorMultiMetodo.jsx`.
No modifica `construirExpedienteHidrologicoMinimo.js`.
No modifica helpers.
No modifica validadores existentes.
No modifica Q-5 operativo.
No modifica Método Racional.
No modifica diagnóstico Q(t).

## Archivo modificado

```text
07_TOOLBOX/powershell/hidroflow-ot-generator.ps1