### PR TITLE
OT-0232 — Auditoría forma salida expediente mínimo

### DIFF
--- a/00_ADMIN/bitacora/OT-0232/OT-0232A_apertura_auditoria-forma-real-salida-expediente-minimo.md
+++ b/00_ADMIN/bitacora/OT-0232/OT-0232A_apertura_auditoria-forma-real-salida-expediente-minimo.md
@@ -1,0 +1,32 @@
+# OT-0232A — Auditoría forma real salida construirExpedienteHidrologicoMinimo
+
+## Objetivo
+
+Auditar la forma real del objeto devuelto por construirExpedienteHidrologicoMinimo para determinar cómo extraer correctamente la salida documental exportable, sin modificar expediente, helper, acople ni archivos críticos.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar el helper.
+- No modificar el acople.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0233 — Ajuste normalizador salida documental expediente mínimo

--- a/00_ADMIN/bitacora/OT-0232/OT-0232B_auditoria_forma_real_salida_expediente_minimo.md
+++ b/00_ADMIN/bitacora/OT-0232/OT-0232B_auditoria_forma_real_salida_expediente_minimo.md
@@ -1,0 +1,111 @@
+# OT-0232B — Auditoría forma real salida construirExpedienteHidrologicoMinimo
+
+## Resumen
+
+```json
+{
+  "auditoria": "OT-0232",
+  "objetivo": "forma_real_salida_construirExpedienteHidrologicoMinimo",
+  "archivoExpediente": "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js",
+  "archivoHelper": "01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js",
+  "formaSalida": {
+    "tipo": "object",
+    "esArray": false,
+    "esNull": false,
+    "keys": [
+      "ok",
+      "texto",
+      "errores",
+      "advertencias",
+      "secciones",
+      "metadata"
+    ],
+    "longitudArray": null,
+    "longitudString": null,
+    "vistaString": "[object Object]",
+    "detalleKeys": {
+      "ok": {
+        "tipo": "boolean",
+        "esArray": false,
+        "longitudArray": null,
+        "longitudString": null,
+        "vistaString": "true"
+      },
+      "texto": {
+        "tipo": "string",
+        "esArray": false,
+        "longitudArray": null,
+        "longitudString": 2868,
+        "vistaString": "# Expediente hidrológico mínimo — Cuenca activa\nEstado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.\nLectura técnica: este helper aún no reemplaza el expediente operativo construi"
+      },
+      "errores": {
+        "tipo": "array",
+        "esArray": true,
+        "longitudArray": 0,
+        "longitudString": null,
+        "vistaString": ""
+      },
+      "advertencias": {
+        "tipo": "array",
+        "esArray": true,
+        "longitudArray": 2,
+        "longitudString": null,
+        "vistaString": "Helper puro inicial no integrado al botón.,El texto generado es contractual/base y no reemplaza todavía el expediente operativo actual."
+      },
+      "secciones": {
+        "tipo": "array",
+        "esArray": true,
+        "longitudArray": 14,
+        "longitudString": null,
+        "vistaString": "# Expediente hidrológico mínimo — Cuenca activa,## 1. Identificación,## 2. Parámetros hidrológicos base,## 3. Tiempo de concentración y roles Tc,## 4. Volumen de referencia,## 5. Escenario Q-Tr activo"
+      },
+      "metadata": {
+        "tipo": "object",
+        "esArray": false,
+        "longitudArray": null,
+        "longitudString": null,
+        "vistaString": "[object Object]"
+      }
+    }
+  },
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false,
+  "candidatosTexto": [
+    {
+      "ruta": "salida.texto",
+      "tipo": "string",
+      "longitud": 2868,
+      "contieneTituloExpediente": true
+    },
+    {
+      "ruta": "salida.errores.join('\\n')",
+      "tipo": "array",
+      "longitud": 0,
+      "contieneTituloExpediente": false
+    },
+    {
+      "ruta": "salida.advertencias.join('\\n')",
+      "tipo": "array",
+      "longitud": 135,
+      "contieneTituloExpediente": false
+    },
+    {
+      "ruta": "salida.secciones.join('\\n')",
+      "tipo": "array",
+      "longitud": 577,
+      "contieneTituloExpediente": true
+    }
+  ]
+}
+```
+
+## Lectura técnica
+
+- Esta auditoría no modifica código funcional.
+- La finalidad es identificar la ruta correcta para extraer el texto documental exportable.
+- No se modifica expediente, helper, acople ni comparador.
+
+## Próximo frente recomendado
+
+`OT-0233 — Ajuste normalizador salida documental expediente mínimo`

--- a/00_ADMIN/bitacora/OT-0232/OT-0232C_cierre_auditoria-forma-real-salida-expediente-minimo.md
+++ b/00_ADMIN/bitacora/OT-0232/OT-0232C_cierre_auditoria-forma-real-salida-expediente-minimo.md
@@ -1,0 +1,21 @@
+# OT-0232C — Cierre Auditoría forma real salida construirExpedienteHidrologicoMinimo
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0232\OT-0232A_apertura_auditoria-forma-real-salida-expediente-minimo.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/07_TOOLBOX/validaciones/auditar_ot0232_forma_real_salida_expediente_minimo.mjs
+++ b/07_TOOLBOX/validaciones/auditar_ot0232_forma_real_salida_expediente_minimo.mjs
@@ -1,0 +1,162 @@
+import fs from "fs";
+import path from "path";
+import { pathToFileURL } from "url";
+
+const rutaExpediente = "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js";
+const rutaHelper = "01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js";
+
+function leerArchivo(ruta) {
+  if (!fs.existsSync(ruta)) return null;
+  return fs.readFileSync(ruta, "utf8");
+}
+
+async function cargarConstructorExpedienteConImportResuelto() {
+  const fuenteOriginal = leerArchivo(rutaExpediente);
+
+  if (!fuenteOriginal) {
+    throw new Error("No existe el archivo de expediente.");
+  }
+
+  const helperUrl = pathToFileURL(path.resolve(rutaHelper)).href;
+
+  const fuenteAjustada = fuenteOriginal.replace(
+    'import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";',
+    `import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "${helperUrl}";`
+  );
+
+  const moduloUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(fuenteAjustada)}`;
+  const modulo = await import(moduloUrl);
+
+  if (typeof modulo.default !== "function") {
+    throw new Error("El módulo de expediente no exporta función default.");
+  }
+
+  return modulo.default;
+}
+
+function resumirValor(valor) {
+  const tipo = Array.isArray(valor) ? "array" : typeof valor;
+
+  const resumen = {
+    tipo,
+    esArray: Array.isArray(valor),
+    esNull: valor === null,
+    keys: valor && typeof valor === "object" && !Array.isArray(valor) ? Object.keys(valor) : [],
+    longitudArray: Array.isArray(valor) ? valor.length : null,
+    longitudString: typeof valor === "string" ? valor.length : null,
+    vistaString: String(valor).slice(0, 300)
+  };
+
+  if (valor && typeof valor === "object" && !Array.isArray(valor)) {
+    resumen.detalleKeys = {};
+
+    for (const key of Object.keys(valor)) {
+      const interno = valor[key];
+      resumen.detalleKeys[key] = {
+        tipo: Array.isArray(interno) ? "array" : typeof interno,
+        esArray: Array.isArray(interno),
+        longitudArray: Array.isArray(interno) ? interno.length : null,
+        longitudString: typeof interno === "string" ? interno.length : null,
+        vistaString: String(interno).slice(0, 200)
+      };
+    }
+  }
+
+  return resumen;
+}
+
+const construirExpedienteHidrologicoMinimo = await cargarConstructorExpedienteConImportResuelto();
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: {},
+  fechaGeneracion: "AUDITORIA_OT_0232"
+});
+
+const resumen = {
+  auditoria: "OT-0232",
+  objetivo: "forma_real_salida_construirExpedienteHidrologicoMinimo",
+  archivoExpediente: rutaExpediente,
+  archivoHelper: rutaHelper,
+  formaSalida: resumirValor(salida),
+  modificaCodigoAplicacion: false,
+  modificaMotor: false,
+  modificaTextoExpediente: false
+};
+
+const candidatosTexto = [];
+
+if (typeof salida === "string") {
+  candidatosTexto.push({
+    ruta: "salida",
+    tipo: "string",
+    longitud: salida.length,
+    contieneTituloExpediente: salida.includes("# Expediente hidrológico mínimo")
+  });
+}
+
+if (Array.isArray(salida)) {
+  const texto = salida.join("\n");
+
+  candidatosTexto.push({
+    ruta: "salida.join('\\n')",
+    tipo: "array",
+    longitud: texto.length,
+    contieneTituloExpediente: texto.includes("# Expediente hidrológico mínimo")
+  });
+}
+
+if (salida && typeof salida === "object" && !Array.isArray(salida)) {
+  for (const key of Object.keys(salida)) {
+    const valor = salida[key];
+
+    if (typeof valor === "string") {
+      candidatosTexto.push({
+        ruta: `salida.${key}`,
+        tipo: "string",
+        longitud: valor.length,
+        contieneTituloExpediente: valor.includes("# Expediente hidrológico mínimo")
+      });
+    }
+
+    if (Array.isArray(valor)) {
+      const texto = valor.join("\n");
+
+      candidatosTexto.push({
+        ruta: `salida.${key}.join('\\n')`,
+        tipo: "array",
+        longitud: texto.length,
+        contieneTituloExpediente: texto.includes("# Expediente hidrológico mínimo")
+      });
+    }
+  }
+}
+
+resumen.candidatosTexto = candidatosTexto;
+
+const salidaMarkdown = [
+  "# OT-0232B — Auditoría forma real salida construirExpedienteHidrologicoMinimo",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Lectura técnica",
+  "",
+  "- Esta auditoría no modifica código funcional.",
+  "- La finalidad es identificar la ruta correcta para extraer el texto documental exportable.",
+  "- No se modifica expediente, helper, acople ni comparador.",
+  "",
+  "## Próximo frente recomendado",
+  "",
+  "`OT-0233 — Ajuste normalizador salida documental expediente mínimo`"
+];
+
+const rutaSalida = "00_ADMIN/bitacora/OT-0232/OT-0232B_auditoria_forma_real_salida_expediente_minimo.md";
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0232", { recursive: true });
+fs.writeFileSync(rutaSalida, salidaMarkdown.join("\n"), "utf8");
+
+console.log("AUDITORIA_OT_0232_FORMA_REAL_SALIDA_EXPEDIENTE_OK");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Auditar la forma real del objeto devuelto por `construirExpedienteHidrologicoMinimo` para determinar cómo extraer correctamente la salida documental exportable, sin modificar expediente, helper, acople ni archivos críticos.

## Resultado

La auditoría se ejecutó correctamente.

```text
AUDITORIA_OT_0232_FORMA_REAL_SALIDA_EXPEDIENTE_OK