### PR TITLE
OT-0214 — Cierre fase tooling documental mínimo

### DIFF
--- a/00_ADMIN/bitacora/OT-0214/OT-0214A_apertura_cierre-fase-tooling-documental-minimo-retorno-expediente.md
+++ b/00_ADMIN/bitacora/OT-0214/OT-0214A_apertura_cierre-fase-tooling-documental-minimo-retorno-expediente.md
@@ -1,0 +1,31 @@
+# OT-0214A — Cierre de fase tooling documental mínimo y retorno controlado al expediente
+
+## Objetivo
+
+Cerrar formalmente la fase de tooling documental mínimo, registrar el estado de Nueva-OTDocumentalHidroFlow y definir el retorno controlado al expediente hidrológico mínimo sin tocar todavía bloques sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar helpers.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0215 — Selección prudente del bloque documental del expediente a retomar

--- a/00_ADMIN/bitacora/OT-0214/OT-0214B_cierre_fase_tooling_documental_minimo_retorno_expediente.md
+++ b/00_ADMIN/bitacora/OT-0214/OT-0214B_cierre_fase_tooling_documental_minimo_retorno_expediente.md
@@ -1,0 +1,104 @@
+# OT-0214B — Cierre de fase tooling documental mínimo y retorno controlado al expediente
+
+## Objetivo
+
+Cerrar formalmente la fase de tooling documental mínimo y definir el retorno controlado al expediente hidrológico mínimo.
+
+## Estado consolidado del tooling documental
+
+La fase de tooling documental mínimo quedó cerrada con la siguiente secuencia:
+
+- OT-0205: decisión de automatizar el ciclo auditor-validación-comparación;
+- OT-0206: diseño del generador operativo de OTs técnicas;
+- OT-0207: implementación mínima del generador documental;
+- OT-0208: validación operativa con hallazgo Markdown;
+- OT-0209: ajuste mínimo del generador por bloque Markdown;
+- OT-0210: revalidación operativa aprobada;
+- OT-0211: protocolo operativo mínimo;
+- OT-0212: uso repetible aprobado;
+- OT-0213: decisión de cerrar fase tooling mínima.
+
+## Herramienta disponible
+
+La herramienta disponible es:
+
+```text
+07_TOOLBOX/powershell/hidroflow-ot-generator.ps1
+```
+
+La función disponible es:
+
+```powershell
+Nueva-OTDocumentalHidroFlow
+```
+
+## Estado funcional de la herramienta
+
+`Nueva-OTDocumentalHidroFlow` queda apta para uso controlado en OTs documentales mínimas no sensibles.
+
+La herramienta puede:
+
+- crear carpeta de bitácora `00_ADMIN/bitacora/OT-XXXX`;
+- crear documento de apertura;
+- crear documento de cierre;
+- registrar restricciones;
+- sugerir comandos Git.
+
+La herramienta no debe:
+
+- ejecutar commits automáticos;
+- modificar motor;
+- modificar UI;
+- modificar `textoExpediente`;
+- modificar `ComparadorMultiMetodo.jsx`;
+- modificar `construirExpedienteHidrologicoMinimo.js`;
+- modificar helpers;
+- modificar validadores existentes;
+- tocar bloques sensibles del expediente.
+
+## Decisión de cierre
+
+Se cierra la fase de tooling documental mínimo.
+
+No se recomienda seguir ampliando el generador por ahora.
+
+No se automatiza Git.
+
+No se modifica el perfil PowerShell.
+
+No se entra todavía a Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Retorno controlado al expediente
+
+El retorno al expediente debe hacerse con menor fricción, pero manteniendo criterio técnico.
+
+El siguiente frente no debe ser implementación directa sobre bloques sensibles.
+
+Debe ser una selección prudente del bloque documental o de decisión a retomar dentro del expediente hidrológico mínimo.
+
+## Criterio para elegir siguiente bloque
+
+El siguiente bloque debe cumplir:
+
+- bajo riesgo operativo;
+- bajo coste de implementación;
+- valor documental claro;
+- posibilidad de usar `Nueva-OTDocumentalHidroFlow` solo para apertura/cierre;
+- ausencia de modificación directa sobre motor o Q-5;
+- ausencia de cambios directos sobre `textoExpediente` sin auditoría previa.
+
+## Próximo frente recomendado
+
+`OT-0215 — Selección prudente del bloque documental del expediente a retomar`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificaron helpers.
+- No se modificaron validadores existentes.
+- No se automatizaron commits.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0214/OT-0214C_cierre_cierre-fase-tooling-documental-minimo-retorno-expediente.md
+++ b/00_ADMIN/bitacora/OT-0214/OT-0214C_cierre_cierre-fase-tooling-documental-minimo-retorno-expediente.md
@@ -1,0 +1,43 @@
+# OT-0214C — Cierre de fase tooling documental mínimo y retorno controlado al expediente
+
+## Resultado
+
+Se cerró formalmente la fase de tooling documental mínimo y se definió el retorno controlado al expediente hidrológico mínimo.
+
+## Evidencia principal
+
+La decisión de cierre quedó documentada en:
+
+```text
+00_ADMIN/bitacora/OT-0214/OT-0214B_cierre_fase_tooling_documental_minimo_retorno_expediente.md
+```
+
+## Herramienta consolidada
+
+```powershell
+Nueva-OTDocumentalHidroFlow
+```
+
+## Alcance mantenido
+
+No se modificó código de aplicación.
+
+No se modificó motor.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron helpers.
+
+No se modificaron validadores existentes.
+
+No se tocaron bloques sensibles del expediente.
+
+## Decisión
+
+La fase tooling documental mínimo queda cerrada.
+
+El siguiente frente recomendado es `OT-0215 — Selección prudente del bloque documental del expediente a retomar`.


### PR DESCRIPTION
## Objetivo

Cerrar formalmente la fase de tooling documental mínimo y definir el retorno controlado al expediente hidrológico mínimo.

## Estado consolidado del tooling documental

La fase de tooling documental mínimo quedó cerrada con la siguiente secuencia:

- OT-0205: decisión de automatizar el ciclo auditor-validación-comparación;
- OT-0206: diseño del generador operativo de OTs técnicas;
- OT-0207: implementación mínima del generador documental;
- OT-0208: validación operativa con hallazgo Markdown;
- OT-0209: ajuste mínimo del generador por bloque Markdown;
- OT-0210: revalidación operativa aprobada;
- OT-0211: protocolo operativo mínimo;
- OT-0212: uso repetible aprobado;
- OT-0213: decisión de cerrar fase tooling mínima.

## Herramienta disponible

```text
07_TOOLBOX/powershell/hidroflow-ot-generator.ps1