### PR TITLE
OT-0247 — Revalidación acople helper identificación

### DIFF
--- a/00_ADMIN/bitacora/OT-0247/OT-0247A_apertura_revalidacion-acople-helper-identificacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0247/OT-0247A_apertura_revalidacion-acople-helper-identificacion-expediente.md
@@ -1,0 +1,34 @@
+# OT-0247A — Revalidación acople helper Identificación del expediente
+
+## Objetivo
+
+Revalidar el acople del helper construirBloqueIdentificacionExpedienteMinimo después de OT-0246, verificando que la salida real del constructor principal use los campos delegados del helper, sin modificar código funcional.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Crear únicamente documentación y/o script de revalidación OT-0247.
+
+## Próximo frente recomendado
+
+OT-0248 — Decisión estabilización bloque Identificación del expediente

--- a/00_ADMIN/bitacora/OT-0247/OT-0247B_revalidacion_acople_helper_identificacion_expediente.md
+++ b/00_ADMIN/bitacora/OT-0247/OT-0247B_revalidacion_acople_helper_identificacion_expediente.md
@@ -202,4 +202,5 @@ El acople del helper de Identificación queda validado.
 
 ## Próximo frente recomendado
 
-`OT-0246 — Decisión estabilización acople helper Identificación del expediente`
+`OT-0248 — Decisión estabilización bloque Identificación del expediente`
+

--- a/00_ADMIN/bitacora/OT-0247/OT-0247B_revalidacion_acople_helper_identificacion_expediente.md
+++ b/00_ADMIN/bitacora/OT-0247/OT-0247B_revalidacion_acople_helper_identificacion_expediente.md
@@ -1,0 +1,205 @@
+# OT-0247B — Revalidación acople helper Identificación del expediente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0247",
+  "helper": "construirBloqueIdentificacionExpedienteMinimo",
+  "totalControles": 16,
+  "controlesAprobados": 16,
+  "controlesFallidos": 0,
+  "buildAprobado": true,
+  "acopleValidado": true,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false
+}
+```
+
+## Controles evaluados
+
+### archivo_expediente
+
+```json
+{
+  "id": "archivo_expediente",
+  "descripcion": "Archivo de expediente existe",
+  "aprobado": true
+}
+```
+
+### import_helper_identificacion_unico
+
+```json
+{
+  "id": "import_helper_identificacion_unico",
+  "descripcion": "Import del helper de Identificación presente una sola vez",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### modulo_temporal_importado
+
+```json
+{
+  "id": "modulo_temporal_importado",
+  "descripcion": "El módulo temporal pudo importarse en Node ESM con imports file://",
+  "error": "",
+  "aprobado": true
+}
+```
+
+### secciones_obligatorias_sin_helper
+
+```json
+{
+  "id": "secciones_obligatorias_sin_helper",
+  "descripcion": "SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO no contiene llamada al helper",
+  "aprobado": true
+}
+```
+
+### secciones_obligatorias_con_identificacion
+
+```json
+{
+  "id": "secciones_obligatorias_con_identificacion",
+  "descripcion": "Sección obligatoria ## 1. Identificación permanece como título",
+  "aprobado": true
+}
+```
+
+### secciones_obligatorias_con_parametros
+
+```json
+{
+  "id": "secciones_obligatorias_con_parametros",
+  "descripcion": "Sección obligatoria ## 2. Parámetros hidrológicos base permanece como título",
+  "aprobado": true
+}
+```
+
+### funcion_identificacion_delegada
+
+```json
+{
+  "id": "funcion_identificacion_delegada",
+  "descripcion": "construirLineasIdentificacionExpediente llama al helper de Identificación",
+  "aprobado": true
+}
+```
+
+### export_default_presente
+
+```json
+{
+  "id": "export_default_presente",
+  "descripcion": "export default del constructor principal presente",
+  "aprobado": true
+}
+```
+
+### lineas_identificacion_array
+
+```json
+{
+  "id": "lineas_identificacion_array",
+  "descripcion": "construirLineasIdentificacionExpediente devuelve string[]",
+  "aprobado": true,
+  "longitud": 10
+}
+```
+
+### lineas_identificacion_campos_delegados
+
+```json
+{
+  "id": "lineas_identificacion_campos_delegados",
+  "descripcion": "La función delegada contiene campos mínimos del helper",
+  "faltantes": [],
+  "aprobado": true
+}
+```
+
+### salida_expediente_generada
+
+```json
+{
+  "id": "salida_expediente_generada",
+  "descripcion": "El constructor principal genera salida documental",
+  "longitud": 3262,
+  "aprobado": true
+}
+```
+
+### salida_expediente_bloque_identificacion_detectado
+
+```json
+{
+  "id": "salida_expediente_bloque_identificacion_detectado",
+  "descripcion": "La salida real contiene bloque ## 1. Identificación antes de ## 2",
+  "aprobado": true
+}
+```
+
+### salida_expediente_usa_campos_delegados
+
+```json
+{
+  "id": "salida_expediente_usa_campos_delegados",
+  "descripcion": "La salida real del expediente usa campos delegados del helper de Identificación",
+  "faltantes": [],
+  "aprobado": true
+}
+```
+
+### bloque_identificacion_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_identificacion_sin_tokens_invalidos",
+  "descripcion": "Bloque Identificación sin tokens inválidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### bloque_identificacion_sin_terminos_sensibles
+
+```json
+{
+  "id": "bloque_identificacion_sin_terminos_sensibles",
+  "descripcion": "Bloque Identificación sin términos hidrológicos sensibles prohibidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "descripcion": "Build Vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La validación revisó fuente, función delegada, salida directa del helper y salida real del expediente.
+- Para ejecutar en Node ESM, la validación generó una copia temporal del módulo con imports `file://`.
+- No se modificó código funcional durante la validación.
+- No se modificó motor.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se tocaron bloques sensibles.
+
+## Decisión
+
+El acople del helper de Identificación queda validado.
+
+## Próximo frente recomendado
+
+`OT-0246 — Decisión estabilización acople helper Identificación del expediente`

--- a/00_ADMIN/bitacora/OT-0247/OT-0247C_cierre_revalidacion-acople-helper-identificacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0247/OT-0247C_cierre_revalidacion-acople-helper-identificacion-expediente.md
@@ -1,0 +1,21 @@
+# OT-0247C — Cierre Revalidación acople helper Identificación del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0247\OT-0247A_apertura_revalidacion-acople-helper-identificacion-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Revalidar el acople del helper `construirBloqueIdentificacionExpedienteMinimo` después de OT-0246, verificando que la salida real del constructor principal use los campos delegados del helper, sin modificar código funcional.

## Resultado

La revalidación quedó aprobada.

```json
{
  "validacion": "OT-0247",
  "helper": "construirBloqueIdentificacionExpedienteMinimo",
  "totalControles": 16,
  "controlesAprobados": 16,
  "controlesFallidos": 0,
  "buildAprobado": true,
  "acopleValidado": true,
  "modificaCodigoAplicacion": false,
  "modificaMotor": false,
  "modificaTextoExpediente": false
}