### PR TITLE
OT-0226 — Decisión integración helper restricciones advertencias

### DIFF
--- a/00_ADMIN/bitacora/OT-0226/OT-0226A_apertura_decision-integracion-helper-restricciones-advertencias-generales.md
+++ b/00_ADMIN/bitacora/OT-0226/OT-0226A_apertura_decision-integracion-helper-restricciones-advertencias-generales.md
@@ -1,0 +1,33 @@
+# OT-0226A — Decisión de integración del helper restricciones y advertencias generales al expediente
+
+## Objetivo
+
+Decidir si procede integrar el helper construirBloqueRestriccionesAdvertenciasGeneralesExpediente al expediente hidrológico mínimo, con base en el contrato, diseño, implementación pura y revalidación aislada aprobada, sin implementar todavía.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar el helper.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No integrar todavía.
+- No consolidar todavía.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+Pendiente según decisión OT-0226

--- a/00_ADMIN/bitacora/OT-0226/OT-0226B_decision_integracion_helper_restricciones_advertencias_generales.md
+++ b/00_ADMIN/bitacora/OT-0226/OT-0226B_decision_integracion_helper_restricciones_advertencias_generales.md
@@ -1,0 +1,122 @@
+# OT-0226B — Decisión de integración del helper restricciones y advertencias generales al expediente
+
+## Objetivo
+
+Decidir si procede integrar el helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente` al expediente hidrológico mínimo.
+
+## Antecedente
+
+El ciclo técnico-documental del helper quedó cerrado así:
+
+- OT-0220: contrato del bloque de restricciones y advertencias generales;
+- OT-0221: diseño del helper;
+- OT-0222: implementación pura del helper;
+- OT-0223: validación aislada con hallazgo;
+- OT-0224: ajuste del criterio del validador;
+- OT-0225: revalidación aislada aprobada.
+
+## Estado actual del helper
+
+El helper existe en:
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js
+```
+
+La función exportada es:
+
+```javascript
+construirBloqueRestriccionesAdvertenciasGeneralesExpediente
+```
+
+## Resultado de revalidación aislada
+
+OT-0225 confirmó:
+
+```json
+{
+  "casos": 5,
+  "casosAprobados": 5,
+  "casosFallidos": 0,
+  "revalidacionAisladaAprobada": true,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false
+}
+```
+
+## Lectura técnica
+
+El helper queda validado como pieza documental pura.
+
+Sin embargo, la integración al expediente operativo requiere cautela porque implicaría tocar el flujo de construcción documental.
+
+La integración no debe realizarse directamente sin definir un punto único de acople y un criterio claro de no contaminación de bloques sensibles.
+
+## Opciones consideradas
+
+### Opción A — Integrar directamente al expediente
+
+Ventaja: permite usar de inmediato el bloque general de restricciones y advertencias.
+
+Riesgo: tocaría `construirExpedienteHidrologicoMinimo.js` sin una estrategia de acople previa.
+
+### Opción B — No integrar y cerrar el ciclo
+
+Ventaja: evita riesgo operativo.
+
+Riesgo: deja un helper validado sin uso dentro del expediente.
+
+### Opción C — Diseñar primero el punto de acople mínimo
+
+Ventaja: mantiene control, define ubicación, entradas permitidas, restricciones y pruebas antes de tocar el expediente operativo.
+
+Riesgo: agrega una OT documental adicional antes de la integración.
+
+## Decisión recomendada
+
+La decisión recomendada es no integrar todavía.
+
+Antes de cualquier integración, debe diseñarse un punto de acople mínimo dentro del expediente hidrológico mínimo.
+
+Ese diseño debe definir:
+
+- ubicación exacta del bloque;
+- entradas permitidas;
+- textos por defecto;
+- restricciones de no contaminación con Q-5, Método Racional, Q(t), Volumen, Q-Tr, Pe y masa;
+- validaciones posteriores.
+
+## Decisión operativa
+
+Se selecciona como siguiente frente el diseño del punto de acople mínimo del helper al expediente.
+
+No se implementa ningún cambio en esta OT.
+
+No se modifica `textoExpediente`.
+
+No se modifica `ComparadorMultiMetodo.jsx`.
+
+No se modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No se modifica el helper.
+
+No se toca motor.
+
+No se toca Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+`OT-0227 — Diseño punto de acople helper restricciones y advertencias generales al expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó el helper.
+- No se integró el helper.
+- No se consolidó contenido.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0226/OT-0226C_cierre_decision-integracion-helper-restricciones-advertencias-generales.md
+++ b/00_ADMIN/bitacora/OT-0226/OT-0226C_cierre_decision-integracion-helper-restricciones-advertencias-generales.md
@@ -1,0 +1,21 @@
+# OT-0226C — Cierre Decisión de integración del helper restricciones y advertencias generales al expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0226\OT-0226A_apertura_decision-integracion-helper-restricciones-advertencias-generales.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Decidir si procede integrar el helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente` al expediente hidrológico mínimo.

## Antecedente

El ciclo técnico-documental del helper quedó cerrado así:

- OT-0220: contrato del bloque de restricciones y advertencias generales;
- OT-0221: diseño del helper;
- OT-0222: implementación pura del helper;
- OT-0223: validación aislada con hallazgo;
- OT-0224: ajuste del criterio del validador;
- OT-0225: revalidación aislada aprobada.

## Estado actual del helper

El helper existe en:

```text
01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js