### PR TITLE
OT-0272 — Corrección salida real helper Tc roles

### DIFF
--- a/00_ADMIN/bitacora/OT-0272/OT-0272A_apertura_correccion-acople-salida-real-helper-tiempo-concentracion-roles-tc-expediente.md
+++ b/00_ADMIN/bitacora/OT-0272/OT-0272A_apertura_correccion-acople-salida-real-helper-tiempo-concentracion-roles-tc-expediente.md
@@ -1,0 +1,49 @@
+# OT-0272A — Corrección acople salida real helper Tiempo de concentración y roles Tc del expediente
+
+## Objetivo
+
+Corregir la salida real del constructor principal para que el bloque Tiempo de concentración y roles Tc use la función auxiliar delegada al helper construirBloqueTiempoConcentracionRolesTcExpediente, sustituyendo únicamente el bloque inline ## 3 dentro del arreglo principal texto.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente fuera del bloque Tc roles.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- Sustituir únicamente el bloque inline ## 3 Tiempo de concentración y roles Tc dentro del arreglo principal texto.
+- No modificar la función auxiliar construirLineasTiempoConcentracionRolesTcExpediente.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No validar valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No decidir competencia hidrológica de Tc.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0273 — Revalidación acople helper Tiempo de concentración y roles Tc del expediente

--- a/00_ADMIN/bitacora/OT-0272/OT-0272B_correccion_acople_salida_real_helper_tiempo_concentracion_roles_tc_expediente.md
+++ b/00_ADMIN/bitacora/OT-0272/OT-0272B_correccion_acople_salida_real_helper_tiempo_concentracion_roles_tc_expediente.md
@@ -1,0 +1,89 @@
+# OT-0272B — Corrección acople salida real helper Tiempo de concentración y roles Tc del expediente
+
+## Objetivo
+
+Corregir la salida real del constructor principal para que el bloque `Tiempo de concentración y roles Tc` use la función auxiliar delegada al helper.
+
+## Antecedente
+
+OT-0271 validó que el acople auxiliar estaba correcto, pero detectó que la salida real del constructor principal aún conservaba el bloque inline antiguo de `## 3. Tiempo de concentración y roles Tc`.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se sustituyó únicamente el bloque inline de `## 3. Tiempo de concentración y roles Tc` dentro del arreglo principal `texto`.
+
+La salida real del constructor principal ahora usa:
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente
+}),
+```
+
+## Cadena técnica resultante
+
+```text
+construirExpedienteHidrologicoMinimo
+↓
+construirLineasTiempoConcentracionRolesTcExpediente
+↓
+construirBloqueTiempoConcentracionRolesTcExpediente
+```
+
+## Alcance mantenido
+
+No se modificó `construirBloqueTiempoConcentracionRolesTcExpediente.js`.
+
+No se modificó la función auxiliar `construirLineasTiempoConcentracionRolesTcExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se modificó bloque Identificación.
+
+No se modificó bloque Parámetros hidrológicos base.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se recalculó `Tc`.
+
+No se modificó `Tc_final`.
+
+No se seleccionó `Tc` adoptado.
+
+No se emitió dictamen hidrológico.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Lectura técnica
+
+La corrección conecta la salida real del constructor principal con la función auxiliar ya delegada al helper.
+
+El bloque inline antiguo queda eliminado del constructor principal.
+
+La validez final del acople deberá revalidarse en una OT posterior.
+
+## Próximo frente recomendado
+
+`OT-0273 — Revalidación acople helper Tiempo de concentración y roles Tc del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper validado.
+- No se modificó la función auxiliar delegada.
+- No se recalculó `Tc`.
+- No se emitió dictamen hidrológico.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0272/OT-0272C_cierre_correccion-acople-salida-real-helper-tiempo-concentracion-roles-tc-expediente.md
+++ b/00_ADMIN/bitacora/OT-0272/OT-0272C_cierre_correccion-acople-salida-real-helper-tiempo-concentracion-roles-tc-expediente.md
@@ -1,0 +1,21 @@
+# OT-0272C — Cierre Corrección acople salida real helper Tiempo de concentración y roles Tc del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0272\OT-0272A_apertura_correccion-acople-salida-real-helper-tiempo-concentracion-roles-tc-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -207,13 +207,10 @@ export default function construirExpedienteHidrologicoMinimo({
       contextoBase
     }),
     "",
-    "## 3. Tiempo de concentración y roles Tc",
-    `Tc comparador: ${
-      Tc_final !== null && Tc_final !== undefined
-        ? formatearNumeroExpediente(Tc_final, 1) + " min"
-        : "—"
-    }`,
-    "Nota: este helper no selecciona ni recalcula Tc.",
+    ...construirLineasTiempoConcentracionRolesTcExpediente({
+      Tc_final,
+      trDisenoActivoExpediente
+    }),
     "",
     "## 4. Volumen de referencia",
     `Lluvia efectiva total: ${
@@ -507,5 +504,6 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 


### PR DESCRIPTION
## Objetivo

Corregir la salida real del constructor principal para que el bloque `Tiempo de concentración y roles Tc` use la función auxiliar delegada al helper.

## Antecedente

OT-0271 validó que el acople auxiliar estaba correcto, pero detectó que la salida real del constructor principal aún conservaba el bloque inline antiguo de `## 3. Tiempo de concentración y roles Tc`.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js