### PR TITLE
OT-0246 — Corrección acople helper identificación

### DIFF
--- a/00_ADMIN/bitacora/OT-0246/OT-0246A_apertura_correccion-acople-helper-identificacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0246/OT-0246A_apertura_correccion-acople-helper-identificacion-expediente.md
@@ -1,0 +1,33 @@
+# OT-0246A — Corrección acople helper Identificación del expediente
+
+## Objetivo
+
+Corregir el acople del helper construirBloqueIdentificacionExpedienteMinimo para que la salida real del constructor principal construirExpedienteHidrologicoMinimo use el bloque delegado de Identificación, sin modificar helper, comparador, motor ni bloques hidrológicos sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0247 — Revalidación acople helper Identificación del expediente

--- a/00_ADMIN/bitacora/OT-0246/OT-0246B_correccion_acople_helper_identificacion_expediente.md
+++ b/00_ADMIN/bitacora/OT-0246/OT-0246B_correccion_acople_helper_identificacion_expediente.md
@@ -1,0 +1,70 @@
+# OT-0246B — Corrección acople helper Identificación del expediente
+
+## Objetivo
+
+Corregir el acople del helper `construirBloqueIdentificacionExpedienteMinimo` para que la salida real del constructor principal use el bloque delegado de Identificación.
+
+## Antecedente
+
+OT-0245 validó el acople y detectó un hallazgo: la función auxiliar `construirLineasIdentificacionExpediente` delegaba correctamente al helper, pero la salida real del constructor principal `construirExpedienteHidrologicoMinimo` aún conservaba un bloque inline antiguo de Identificación.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se sustituyó únicamente el bloque inline de `## 1. Identificación` dentro del constructor principal `construirExpedienteHidrologicoMinimo`.
+
+El constructor principal ahora usa:
+
+```javascript
+...construirLineasIdentificacionExpediente({
+  contextoBase,
+  fechaGeneracion
+}),
+```
+
+## Alcance mantenido
+
+No se modificó `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
+
+No se modificó `construirLineasIdentificacionExpediente`.
+
+No se modificó `construirBloqueIdentificacionExpedienteMinimo.js`.
+
+No se modificó `construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificaron validadores existentes.
+
+No se modificó motor.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Lectura técnica
+
+La corrección conecta la salida real del constructor principal con la función auxiliar ya delegada al helper de Identificación.
+
+La constante de secciones obligatorias conserva únicamente títulos de sección.
+
+El `export default` del constructor principal se conserva.
+
+## Próximo frente recomendado
+
+`OT-0247 — Revalidación acople helper Identificación del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper de Identificación.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se tocó el acople de restricciones y advertencias.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0246/OT-0246C_cierre_correccion-acople-helper-identificacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0246/OT-0246C_cierre_correccion-acople-helper-identificacion-expediente.md
@@ -1,0 +1,21 @@
+# OT-0246C — Cierre Corrección acople helper Identificación del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0246\OT-0246A_apertura_correccion-acople-helper-identificacion-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -196,12 +196,11 @@ export default function construirExpedienteHidrologicoMinimo({
     "Lectura técnica: este helper aún no reemplaza el expediente operativo construido en ComparadorMultiMetodo.jsx.",
     "Alcance: contrato inicial de construcción documental; no copia al portapapeles, no modifica UI y no recalcula resultados.",
     "",
-    "## 1. Identificación",
-    `Cuenca: ${metadata.cuenca}`,
-    `Área: ${Number.isFinite(areaKm2) ? formatearNumeroExpediente(areaKm2, 4) + " km²" : "—"}`,
-    `Fuente de contexto: ${contextoBase?.fuente ?? "HidroFlow"}`,
-    "",
-    "## 2. Parámetros hidrológicos base",
+    ...construirLineasIdentificacionExpediente({
+      contextoBase,
+      fechaGeneracion
+    }),
+    "",    "## 2. Parámetros hidrológicos base",
     `CN: ${textoSeguro(contextoBase?.CN)}`,
     `CN base: ${textoSeguro(contextoBase?.CN_base)}`,
     `CN efectivo: ${textoSeguro(contextoBase?.CN_efectivo)}`,
@@ -570,5 +569,6 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 


### PR DESCRIPTION
## Objetivo

Corregir el acople del helper `construirBloqueIdentificacionExpedienteMinimo` para que la salida real del constructor principal `construirExpedienteHidrologicoMinimo` use el bloque delegado de Identificación.

## Antecedente

OT-0245 validó el acople y detectó un hallazgo: la función auxiliar `construirLineasIdentificacionExpediente` delegaba correctamente al helper, pero la salida real del constructor principal `construirExpedienteHidrologicoMinimo` aún conservaba un bloque inline antiguo de Identificación.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js