### PR TITLE
OT-0212 — Validación uso repetible generador documental

### DIFF
--- a/00_ADMIN/bitacora/OT-0212/OT-0212A_apertura_validacion-uso-repetible-generador-documental.md
+++ b/00_ADMIN/bitacora/OT-0212/OT-0212A_apertura_validacion-uso-repetible-generador-documental.md
@@ -1,0 +1,27 @@
+# OT-0212A — Validación de uso repetible del generador documental
+
+## Objetivo
+
+Validar que Nueva-OTDocumentalHidroFlow puede reutilizarse de forma controlada para generar una estructura documental mínima en una OT no sensible.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar helpers.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No usar sobre bloques sensibles del expediente.
+
+## Próximo frente recomendado
+
+OT-0213 — Decisión de siguiente automatización documental mínima

--- a/00_ADMIN/bitacora/OT-0212/OT-0212B_validacion_uso_repetible_generador_documental.md
+++ b/00_ADMIN/bitacora/OT-0212/OT-0212B_validacion_uso_repetible_generador_documental.md
@@ -1,0 +1,55 @@
+# OT-0212B — Validación de uso repetible del generador documental
+
+## Resumen
+
+```json
+{
+  "scriptGeneradorExiste": true,
+  "aperturaGenerada": true,
+  "cierreGenerado": true,
+  "aperturaContieneObjetivo": true,
+  "cierreContieneFenceText": true,
+  "cierreContieneRutaApertura": true,
+  "cierreContieneResiduoExt": false,
+  "cierreContieneComillasResiduales": false,
+  "ejecutaCommitAutomatico": false,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false,
+  "usoRepetibleAprobado": true
+}
+```
+
+## Resultado
+
+La validación de uso repetible del generador documental fue aprobada.
+
+## Archivos generados
+
+```text
+00_ADMIN\bitacora\OT-0212\OT-0212A_apertura_validacion-uso-repetible-generador-documental.md
+00_ADMIN\bitacora\OT-0212\OT-0212C_cierre_validacion-uso-repetible-generador-documental.md
+```
+
+## Lectura técnica
+
+- El generador se reutilizó en una nueva OT no sensible.
+- La apertura documental fue creada correctamente.
+- El cierre documental fue creado correctamente.
+- El cierre conserva bloque Markdown `text` legible.
+- No se detectaron residuos de formato asociados al hallazgo de OT-0208.
+- El generador no ejecutó `git add`, `git commit` ni `git push`.
+
+## Restricciones mantenidas
+
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `textoExpediente`.
+- No se tocó motor hidrológico.
+- No se tocó Q-5 operativo.
+- No se tocó Método Racional.
+- No se tocó diagnóstico Q(t).
+
+## Decisión
+
+El generador documental queda validado como reutilizable para OTs documentales mínimas no sensibles.

--- a/00_ADMIN/bitacora/OT-0212/OT-0212C_cierre_validacion-uso-repetible-generador-documental.md
+++ b/00_ADMIN/bitacora/OT-0212/OT-0212C_cierre_validacion-uso-repetible-generador-documental.md
@@ -1,0 +1,21 @@
+# OT-0212C — Cierre Validación de uso repetible del generador documental
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0212\OT-0212A_apertura_validacion-uso-repetible-generador-documental.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Validar que `Nueva-OTDocumentalHidroFlow` puede reutilizarse de forma controlada para generar una estructura documental mínima en una OT no sensible.

## Resultado

La validación de uso repetible del generador documental fue aprobada.

## Resumen

```json
{
  "scriptGeneradorExiste": true,
  "aperturaGenerada": true,
  "cierreGenerado": true,
  "aperturaContieneObjetivo": true,
  "cierreContieneFenceText": true,
  "cierreContieneRutaApertura": true,
  "cierreContieneResiduoExt": false,
  "cierreContieneComillasResiduales": false,
  "ejecutaCommitAutomatico": false,
  "modificaCodigoAplicacion": false,
  "modificaMotor": false,
  "modificaTextoExpediente": false,
  "usoRepetibleAprobado": true
}