### PR TITLE
OT-0233 — Ajuste normalizador salida documental

### DIFF
--- a/00_ADMIN/bitacora/OT-0233/OT-0233A_apertura_ajuste-normalizador-salida-documental-expediente-minimo.md
+++ b/00_ADMIN/bitacora/OT-0233/OT-0233A_apertura_ajuste-normalizador-salida-documental-expediente-minimo.md
@@ -1,0 +1,32 @@
+# OT-0233A — Ajuste normalizador salida documental expediente mínimo
+
+## Objetivo
+
+Ajustar los scripts de validación/revalidación para extraer correctamente la salida documental desde salida.texto, con base en la auditoría OT-0232, sin modificar expediente, helper, acople ni archivos críticos.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar el helper.
+- No modificar el acople.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Modificar únicamente scripts de validación/revalidación y bitácora documental de OT-0233.
+
+## Próximo frente recomendado
+
+OT-0234 — Revalidación expediente con normalizador corregido

--- a/00_ADMIN/bitacora/OT-0233/OT-0233B_ajuste_normalizador_salida_documental_expediente_minimo.md
+++ b/00_ADMIN/bitacora/OT-0233/OT-0233B_ajuste_normalizador_salida_documental_expediente_minimo.md
@@ -1,0 +1,81 @@
+# OT-0233B — Ajuste normalizador salida documental expediente mínimo
+
+## Objetivo
+
+Ajustar los scripts de validación/revalidación para extraer correctamente la salida documental real desde `salida.texto`, con base en la auditoría OT-0232.
+
+## Antecedente
+
+OT-0232 auditó la forma real de salida de `construirExpedienteHidrologicoMinimo`.
+
+La salida real no es un string directo ni un array, sino un objeto con las claves:
+
+```text
+ok
+texto
+errores
+advertencias
+secciones
+metadata
+```
+
+La ruta correcta para el texto documental exportable es:
+
+```text
+salida.texto
+```
+
+## Ajuste aplicado
+
+Se ajustó el normalizador en los scripts:
+
+```text
+07_TOOLBOX/validaciones/validar_ot0229_expediente_restricciones_advertencias_acoplado.mjs
+07_TOOLBOX/validaciones/revalidar_ot0231_expediente_criterio_ajustado_tokens.mjs
+```
+
+## Nuevo criterio de normalización
+
+El normalizador ahora prioriza:
+
+1. string directo;
+2. array directo;
+3. `salida.texto`;
+4. `salida.lineas`;
+5. `salida.textoExpediente`;
+6. `salida.markdown`;
+7. `salida.contenido`;
+8. `salida.secciones` como último respaldo.
+
+## Alcance mantenido
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificó `construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó el acople OT-0228.
+
+No se tocó motor.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Decisión
+
+El normalizador queda ajustado para una nueva revalidación del expediente acoplado.
+
+## Próximo frente recomendado
+
+`OT-0234 — Revalidación expediente con normalizador corregido`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó el helper.
+- No se modificó el acople.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0233/OT-0233C_cierre_ajuste-normalizador-salida-documental-expediente-minimo.md
+++ b/00_ADMIN/bitacora/OT-0233/OT-0233C_cierre_ajuste-normalizador-salida-documental-expediente-minimo.md
@@ -1,0 +1,21 @@
+# OT-0233C — Cierre Ajuste normalizador salida documental expediente mínimo
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0233\OT-0233A_apertura_ajuste-normalizador-salida-documental-expediente-minimo.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/07_TOOLBOX/validaciones/revalidar_ot0231_expediente_criterio_ajustado_tokens.mjs
+++ b/07_TOOLBOX/validaciones/revalidar_ot0231_expediente_criterio_ajustado_tokens.mjs
@@ -79,9 +79,41 @@ function contarOcurrencias(texto, patron) {
 }
 
 function normalizarSalidaExpediente(salida) {
-  if (Array.isArray(salida)) return salida.join("\n");
-  if (typeof salida === "string") return salida;
-  return String(salida ?? "");
+  if (typeof salida === "string") {
+    return salida;
+  }
+
+  if (Array.isArray(salida)) {
+    return salida.join("\n");
+  }
+
+  if (salida && typeof salida === "object") {
+    if (typeof salida.texto === "string") {
+      return salida.texto;
+    }
+
+    if (Array.isArray(salida.lineas)) {
+      return salida.lineas.join("\n");
+    }
+
+    if (typeof salida.textoExpediente === "string") {
+      return salida.textoExpediente;
+    }
+
+    if (typeof salida.markdown === "string") {
+      return salida.markdown;
+    }
+
+    if (typeof salida.contenido === "string") {
+      return salida.contenido;
+    }
+
+    if (Array.isArray(salida.secciones)) {
+      return salida.secciones.join("\n");
+    }
+  }
+
+  return "";
 }
 
 async function cargarConstructorExpedienteConImportResuelto() {
@@ -318,3 +350,4 @@ fs.writeFileSync(rutaSalida, salida.join("\n"), "utf8");
 
 console.log("REVALIDACION_OT_0231_EXPEDIENTE_CRITERIO_AJUSTADO_OK");
 console.log(JSON.stringify(resumen, null, 2));
+

--- a/07_TOOLBOX/validaciones/validar_ot0229_expediente_restricciones_advertencias_acoplado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0229_expediente_restricciones_advertencias_acoplado.mjs
@@ -64,15 +64,41 @@ function contarOcurrencias(texto, patron) {
 }
 
 function normalizarSalidaExpediente(salida) {
-  if (Array.isArray(salida)) {
-    return salida.join("\n");
-  }
-
   if (typeof salida === "string") {
     return salida;
   }
 
-  return String(salida ?? "");
+  if (Array.isArray(salida)) {
+    return salida.join("\n");
+  }
+
+  if (salida && typeof salida === "object") {
+    if (typeof salida.texto === "string") {
+      return salida.texto;
+    }
+
+    if (Array.isArray(salida.lineas)) {
+      return salida.lineas.join("\n");
+    }
+
+    if (typeof salida.textoExpediente === "string") {
+      return salida.textoExpediente;
+    }
+
+    if (typeof salida.markdown === "string") {
+      return salida.markdown;
+    }
+
+    if (typeof salida.contenido === "string") {
+      return salida.contenido;
+    }
+
+    if (Array.isArray(salida.secciones)) {
+      return salida.secciones.join("\n");
+    }
+  }
+
+  return "";
 }
 
 const expedienteFuente = leerArchivo(rutaExpediente);
@@ -263,3 +289,4 @@ fs.writeFileSync(rutaSalida, salida.join("\n"), "utf8");
 
 console.log("VALIDACION_OT_0229_EXPEDIENTE_RESTRICCIONES_ADVERTENCIAS_CRITERIO_AJUSTADO_OK");
 console.log(JSON.stringify(resumen, null, 2));
+


### PR DESCRIPTION
## Objetivo

Ajustar los scripts de validación/revalidación para extraer correctamente la salida documental real desde `salida.texto`, con base en la auditoría OT-0232.

## Antecedente

OT-0232 auditó la forma real de salida de `construirExpedienteHidrologicoMinimo`.

La salida real no es un string directo ni un array, sino un objeto con las claves:

```text
ok
texto
errores
advertencias
secciones
metadata