### PR TITLE
OT-0244 — Acople helper identificación expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0244/OT-0244A_apertura_implementacion-acople-minimo-helper-identificacion.md
+++ b/00_ADMIN/bitacora/OT-0244/OT-0244A_apertura_implementacion-acople-minimo-helper-identificacion.md
@@ -1,0 +1,33 @@
+# OT-0244A — Implementación acople mínimo helper Identificación del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper construirBloqueIdentificacionExpedienteMinimo dentro del expediente hidrológico mínimo, reemplazando únicamente el bloque documental de Identificación y sin tocar motor, comparador ni bloques hidrológicos sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0245 — Validación acople helper Identificación del expediente

--- a/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
@@ -1,0 +1,75 @@
+# OT-0244B — Implementación acople mínimo helper Identificación del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper `construirBloqueIdentificacionExpedienteMinimo` dentro del expediente hidrológico mínimo.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Helper acoplado
+
+```text
+construirBloqueIdentificacionExpedienteMinimo
+```
+
+## Archivo helper usado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueIdentificacionExpedienteMinimo.js
+```
+
+## Cambio aplicado
+
+Se agregó el import del helper de Identificación.
+
+Se sustituyó el bloque textual de la sección `## 1. Identificación` por una llamada explícita al helper.
+
+El acople se ubicó antes de la sección `## 2. Parámetros hidrológicos base`.
+
+## Entradas usadas
+
+El acople pasa únicamente campos documentales:
+
+- cuenca;
+- identificador interno de cuenca;
+- versión documental del expediente;
+- tipo de salida documental;
+- fecha de generación;
+- fuente o modo de generación;
+- estado documental;
+- alcance documental;
+- `incluirTitulo: true`.
+
+## Alcance mantenido
+
+No se modificó `construirBloqueIdentificacionExpedienteMinimo.js`.
+
+No se modificó `construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificaron validadores existentes.
+
+No se modificó motor.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+`OT-0245 — Validación acople helper Identificación del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper de Identificación.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se tocó el acople de restricciones y advertencias.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
@@ -4,6 +4,14 @@
 
 Implementar el acople mínimo del helper `construirBloqueIdentificacionExpedienteMinimo` dentro del expediente hidrológico mínimo.
 
+## Corrección aplicada
+
+Se corrigió el acople para evitar intervenir `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
+
+El arreglo de secciones obligatorias conserva únicamente títulos de sección.
+
+El acople funcional se aplica únicamente dentro de `construirLineasIdentificacionExpediente`.
+
 ## Archivo funcional modificado
 
 ```text
@@ -26,9 +34,9 @@ construirBloqueIdentificacionExpedienteMinimo
 
 Se agregó el import del helper de Identificación.
 
-Se sustituyó el bloque textual de la sección `## 1. Identificación` por una llamada explícita al helper.
+Se sustituyó el cuerpo de `construirLineasIdentificacionExpediente` por una llamada explícita al helper.
 
-El acople se ubicó antes de la sección `## 2. Parámetros hidrológicos base`.
+No se modificó la constante `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
 
 ## Entradas usadas
 

--- a/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
+++ b/00_ADMIN/bitacora/OT-0244/OT-0244B_implementacion_acople_minimo_helper_identificacion.md
@@ -12,6 +12,10 @@ El arreglo de secciones obligatorias conserva únicamente títulos de sección.
 
 El acople funcional se aplica únicamente dentro de `construirLineasIdentificacionExpediente`.
 
+La corrección conserva el `export default` de `construirExpedienteHidrologicoMinimo`.
+
+La sustitución usa como frontera segura `construirLineasSelloTecnicoAuxiliarExpediente`, evitando cortes sobre el constructor principal.
+
 ## Archivo funcional modificado
 
 ```text
@@ -34,9 +38,13 @@ construirBloqueIdentificacionExpedienteMinimo
 
 Se agregó el import del helper de Identificación.
 
-Se sustituyó el cuerpo de `construirLineasIdentificacionExpediente` por una llamada explícita al helper.
+Se sustituyó exclusivamente el cuerpo de `construirLineasIdentificacionExpediente` por una llamada explícita al helper.
 
 No se modificó la constante `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
+
+No se modificó la función `construirLineasParametrosHidrologicosBaseExpediente`.
+
+No se eliminó el `export default` del constructor principal.
 
 ## Entradas usadas
 

--- a/00_ADMIN/bitacora/OT-0244/OT-0244C_cierre_implementacion-acople-minimo-helper-identificacion.md
+++ b/00_ADMIN/bitacora/OT-0244/OT-0244C_cierre_implementacion-acople-minimo-helper-identificacion.md
@@ -1,0 +1,21 @@
+# OT-0244C — Cierre Implementación acople mínimo helper Identificación del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0244\OT-0244A_apertura_implementacion-acople-minimo-helper-identificacion.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -1,4 +1,5 @@
 import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";
+import { construirBloqueIdentificacionExpedienteMinimo } from "./construirBloqueIdentificacionExpedienteMinimo";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -8,8 +9,18 @@ export const VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO =
 
 export const SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO = Object.freeze([
   "# Expediente hidrológico mínimo — Cuenca activa",
-  "## 1. Identificación",
-  "## 2. Parámetros hidrológicos base",
+  ...construirBloqueIdentificacionExpedienteMinimo({
+  cuenca: contextoBase?.cuenca?.nombre ?? contextoBase?.cuencaActiva?.nombre ?? contextoBase?.nombreCuenca ?? "Cuenca activa",
+  identificadorCuenca: contextoBase?.cuenca?.id ?? contextoBase?.cuencaActiva?.id ?? contextoBase?.identificadorCuenca ?? "—",
+  versionExpediente: "expediente_hidrologico_minimo_v0_1",
+  tipoSalida: "expediente_hidrologico_minimo",
+  fechaGeneracion,
+  fuente: "construirExpedienteHidrologicoMinimo",
+  estadoDocumental: "Borrador documental controlado",
+  alcanceDocumental: "Bloque documental de identificación del expediente.",
+  incluirTitulo: true
+}),
+"","## 2. Parámetros hidrológicos base",
   "## 3. Tiempo de concentración y roles Tc",
   "## 4. Volumen de referencia",
   "## 5. Escenario Q-Tr activo — control de trazabilidad",
@@ -185,77 +196,18 @@ export function construirLineasIdentificacionExpediente(entrada = {}) {
     fuenteFallback;
 
   return [
-    "## 1. Identificación",
-    `Cuenca: ${textoSeguro(nombreCuenca, "Cuenca activa")}`,
-    `Área: ${
-      Number.isFinite(areaKm2)
-        ? areaKm2.toFixed(4) + " km²"
-        : "—"
-    }`,
-    `Fuente de contexto: ${textoSeguro(fuenteContexto, fuenteFallback)}`,
-    `Estación IDF: ${textoSeguro(estacionIdf, estacionIdfFallback)}`,
-    `Pendiente media: ${
-      Number.isFinite(pendienteMediaPct)
-        ? pendienteMediaPct.toFixed(2) + " %"
-        : "—"
-    }`,
-    `Longitud cauce principal: ${
-      Number.isFinite(longitudCauceKm)
-        ? longitudCauceKm.toFixed(3) + " km"
-        : "—"
-    }`
-  ];
-}
-
-export function construirLineasSelloTecnicoAuxiliarExpediente({
-  metadata = {},
-  versionExpediente = metadata?.versionExpediente ?? VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
-  estadoIntegracion = metadata?.estadoIntegracion ?? "helper_no_integrado",
-  tipoSalida = metadata?.tipoSalida ?? "expediente_hidrologico_minimo"
-} = {}) {
-  return [
-    `Versión auxiliar helper expediente: ${textoSeguro(versionExpediente, "no integrada")}.`,
-    `Estado auxiliar helper expediente: ${textoSeguro(estadoIntegracion, "no informado")}.`,
-    `Tipo auxiliar helper expediente: ${textoSeguro(tipoSalida, "expediente_hidrologico_minimo")}.`
-  ];
-}
-export default function construirExpedienteHidrologicoMinimo({
-  contextoBase = {},
-  Tc_final = null,
-  metodos = [],
-  filasMorfologiaQt = [],
-  filasDictamenFormaQt = [],
-  filasRiesgoTemporalQt = [],
-  sintesisRiesgoTemporalQt = null,
-  fechaGeneracion = null,
-  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO
-} = {}) {
-  const metadata = construirMetadataExpediente({
-    contextoBase,
-    fechaGeneracion,
-    versionExpediente
-  });
-
-  const areaKm2 = Number(contextoBase?.area_km2);
-  const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
-
-  const volumenEsperadoM3 =
-    Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
-      ? areaKm2 * peTotalMm * 1000
-      : null;
-
-  const texto = [
-    "# Expediente hidrológico mínimo — Cuenca activa",
-    "Estado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.",
-    "Lectura técnica: este helper aún no reemplaza el expediente operativo construido en ComparadorMultiMetodo.jsx.",
-    "Alcance: contrato inicial de construcción documental; no copia al portapapeles, no modifica UI y no recalcula resultados.",
-    "",
-    "## 1. Identificación",
-    `Cuenca: ${metadata.cuenca}`,
-    `Área: ${Number.isFinite(areaKm2) ? formatearNumeroExpediente(areaKm2, 4) + " km²" : "—"}`,
-    `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
-    "",
-    "## 2. Parámetros hidrológicos base",
+    ...construirBloqueIdentificacionExpedienteMinimo({
+  cuenca: contextoBase?.cuenca?.nombre ?? contextoBase?.cuencaActiva?.nombre ?? contextoBase?.nombreCuenca ?? "Cuenca activa",
+  identificadorCuenca: contextoBase?.cuenca?.id ?? contextoBase?.cuencaActiva?.id ?? contextoBase?.identificadorCuenca ?? "—",
+  versionExpediente: "expediente_hidrologico_minimo_v0_1",
+  tipoSalida: "expediente_hidrologico_minimo",
+  fechaGeneracion,
+  fuente: "construirExpedienteHidrologicoMinimo",
+  estadoDocumental: "Borrador documental controlado",
+  alcanceDocumental: "Bloque documental de identificación del expediente.",
+  incluirTitulo: true
+}),
+"","## 2. Parámetros hidrológicos base",
     `CN: ${textoSeguro(contextoBase?.CN)}`,
     `CN base: ${textoSeguro(contextoBase?.CN_base)}`,
     `CN efectivo: ${textoSeguro(contextoBase?.CN_efectivo)}`,
@@ -624,4 +576,5 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -9,18 +9,8 @@ export const VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO =
 
 export const SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO = Object.freeze([
   "# Expediente hidrológico mínimo — Cuenca activa",
-  ...construirBloqueIdentificacionExpedienteMinimo({
-  cuenca: contextoBase?.cuenca?.nombre ?? contextoBase?.cuencaActiva?.nombre ?? contextoBase?.nombreCuenca ?? "Cuenca activa",
-  identificadorCuenca: contextoBase?.cuenca?.id ?? contextoBase?.cuencaActiva?.id ?? contextoBase?.identificadorCuenca ?? "—",
-  versionExpediente: "expediente_hidrologico_minimo_v0_1",
-  tipoSalida: "expediente_hidrologico_minimo",
-  fechaGeneracion,
-  fuente: "construirExpedienteHidrologicoMinimo",
-  estadoDocumental: "Borrador documental controlado",
-  alcanceDocumental: "Bloque documental de identificación del expediente.",
-  incluirTitulo: true
-}),
-"","## 2. Parámetros hidrológicos base",
+  "## 1. Identificación",
+  "## 2. Parámetros hidrológicos base",
   "## 3. Tiempo de concentración y roles Tc",
   "## 4. Volumen de referencia",
   "## 5. Escenario Q-Tr activo — control de trazabilidad",
@@ -196,18 +186,77 @@ export function construirLineasIdentificacionExpediente(entrada = {}) {
     fuenteFallback;
 
   return [
-    ...construirBloqueIdentificacionExpedienteMinimo({
-  cuenca: contextoBase?.cuenca?.nombre ?? contextoBase?.cuencaActiva?.nombre ?? contextoBase?.nombreCuenca ?? "Cuenca activa",
-  identificadorCuenca: contextoBase?.cuenca?.id ?? contextoBase?.cuencaActiva?.id ?? contextoBase?.identificadorCuenca ?? "—",
-  versionExpediente: "expediente_hidrologico_minimo_v0_1",
-  tipoSalida: "expediente_hidrologico_minimo",
-  fechaGeneracion,
-  fuente: "construirExpedienteHidrologicoMinimo",
-  estadoDocumental: "Borrador documental controlado",
-  alcanceDocumental: "Bloque documental de identificación del expediente.",
-  incluirTitulo: true
-}),
-"","## 2. Parámetros hidrológicos base",
+    "## 1. Identificación",
+    `Cuenca: ${textoSeguro(nombreCuenca, "Cuenca activa")}`,
+    `Área: ${
+      Number.isFinite(areaKm2)
+        ? areaKm2.toFixed(4) + " km²"
+        : "—"
+    }`,
+    `Fuente de contexto: ${textoSeguro(fuenteContexto, fuenteFallback)}`,
+    `Estación IDF: ${textoSeguro(estacionIdf, estacionIdfFallback)}`,
+    `Pendiente media: ${
+      Number.isFinite(pendienteMediaPct)
+        ? pendienteMediaPct.toFixed(2) + " %"
+        : "—"
+    }`,
+    `Longitud cauce principal: ${
+      Number.isFinite(longitudCauceKm)
+        ? longitudCauceKm.toFixed(3) + " km"
+        : "—"
+    }`
+  ];
+}
+
+export function construirLineasSelloTecnicoAuxiliarExpediente({
+  metadata = {},
+  versionExpediente = metadata?.versionExpediente ?? VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+  estadoIntegracion = metadata?.estadoIntegracion ?? "helper_no_integrado",
+  tipoSalida = metadata?.tipoSalida ?? "expediente_hidrologico_minimo"
+} = {}) {
+  return [
+    `Versión auxiliar helper expediente: ${textoSeguro(versionExpediente, "no integrada")}.`,
+    `Estado auxiliar helper expediente: ${textoSeguro(estadoIntegracion, "no informado")}.`,
+    `Tipo auxiliar helper expediente: ${textoSeguro(tipoSalida, "expediente_hidrologico_minimo")}.`
+  ];
+}
+export default function construirExpedienteHidrologicoMinimo({
+  contextoBase = {},
+  Tc_final = null,
+  metodos = [],
+  filasMorfologiaQt = [],
+  filasDictamenFormaQt = [],
+  filasRiesgoTemporalQt = [],
+  sintesisRiesgoTemporalQt = null,
+  fechaGeneracion = null,
+  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO
+} = {}) {
+  const metadata = construirMetadataExpediente({
+    contextoBase,
+    fechaGeneracion,
+    versionExpediente
+  });
+
+  const areaKm2 = Number(contextoBase?.area_km2);
+  const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
+
+  const volumenEsperadoM3 =
+    Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
+      ? areaKm2 * peTotalMm * 1000
+      : null;
+
+  const texto = [
+    "# Expediente hidrológico mínimo — Cuenca activa",
+    "Estado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.",
+    "Lectura técnica: este helper aún no reemplaza el expediente operativo construido en ComparadorMultiMetodo.jsx.",
+    "Alcance: contrato inicial de construcción documental; no copia al portapapeles, no modifica UI y no recalcula resultados.",
+    "",
+    "## 1. Identificación",
+    `Cuenca: ${metadata.cuenca}`,
+    `Área: ${Number.isFinite(areaKm2) ? formatearNumeroExpediente(areaKm2, 4) + " km²" : "—"}`,
+    `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
+    "",
+    "## 2. Parámetros hidrológicos base",
     `CN: ${textoSeguro(contextoBase?.CN)}`,
     `CN base: ${textoSeguro(contextoBase?.CN_base)}`,
     `CN efectivo: ${textoSeguro(contextoBase?.CN_efectivo)}`,

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -131,83 +131,28 @@ export function construirLineasIdentificacionExpediente(entrada = {}) {
       ? entrada.contextoBase
       : entrada;
 
-  const fuenteFallback =
-    textoSeguro(entrada?.fuenteFallback, "") || "HidroFlow";
+  const fechaGeneracion = entrada?.fechaGeneracion ?? "—";
 
-  const estacionIdfFallback =
-    textoSeguro(entrada?.estacionIdfFallback, "") || "SAN CRISTOBAL";
-
-  const nombreCuenca = normalizarTextoIdentificacionExpediente(
-    contextoBase?.nombreCuenca ??
-      contextoBase?.cuenca,
-    "Cuenca activa"
-  );
-
-  const areaKm2 =
-    Number.isFinite(Number(contextoBase?.area_km2))
-      ? Number(contextoBase.area_km2)
-      : Number.isFinite(Number(contextoBase?.areaKm2))
-      ? Number(contextoBase.areaKm2)
-      : Number.isFinite(Number(contextoBase?.cuencaActiva?.areaKm2))
-      ? Number(contextoBase.cuencaActiva.areaKm2)
-      : null;
-
-  const pendienteMediaPct =
-    Number.isFinite(Number(contextoBase?.pendiente_media_pct))
-      ? Number(contextoBase.pendiente_media_pct)
-      : Number.isFinite(Number(contextoBase?.pendienteMediaPct))
-      ? Number(contextoBase.pendienteMediaPct)
-      : Number.isFinite(Number(contextoBase?.cuencaActiva?.pendienteMediaPct))
-      ? Number(contextoBase.cuencaActiva.pendienteMediaPct)
-      : null;
-
-  const longitudCauceKm =
-    Number.isFinite(Number(contextoBase?.longitud_cauce_km))
-      ? Number(contextoBase.longitud_cauce_km)
-      : Number.isFinite(Number(contextoBase?.longitudCaucePrincipalKm))
-      ? Number(contextoBase.longitudCaucePrincipalKm)
-      : Number.isFinite(Number(contextoBase?.cuencaActiva?.longitudCaucePrincipalKm))
-      ? Number(contextoBase.cuencaActiva.longitudCaucePrincipalKm)
-      : null;
-
-  const estacionIdf =
-    textoSeguro(contextoBase?.estacion_idf, "") ||
-    textoSeguro(contextoBase?.estacionIDF, "") ||
-    textoSeguro(contextoBase?.estacionIdf, "") ||
-    textoSeguro(contextoBase?.estacion, "") ||
-    textoSeguro(contextoBase?.nombre_estacion, "") ||
-    textoSeguro(contextoBase?.idf?.nombre, "") ||
-    textoSeguro(contextoBase?.idf?.estacion, "") ||
-    estacionIdfFallback;
-
-  const fuenteContexto =
-    textoSeguro(contextoBase?.fuente, "") ||
-    textoSeguro(contextoBase?.fuenteContexto, "") ||
-    fuenteFallback;
-
-  return [
-    "## 1. Identificación",
-    `Cuenca: ${textoSeguro(nombreCuenca, "Cuenca activa")}`,
-    `Área: ${
-      Number.isFinite(areaKm2)
-        ? areaKm2.toFixed(4) + " km²"
-        : "—"
-    }`,
-    `Fuente de contexto: ${textoSeguro(fuenteContexto, fuenteFallback)}`,
-    `Estación IDF: ${textoSeguro(estacionIdf, estacionIdfFallback)}`,
-    `Pendiente media: ${
-      Number.isFinite(pendienteMediaPct)
-        ? pendienteMediaPct.toFixed(2) + " %"
-        : "—"
-    }`,
-    `Longitud cauce principal: ${
-      Number.isFinite(longitudCauceKm)
-        ? longitudCauceKm.toFixed(3) + " km"
-        : "—"
-    }`
-  ];
+  return construirBloqueIdentificacionExpedienteMinimo({
+    cuenca:
+      contextoBase?.cuenca?.nombre ??
+      contextoBase?.cuencaActiva?.nombre ??
+      contextoBase?.nombreCuenca ??
+      "Cuenca activa",
+    identificadorCuenca:
+      contextoBase?.cuenca?.id ??
+      contextoBase?.cuencaActiva?.id ??
+      contextoBase?.identificadorCuenca ??
+      "—",
+    versionExpediente: VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+    tipoSalida: "expediente_hidrologico_minimo",
+    fechaGeneracion,
+    fuente: "construirExpedienteHidrologicoMinimo",
+    estadoDocumental: "Borrador documental controlado",
+    alcanceDocumental: "Bloque documental de identificación del expediente.",
+    incluirTitulo: true
+  });
 }
-
 export function construirLineasSelloTecnicoAuxiliarExpediente({
   metadata = {},
   versionExpediente = metadata?.versionExpediente ?? VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,


### PR DESCRIPTION
## Objetivo

Implementar el acople mínimo del helper `construirBloqueIdentificacionExpedienteMinimo` dentro del expediente hidrológico mínimo.

## Corrección aplicada

Se corrigió el acople para evitar intervenir `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.

El arreglo de secciones obligatorias conserva únicamente títulos de sección.

El acople funcional se aplica únicamente dentro de `construirLineasIdentificacionExpediente`.

La corrección conserva el `export default` de `construirExpedienteHidrologicoMinimo`.

La sustitución usa como frontera segura `construirLineasSelloTecnicoAuxiliarExpediente`, evitando cortes sobre el constructor principal.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
``