### PR TITLE
OT-0257 — Acople helper parámetros base

### DIFF
--- a/00_ADMIN/bitacora/OT-0257/OT-0257A_apertura_implementacion-acople-minimo-helper-parametros-hidrologicos-base-expediente.md
+++ b/00_ADMIN/bitacora/OT-0257/OT-0257A_apertura_implementacion-acople-minimo-helper-parametros-hidrologicos-base-expediente.md
@@ -1,0 +1,41 @@
+# OT-0257A — Implementación acople mínimo helper Parámetros hidrológicos base del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper construirBloqueParametrosHidrologicosBaseExpediente dentro de la función auxiliar construirLineasParametrosHidrologicosBaseExpediente, sin modificar el helper validado, sin tocar el constructor principal directamente y sin modificar motor, comparador ni bloques hidrológicos sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No intervenir directamente el arreglo principal texto del constructor.
+- No modificar bloque Identificación.
+- No validar valores hidrológicos.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0258 — Validación acople helper Parámetros hidrológicos base del expediente

--- a/00_ADMIN/bitacora/OT-0257/OT-0257B_implementacion_acople_minimo_helper_parametros_hidrologicos_base_expediente.md
+++ b/00_ADMIN/bitacora/OT-0257/OT-0257B_implementacion_acople_minimo_helper_parametros_hidrologicos_base_expediente.md
@@ -1,0 +1,95 @@
+# OT-0257B — Implementación acople mínimo helper Parámetros hidrológicos base del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper `construirBloqueParametrosHidrologicosBaseExpediente` dentro del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0256 diseñó el punto de acople seguro para el helper de Parámetros hidrológicos base.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se agregó el import del helper:
+
+```javascript
+import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construirBloqueParametrosHidrologicosBaseExpediente";
+```
+
+Se sustituyó exclusivamente el cuerpo de la función auxiliar:
+
+```text
+construirLineasParametrosHidrologicosBaseExpediente
+```
+
+La función auxiliar ahora delega al helper validado:
+
+```javascript
+return construirBloqueParametrosHidrologicosBaseExpediente({
+  CN: contextoBase?.CN,
+  CN_base: contextoBase?.CN_base,
+  CN_efectivo: contextoBase?.CN_efectivo,
+  AMC: contextoBase?.AMC,
+  incluirTitulo: true
+});
+```
+
+## Frontera aplicada
+
+La sustitución quedó acotada entre:
+
+```text
+export function construirLineasParametrosHidrologicosBaseExpediente
+```
+
+y:
+
+```text
+export function construirLineasTiempoConcentracionRolesTcExpediente
+```
+
+## Alcance mantenido
+
+No se modificó el helper `construirBloqueParametrosHidrologicosBaseExpediente.js`.
+
+No se modificó `construirBloqueIdentificacionExpedienteMinimo.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se intervino directamente el arreglo principal `texto` del constructor.
+
+No se modificó `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
+
+No se recalcularon ni validaron `CN`, `CN base`, `CN efectivo` ni `AMC`.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Riesgo pendiente
+
+Debe validarse en OT-0258 si la salida real del constructor principal consume efectivamente la función auxiliar delegada o si aún conserva un bloque inline para `## 2. Parámetros hidrológicos base`.
+
+## Próximo frente recomendado
+
+`OT-0258 — Validación acople helper Parámetros hidrológicos base del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper validado de parámetros base.
+- No se modificó el helper de Identificación.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se tocó el acople de restricciones y advertencias.
+- No se intervino directamente el arreglo principal `texto`.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0257/OT-0257C_cierre_implementacion-acople-minimo-helper-parametros-hidrologicos-base-expediente.md
+++ b/00_ADMIN/bitacora/OT-0257/OT-0257C_cierre_implementacion-acople-minimo-helper-parametros-hidrologicos-base-expediente.md
@@ -1,0 +1,21 @@
+# OT-0257C — Cierre Implementación acople mínimo helper Parámetros hidrológicos base del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0257\OT-0257A_apertura_implementacion-acople-minimo-helper-parametros-hidrologicos-base-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -1,5 +1,6 @@
 import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";
 import { construirBloqueIdentificacionExpedienteMinimo } from "./construirBloqueIdentificacionExpedienteMinimo";
+import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construirBloqueParametrosHidrologicosBaseExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -307,31 +308,13 @@ export function construirLineasParametrosHidrologicosBaseExpediente(entrada = {}
       ? entrada.contextoBase
       : entrada;
 
-  const valorDocumental = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "number" && !Number.isFinite(valor)) {
-      return "—";
-    }
-
-    if (typeof valor === "object") {
-      return "—";
-    }
-
-    const textoValor = String(valor).trim();
-
-    return textoValor.length > 0 ? textoValor : "—";
-  };
-
-  return [
-    "## 2. Parámetros hidrológicos base",
-    `CN: ${valorDocumental(contextoBase?.CN)}`,
-    `CN base: ${valorDocumental(contextoBase?.CN_base)}`,
-    `CN efectivo: ${valorDocumental(contextoBase?.CN_efectivo)}`,
-    `AMC: ${valorDocumental(contextoBase?.AMC)}`
-  ];
+  return construirBloqueParametrosHidrologicosBaseExpediente({
+    CN: contextoBase?.CN,
+    CN_base: contextoBase?.CN_base,
+    CN_efectivo: contextoBase?.CN_efectivo,
+    AMC: contextoBase?.AMC,
+    incluirTitulo: true
+  });
 }
 export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}) {
   const formatearTc = (valor) => {
@@ -569,6 +552,7 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 
 


### PR DESCRIPTION
## Objetivo

Implementar el acople mínimo del helper `construirBloqueParametrosHidrologicosBaseExpediente` dentro del expediente hidrológico mínimo.

## Antecedente

OT-0256 diseñó el punto de acople seguro para el helper de Parámetros hidrológicos base.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js