### PR TITLE
OT-0259 — Corrección acople helper parámetros base

### DIFF
--- a/00_ADMIN/bitacora/OT-0259/OT-0259A_apertura_correccion-acople-helper-parametros-hidrologicos-base-expediente.md
+++ b/00_ADMIN/bitacora/OT-0259/OT-0259A_apertura_correccion-acople-helper-parametros-hidrologicos-base-expediente.md
@@ -1,0 +1,40 @@
+# OT-0259A — Corrección acople helper Parámetros hidrológicos base del expediente
+
+## Objetivo
+
+Corregir la salida real del constructor principal para que el bloque Parámetros hidrológicos base use la función auxiliar delegada al helper construirBloqueParametrosHidrologicosBaseExpediente, sin modificar el helper validado, sin tocar motor, comparador ni bloques hidrológicos sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No modificar bloque Identificación.
+- No validar valores hidrológicos.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0260 — Revalidación acople helper Parámetros hidrológicos base del expediente

--- a/00_ADMIN/bitacora/OT-0259/OT-0259B_correccion_acople_helper_parametros_hidrologicos_base_expediente.md
+++ b/00_ADMIN/bitacora/OT-0259/OT-0259B_correccion_acople_helper_parametros_hidrologicos_base_expediente.md
@@ -1,0 +1,72 @@
+# OT-0259B — Corrección acople helper Parámetros hidrológicos base del expediente
+
+## Objetivo
+
+Corregir la salida real del constructor principal para que el bloque `Parámetros hidrológicos base` use la función auxiliar delegada al helper.
+
+## Antecedente
+
+OT-0258 validó que el acople auxiliar estaba correcto, pero detectó que la salida real del constructor principal aún conservaba un bloque inline de `## 2. Parámetros hidrológicos base`.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se sustituyó únicamente el bloque inline de `## 2. Parámetros hidrológicos base` dentro del arreglo principal `texto`.
+
+La salida real del constructor principal ahora usa:
+
+```javascript
+...construirLineasParametrosHidrologicosBaseExpediente({
+  contextoBase
+}),
+```
+
+## Alcance mantenido
+
+No se modificó `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`.
+
+No se modificó `construirLineasParametrosHidrologicosBaseExpediente`.
+
+No se modificó `construirBloqueParametrosHidrologicosBaseExpediente.js`.
+
+No se modificó `construirBloqueIdentificacionExpedienteMinimo.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificaron validadores existentes.
+
+No se modificó motor.
+
+No se recalcularon ni validaron `CN`, `CN base`, `CN efectivo` ni `AMC`.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Lectura técnica
+
+La corrección conecta la salida real del constructor principal con la función auxiliar ya delegada al helper de Parámetros hidrológicos base.
+
+La constante de secciones obligatorias conserva únicamente títulos de sección.
+
+El `export default` del constructor principal se conserva.
+
+## Próximo frente recomendado
+
+`OT-0260 — Revalidación acople helper Parámetros hidrológicos base del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper validado de parámetros base.
+- No se modificó el helper de Identificación.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se tocó el acople de restricciones y advertencias.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0259/OT-0259C_cierre_correccion-acople-helper-parametros-hidrologicos-base-expediente.md
+++ b/00_ADMIN/bitacora/OT-0259/OT-0259C_cierre_correccion-acople-helper-parametros-hidrologicos-base-expediente.md
@@ -1,0 +1,21 @@
+# OT-0259C — Cierre Corrección acople helper Parámetros hidrológicos base del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0259\OT-0259A_apertura_correccion-acople-helper-parametros-hidrologicos-base-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -201,11 +201,10 @@ export default function construirExpedienteHidrologicoMinimo({
       contextoBase,
       fechaGeneracion
     }),
-    "",    "## 2. Parámetros hidrológicos base",
-    `CN: ${textoSeguro(contextoBase?.CN)}`,
-    `CN base: ${textoSeguro(contextoBase?.CN_base)}`,
-    `CN efectivo: ${textoSeguro(contextoBase?.CN_efectivo)}`,
-    `AMC: ${textoSeguro(contextoBase?.AMC)}`,
+    "",
+    ...construirLineasParametrosHidrologicosBaseExpediente({
+      contextoBase
+    }),
     "",
     "## 3. Tiempo de concentración y roles Tc",
     `Tc comparador: ${
@@ -552,7 +551,4 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
-
-
-
 


### PR DESCRIPTION
## Objetivo

Corregir la salida real del constructor principal para que el bloque `Parámetros hidrológicos base` use la función auxiliar delegada al helper.

## Antecedente

OT-0258 validó que el acople auxiliar estaba correcto, pero detectó que la salida real del constructor principal aún conservaba un bloque inline de:

```text
## 2. Parámetros hidrológicos base