### PR TITLE
OT-0224 — Ajuste criterio validador restricciones advertencias

### DIFF
--- a/00_ADMIN/bitacora/OT-0224/OT-0224A_apertura_ajuste-criterio-validador-helper-restricciones-advertencias.md
+++ b/00_ADMIN/bitacora/OT-0224/OT-0224A_apertura_ajuste-criterio-validador-helper-restricciones-advertencias.md
@@ -1,0 +1,33 @@
+# OT-0224A — Ajuste criterio validador helper restricciones advertencias generales
+
+## Objetivo
+
+Ajustar el criterio del validador aislado del helper construirBloqueRestriccionesAdvertenciasGeneralesExpediente para evitar falsos positivos por términos demasiado amplios, sin modificar el helper ni integrarlo al expediente operativo.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar el helper.
+- No modificar helpers existentes.
+- No automatizar commits.
+- No integrar todavía.
+- No consolidar todavía.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0225 — Revalidación aislada helper restricciones y advertencias generales

--- a/00_ADMIN/bitacora/OT-0224/OT-0224B_ajuste_criterio_validador_helper_restricciones_advertencias.md
+++ b/00_ADMIN/bitacora/OT-0224/OT-0224B_ajuste_criterio_validador_helper_restricciones_advertencias.md
@@ -1,0 +1,64 @@
+# OT-0224B — Ajuste criterio validador helper restricciones advertencias generales
+
+## Objetivo
+
+Ajustar el criterio del validador aislado creado en OT-0223 para evitar falsos positivos por términos demasiado amplios.
+
+## Antecedente
+
+OT-0223 ejecutó la validación aislada del helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente`.
+
+La validación no quedó aprobada porque todos los casos detectaron como sensibles los términos `pe` y `adopción`.
+
+## Hallazgo
+
+`pe` es un patrón demasiado corto y puede aparecer dentro de palabras generales como `expediente`, `especializada` o `específicos`.
+
+`adopción` aparece dentro de una frase permitida por diseño: `Las advertencias generales no implican adopción hidrológica`.
+
+## Ajuste aplicado
+
+Se ajustó únicamente el validador aislado:
+
+```text
+07_TOOLBOX/validaciones/validar_ot0223_helper_restricciones_advertencias_generales_expediente.mjs
+```
+
+Cambios de criterio:
+
+- se elimina `pe` como término sensible global;
+- se elimina `adopción` / `adopcion` como término sensible literal global;
+- se mantiene el control sobre términos sensibles explícitos como Q-5, Método Racional, Q(t), Volumen, Q-Tr, masa, hidrogramas, caudales y adopciones afirmativas;
+- se conserva la frase permitida de cautela: `no implican adopción hidrológica`.
+
+## Alcance mantenido
+
+No se modificó el helper.
+
+No se modificó `textoExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se integró el helper al expediente operativo.
+
+## Decisión
+
+El validador queda ajustado para una nueva revalidación aislada posterior.
+
+## Próximo frente recomendado
+
+`OT-0225 — Revalidación aislada helper restricciones y advertencias generales`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó el helper.
+- No se integró el helper.
+- No se consolidó contenido.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0224/OT-0224C_cierre_ajuste-criterio-validador-helper-restricciones-advertencias.md
+++ b/00_ADMIN/bitacora/OT-0224/OT-0224C_cierre_ajuste-criterio-validador-helper-restricciones-advertencias.md
@@ -1,0 +1,21 @@
+# OT-0224C — Cierre Ajuste criterio validador helper restricciones advertencias generales
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0224\OT-0224A_apertura_ajuste-criterio-validador-helper-restricciones-advertencias.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/07_TOOLBOX/validaciones/validar_ot0223_helper_restricciones_advertencias_generales_expediente.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0223_helper_restricciones_advertencias_generales_expediente.mjs
@@ -21,21 +21,24 @@ function contieneSensibles(lineas) {
     "q(t)",
     "volumen",
     "q-tr",
-    "pe",
-    "masa",
+        "masa",
     "hidrograma",
     "hidrogramas",
     "caudal",
     "caudales",
     "adoptado",
-    "adopción",
-    "adopcion",
-    "validado",
+            "validado",
     "aprobado",
     "seleccionado"
   ];
 
-  return sensibles.filter((termino) => texto.includes(termino));
+  return sensibles.filter((termino) => {
+    if (termino === "adoptado" && texto.includes("no implican adopción hidrológica")) {
+      return false;
+    }
+
+    return texto.includes(termino);
+  });
 }
 
 function esArregloTexto(lineas) {
@@ -195,3 +198,4 @@ await import("fs").then((fs) => {
 
 console.log("VALIDACION_OT_0223_HELPER_RESTRICCIONES_ADVERTENCIAS_OK");
 console.log(JSON.stringify(resumen, null, 2));
+


### PR DESCRIPTION
## Objetivo

Ajustar el criterio del validador aislado creado en OT-0223 para evitar falsos positivos por términos demasiado amplios.

## Antecedente

OT-0223 ejecutó la validación aislada del helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente`.

La validación no quedó aprobada porque todos los casos detectaron como sensibles los términos `pe` y `adopción`.

## Hallazgo

`pe` es un patrón demasiado corto y puede aparecer dentro de palabras generales como `expediente`, `especializada` o `específicos`.

`adopción` aparece dentro de una frase permitida por diseño:

```text
Las advertencias generales no implican adopción hidrológica