### PR TITLE
OT-0270 — Acople mínimo helper Tc roles

### DIFF
--- a/00_ADMIN/bitacora/OT-0270/OT-0270A_apertura_implementacion-acople-minimo-helper-tiempo-concentracion-roles-tc-expediente.md
+++ b/00_ADMIN/bitacora/OT-0270/OT-0270A_apertura_implementacion-acople-minimo-helper-tiempo-concentracion-roles-tc-expediente.md
@@ -1,0 +1,48 @@
+# OT-0270A — Implementación acople mínimo helper Tiempo de concentración y roles Tc del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper construirBloqueTiempoConcentracionRolesTcExpediente dentro de construirExpedienteHidrologicoMinimo.js, agregando import y delegando únicamente la función auxiliar construirLineasTiempoConcentracionRolesTcExpediente, sin tocar directamente el arreglo principal texto ni modificar comparador, motor o bloques hidrológicos sensibles.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No tocar directamente el arreglo principal texto.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No validar valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No decidir competencia hidrológica de Tc.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0271 — Validación acople helper Tiempo de concentración y roles Tc del expediente

--- a/00_ADMIN/bitacora/OT-0270/OT-0270B_implementacion_acople_minimo_helper_tiempo_concentracion_roles_tc_expediente.md
+++ b/00_ADMIN/bitacora/OT-0270/OT-0270B_implementacion_acople_minimo_helper_tiempo_concentracion_roles_tc_expediente.md
@@ -1,0 +1,97 @@
+# OT-0270B — Implementación acople mínimo helper Tiempo de concentración y roles Tc del expediente
+
+## Objetivo
+
+Implementar el acople mínimo del helper `construirBloqueTiempoConcentracionRolesTcExpediente` dentro de `construirExpedienteHidrologicoMinimo.js`.
+
+## Antecedente
+
+OT-0269 diseñó el punto de acople mediante delegación de la función auxiliar `construirLineasTiempoConcentracionRolesTcExpediente` hacia el helper validado.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se agregó el import del helper:
+
+```javascript
+import { construirBloqueTiempoConcentracionRolesTcExpediente } from "./construirBloqueTiempoConcentracionRolesTcExpediente";
+```
+
+Se sustituyó únicamente el cuerpo de la función auxiliar:
+
+```text
+construirLineasTiempoConcentracionRolesTcExpediente
+```
+
+La función auxiliar ahora delega en:
+
+```javascript
+return construirBloqueTiempoConcentracionRolesTcExpediente({
+  Tc_final: entrada?.Tc_final,
+  trDisenoActivoExpediente: entrada?.trDisenoActivoExpediente,
+  incluirTitulo: true
+});
+```
+
+## Alcance mantenido
+
+No se tocó directamente el arreglo principal `texto`.
+
+No se modificó `construirBloqueTiempoConcentracionRolesTcExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se modificó bloque Identificación.
+
+No se modificó bloque Parámetros hidrológicos base.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se recalculó `Tc`.
+
+No se modificó `Tc_final`.
+
+No se seleccionó `Tc` adoptado.
+
+No se emitió dictamen hidrológico.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Lectura técnica
+
+El acople mínimo deja preparada la cadena:
+
+```text
+construirExpedienteHidrologicoMinimo
+↓
+construirLineasTiempoConcentracionRolesTcExpediente
+↓
+construirBloqueTiempoConcentracionRolesTcExpediente
+```
+
+La salida real del constructor principal deberá validarse en una OT posterior.
+
+## Próximo frente recomendado
+
+`OT-0271 — Validación acople helper Tiempo de concentración y roles Tc del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se tocó directamente el arreglo principal `texto`.
+- No se modificó el helper validado.
+- No se recalculó `Tc`.
+- No se emitió dictamen hidrológico.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0270/OT-0270C_cierre_implementacion-acople-minimo-helper-tiempo-concentracion-roles-tc-expediente.md
+++ b/00_ADMIN/bitacora/OT-0270/OT-0270C_cierre_implementacion-acople-minimo-helper-tiempo-concentracion-roles-tc-expediente.md
@@ -1,0 +1,21 @@
+# OT-0270C — Cierre Implementación acople mínimo helper Tiempo de concentración y roles Tc del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0270\OT-0270A_apertura_implementacion-acople-minimo-helper-tiempo-concentracion-roles-tc-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -1,6 +1,7 @@
 import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";
 import { construirBloqueIdentificacionExpedienteMinimo } from "./construirBloqueIdentificacionExpedienteMinimo";
 import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construirBloqueParametrosHidrologicosBaseExpediente";
+import { construirBloqueTiempoConcentracionRolesTcExpediente } from "./construirBloqueTiempoConcentracionRolesTcExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -316,56 +317,11 @@ export function construirLineasParametrosHidrologicosBaseExpediente(entrada = {}
   });
 }
 export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}) {
-  const formatearTc = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "string" && valor.trim().length === 0) {
-      return "—";
-    }
-
-    const numero = Number(valor);
-
-    if (!Number.isFinite(numero)) {
-      return "—";
-    }
-
-    return `${numero.toFixed(1)} min`;
-  };
-
-  const valorDocumental = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "number" && !Number.isFinite(valor)) {
-      return "—";
-    }
-
-    if (typeof valor === "object") {
-      return "—";
-    }
-
-    const textoValor = String(valor).trim();
-
-    return textoValor.length > 0 ? textoValor : "—";
-  };
-
-  const trGlobalActivo = valorDocumental(entrada?.trDisenoActivoExpediente);
-
-  return [
-    "## 3. Tiempo de concentración y roles Tc",
-    `Tc comparador: ${formatearTc(entrada?.Tc_final)}`,
-    `Tr global activo: ${trGlobalActivo} años`,
-    "Nota Tr: estado global visual/exportable; no implica recálculo automático hasta propagación hidrológica controlada.",
-    "Roles Tc:",
-    "- Tc global Índice: referencia hidrológica general.",
-    "- Tc operativo Q(t): ruta interna del hidrograma.",
-    "- Duración evento: 3 h para almacenamiento/regulación.",
-    "- Lag / forma SCS: parámetro derivado para forma temporal.",
-    "- Tc comparador: referencia especializada para coherencia Q-5."
-  ];
+  return construirBloqueTiempoConcentracionRolesTcExpediente({
+    Tc_final: entrada?.Tc_final,
+    trDisenoActivoExpediente: entrada?.trDisenoActivoExpediente,
+    incluirTitulo: true
+  });
 }
 export function construirLineasVolumenReferenciaExpediente(entrada = {}) {
   const formatearLluviaEfectiva = (valor) => {
@@ -551,4 +507,5 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 


### PR DESCRIPTION
## Objetivo

Implementar el acople mínimo del helper `construirBloqueTiempoConcentracionRolesTcExpediente` dentro de `construirExpedienteHidrologicoMinimo.js`.

## Antecedente

OT-0269 diseñó el punto de acople mediante delegación de la función auxiliar `construirLineasTiempoConcentracionRolesTcExpediente` hacia el helper validado.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js