### PR TITLE
OT-0222 — Helper restricciones advertencias generales

### DIFF
--- a/00_ADMIN/bitacora/OT-0222/OT-0222A_apertura_implementacion-helper-restricciones-advertencias-generales-expediente.md
+++ b/00_ADMIN/bitacora/OT-0222/OT-0222A_apertura_implementacion-helper-restricciones-advertencias-generales-expediente.md
@@ -1,0 +1,33 @@
+# OT-0222A — Implementación helper puro restricciones y advertencias generales del expediente
+
+## Objetivo
+
+Implementar el helper puro documental construirBloqueRestriccionesAdvertenciasGeneralesExpediente, sin integrarlo todavía al expediente operativo ni tocar archivos críticos.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No integrar todavía.
+- No consolidar todavía.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0223 — Validación aislada helper restricciones y advertencias generales del expediente

--- a/00_ADMIN/bitacora/OT-0222/OT-0222B_implementacion_helper_restricciones_advertencias_generales_expediente.md
+++ b/00_ADMIN/bitacora/OT-0222/OT-0222B_implementacion_helper_restricciones_advertencias_generales_expediente.md
@@ -1,0 +1,71 @@
+# OT-0222B — Implementación helper puro restricciones y advertencias generales del expediente
+
+## Objetivo
+
+Implementar el helper puro documental `construirBloqueRestriccionesAdvertenciasGeneralesExpediente` conforme al diseño OT-0221.
+
+## Archivo creado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js
+```
+
+## Tipo de cambio
+
+Implementación de helper puro documental.
+
+No se integra todavía al expediente operativo.
+
+## Función exportada
+
+```javascript
+construirBloqueRestriccionesAdvertenciasGeneralesExpediente
+```
+
+## Entradas permitidas
+
+- `advertenciasGenerales`.
+- `restriccionesGenerales`.
+- `alcanceGeneral`.
+- `incluirTitulo`.
+
+## Controles incluidos
+
+- Ignora entradas que no sean arreglos.
+- Ignora elementos que no sean texto.
+- Normaliza espacios.
+- Omite textos vacíos.
+- Omite textos con términos sensibles.
+- Devuelve arreglo de líneas Markdown.
+- No consulta motor.
+- No modifica UI.
+- No copia al portapapeles.
+
+## Alcance mantenido
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se integró el helper al expediente operativo.
+
+## Próximo frente recomendado
+
+`OT-0223 — Validación aislada helper restricciones y advertencias generales del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se integró el helper.
+- No se consolidó contenido.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0222/OT-0222C_cierre_implementacion-helper-restricciones-advertencias-generales-expediente.md
+++ b/00_ADMIN/bitacora/OT-0222/OT-0222C_cierre_implementacion-helper-restricciones-advertencias-generales-expediente.md
@@ -1,0 +1,21 @@
+# OT-0222C — Cierre Implementación helper puro restricciones y advertencias generales del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0222\OT-0222A_apertura_implementacion-helper-restricciones-advertencias-generales-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js
@@ -1,0 +1,124 @@
+// OT-0222 — Helper puro documental.
+// Construye un bloque acotado de restricciones y advertencias generales del expediente.
+// No consulta motor, no recalcula, no modifica UI y no integra textoExpediente.
+
+const TERMINOS_SENSIBLES = [
+  "q-5",
+  "método racional",
+  "metodo racional",
+  "diagnóstico q(t)",
+  "diagnostico q(t)",
+  "q(t)",
+  "volumen",
+  "q-tr",
+  "pe",
+  "masa",
+  "hidrograma",
+  "hidrogramas",
+  "caudal",
+  "caudales",
+  "adoptado",
+  "adopción",
+  "adopcion",
+  "validado",
+  "aprobado",
+  "seleccionado"
+];
+
+function normalizarTextoGeneral(valor) {
+  if (typeof valor !== "string") {
+    return "";
+  }
+
+  return valor
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function contieneTerminoSensible(texto) {
+  const base = normalizarTextoGeneral(texto).toLowerCase();
+
+  if (!base) {
+    return false;
+  }
+
+  return TERMINOS_SENSIBLES.some((termino) => base.includes(termino));
+}
+
+function limpiarListaGeneral(lista) {
+  if (!Array.isArray(lista)) {
+    return [];
+  }
+
+  return lista
+    .map((item) => normalizarTextoGeneral(item))
+    .filter((item) => item.length > 0)
+    .filter((item) => !contieneTerminoSensible(item));
+}
+
+function agregarLista(lineas, titulo, elementos, textoVacio) {
+  lineas.push(`### ${titulo}`);
+  lineas.push("");
+
+  if (!elementos.length) {
+    lineas.push(`- ${textoVacio}`);
+    lineas.push("");
+    return;
+  }
+
+  elementos.forEach((elemento) => {
+    lineas.push(`- ${elemento}`);
+  });
+
+  lineas.push("");
+}
+
+export function construirBloqueRestriccionesAdvertenciasGeneralesExpediente({
+  advertenciasGenerales = [],
+  restriccionesGenerales = [],
+  alcanceGeneral = "",
+  incluirTitulo = true
+} = {}) {
+  const lineas = [];
+
+  const advertencias = limpiarListaGeneral(advertenciasGenerales);
+  const restricciones = limpiarListaGeneral(restriccionesGenerales);
+  const alcance = normalizarTextoGeneral(alcanceGeneral);
+
+  if (incluirTitulo) {
+    lineas.push("## Restricciones y advertencias generales del expediente");
+    lineas.push("");
+  }
+
+  if (alcance && !contieneTerminoSensible(alcance)) {
+    lineas.push(alcance);
+    lineas.push("");
+  } else {
+    lineas.push("Este bloque tiene alcance documental e interpretativo general.");
+    lineas.push("");
+  }
+
+  agregarLista(
+    lineas,
+    "Restricciones generales",
+    restricciones,
+    "No se suministraron restricciones generales específicas."
+  );
+
+  agregarLista(
+    lineas,
+    "Advertencias generales",
+    advertencias,
+    "No se suministraron advertencias generales específicas."
+  );
+
+  lineas.push("### Nota de alcance");
+  lineas.push("");
+  lineas.push("- El expediente no modifica el motor hidrológico.");
+  lineas.push("- El expediente no recalcula resultados.");
+  lineas.push("- Las advertencias generales no implican adopción hidrológica.");
+  lineas.push("- Los resultados sensibles deben revisarse en sus bloques específicos.");
+  lineas.push("- Este bloque no sustituye la validación técnica especializada.");
+
+  return lineas;
+}


### PR DESCRIPTION
## Objetivo

Implementar el helper puro documental `construirBloqueRestriccionesAdvertenciasGeneralesExpediente`, sin integrarlo todavía al expediente operativo ni tocar archivos críticos.

## Archivo creado

```text
01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js