### PR TITLE
OT-0210 — Revalidación generador documental ajustado

### DIFF
--- a/00_ADMIN/bitacora/OT-0210/OT-0210A_apertura_revalidacion-operativa-generador-documental-ajustado.md
+++ b/00_ADMIN/bitacora/OT-0210/OT-0210A_apertura_revalidacion-operativa-generador-documental-ajustado.md
@@ -1,0 +1,26 @@
+# OT-0210A — Revalidación operativa del generador documental ajustado
+
+## Objetivo
+
+Revalidar operativamente que Nueva-OTDocumentalHidroFlow genera apertura y cierre documental limpios después del ajuste Markdown aplicado en OT-0209.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar helpers.
+- No modificar validadores existentes.
+- No ejecutar commits automáticos.
+
+## Próximo frente recomendado
+
+OT-0211 — Integración operativa mínima del generador en flujo de trabajo

--- a/00_ADMIN/bitacora/OT-0210/OT-0210B_revalidacion_operativa_generador_documental_ajustado.md
+++ b/00_ADMIN/bitacora/OT-0210/OT-0210B_revalidacion_operativa_generador_documental_ajustado.md
@@ -1,0 +1,54 @@
+# OT-0210B — Revalidación operativa generador documental ajustado
+
+## Resumen
+
+```json
+{
+  "scriptGeneradorExiste": true,
+  "aperturaGenerada": true,
+  "cierreGenerado": true,
+  "funcionDisponible": true,
+  "cierreContieneFenceText": true,
+  "cierreContieneRutaApertura": true,
+  "cierreContieneResiduoExt": false,
+  "cierreContieneComillasResiduales": false,
+  "ejecutaCommitAutomatico": false,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false,
+  "revalidacionOperativaAprobada": true
+}
+```
+
+## Resultado
+
+La revalidación operativa del generador documental ajustado fue aprobada.
+
+## Archivos generados
+
+```text
+00_ADMIN\bitacora\OT-0210\OT-0210A_apertura_revalidacion-operativa-generador-documental-ajustado.md
+00_ADMIN\bitacora\OT-0210\OT-0210C_cierre_revalidacion-operativa-generador-documental-ajustado.md
+```
+
+## Lectura técnica
+
+- El generador creó apertura y cierre documental.
+- El cierre conserva bloque Markdown `text` legible.
+- El cierre contiene la ruta del documento de apertura.
+- No se detectaron residuos de formato asociados al hallazgo de OT-0208.
+- El generador no ejecutó `git add`, `git commit` ni `git push`.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se tocó motor hidrológico.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+
+## Decisión
+
+El generador documental ajustado queda revalidado operativamente para estructuras documentales mínimas.

--- a/00_ADMIN/bitacora/OT-0210/OT-0210C_cierre_revalidacion-operativa-generador-documental-ajustado.md
+++ b/00_ADMIN/bitacora/OT-0210/OT-0210C_cierre_revalidacion-operativa-generador-documental-ajustado.md
@@ -1,0 +1,21 @@
+# OT-0210C — Cierre Revalidación operativa del generador documental ajustado
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0210\OT-0210A_apertura_revalidacion-operativa-generador-documental-ajustado.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Revalidar operativamente que `Nueva-OTDocumentalHidroFlow` genera apertura y cierre documental limpios después del ajuste Markdown aplicado en OT-0209.

## Antecedente

OT-0207 creó el generador documental mínimo.

OT-0208 validó operativamente el generador y detectó un hallazgo de formato Markdown en el cierre generado.

OT-0209 corrigió de forma mínima la escritura de bloques Markdown con triple backtick dentro del generador.

## Resultado

La revalidación operativa del generador documental ajustado fue aprobada.

## Resumen

```json
{
  "scriptGeneradorExiste": true,
  "aperturaGenerada": true,
  "cierreGenerado": true,
  "funcionDisponible": true,
  "cierreContieneFenceText": true,
  "cierreContieneRutaApertura": true,
  "cierreContieneResiduoExt": false,
  "cierreContieneComillasResiduales": false,
  "ejecutaCommitAutomatico": false,
  "modificaCodigoAplicacion": false,
  "modificaMotor": false,
  "modificaTextoExpediente": false,
  "revalidacionOperativaAprobada": true
}