### PR TITLE
OT-0228 — Acople restricciones advertencias generales

### DIFF
--- a/00_ADMIN/bitacora/OT-0228/OT-0228A_apertura_implementacion-acople-minimo-helper-restricciones-advertencias.md
+++ b/00_ADMIN/bitacora/OT-0228/OT-0228A_apertura_implementacion-acople-minimo-helper-restricciones-advertencias.md
@@ -1,0 +1,31 @@
+# OT-0228A — Implementación acople mínimo helper restricciones y advertencias generales
+
+## Objetivo
+
+Implementar el acople mínimo del helper construirBloqueRestriccionesAdvertenciasGeneralesExpediente dentro del expediente hidrológico mínimo, tocando únicamente construirExpedienteHidrologicoMinimo.js y sin modificar bloques sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar el helper.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js si el anclaje exacto existe.
+
+## Próximo frente recomendado
+
+OT-0229 — Validación expediente con bloque restricciones y advertencias generales acoplado

--- a/00_ADMIN/bitacora/OT-0228/OT-0228B_implementacion_acople_minimo_helper_restricciones_advertencias.md
+++ b/00_ADMIN/bitacora/OT-0228/OT-0228B_implementacion_acople_minimo_helper_restricciones_advertencias.md
@@ -1,0 +1,76 @@
+# OT-0228B — Implementación acople mínimo helper restricciones y advertencias generales
+
+## Objetivo
+
+Implementar el acople mínimo del helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente` dentro del expediente hidrológico mínimo.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Helper acoplado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js
+```
+
+## Punto de acople
+
+Se acopló el helper en la sección general:
+
+```text
+## 12. Restricciones y advertencias técnicas
+```
+
+## Tipo de cambio
+
+Acople mínimo, único y auditable.
+
+No se modificó el helper.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó `textoExpediente` directamente.
+
+## Textos generales acoplados
+
+Restricciones generales:
+
+- El expediente no modifica el motor hidrológico.
+- El expediente no recalcula resultados.
+- El bloque tiene alcance documental e interpretativo general.
+
+Advertencias generales:
+
+- Las advertencias generales no implican adopción hidrológica.
+- Los resultados sensibles deben revisarse en sus bloques específicos.
+- Este bloque no sustituye la validación técnica especializada.
+
+## Alcance mantenido
+
+No se tocó motor.
+
+No se tocó UI.
+
+No se tocó `ComparadorMultiMetodo.jsx`.
+
+No se modificó el helper.
+
+No se modificaron validadores existentes.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+`OT-0229 — Validación expediente con bloque restricciones y advertencias generales acoplado`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente` directamente.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0228/OT-0228C_cierre_implementacion-acople-minimo-helper-restricciones-advertencias.md
+++ b/00_ADMIN/bitacora/OT-0228/OT-0228C_cierre_implementacion-acople-minimo-helper-restricciones-advertencias.md
@@ -1,0 +1,21 @@
+# OT-0228C — Cierre Implementación acople mínimo helper restricciones y advertencias generales
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0228\OT-0228A_apertura_implementacion-acople-minimo-helper-restricciones-advertencias.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -1,3 +1,4 @@
+import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -315,6 +316,21 @@ export default function construirExpedienteHidrologicoMinimo({
     "Alcance: helper puro inicial no integrado al botón de copiado.",
     "",
     "## 12. Restricciones y advertencias técnicas",
+// OT-0228 — Acople mínimo helper restricciones y advertencias generales.
+...construirBloqueRestriccionesAdvertenciasGeneralesExpediente({
+  restriccionesGenerales: [
+    "El expediente no modifica el motor hidrológico.",
+    "El expediente no recalcula resultados.",
+    "El bloque tiene alcance documental e interpretativo general."
+  ],
+  advertenciasGenerales: [
+    "Las advertencias generales no implican adopción hidrológica.",
+    "Los resultados sensibles deben revisarse en sus bloques específicos.",
+    "Este bloque no sustituye la validación técnica especializada."
+  ],
+  alcanceGeneral: "Sección general de cautela documental del expediente.",
+  incluirTitulo: false
+}),
     "- No modifica el motor hidrológico.",
     "- No recalcula hidrogramas.",
     "- No altera Qp, tPico, Volumen ni Q(t).",
@@ -608,3 +624,4 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+


### PR DESCRIPTION
## Objetivo

Implementar el acople mínimo del helper `construirBloqueRestriccionesAdvertenciasGeneralesExpediente` dentro del expediente hidrológico mínimo.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js