### PR TITLE
OT-0274 — Corrección runtime Tr diseño Tc roles

### DIFF
--- a/00_ADMIN/bitacora/OT-0274/OT-0274A_apertura_correccion-runtime-variable-trdisenoactivoexpediente-salida-real-tc-roles.md
+++ b/00_ADMIN/bitacora/OT-0274/OT-0274A_apertura_correccion-runtime-variable-trdisenoactivoexpediente-salida-real-tc-roles.md
@@ -1,0 +1,48 @@
+# OT-0274A — Corrección runtime variable trDisenoActivoExpediente en salida real Tc roles
+
+## Objetivo
+
+Corregir el error runtime ReferenceError trDisenoActivoExpediente is not defined en la salida real del bloque Tiempo de concentración y roles Tc, declarando la variable dentro del constructor principal sin modificar helper, función auxiliar, comparador ni motor.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente fuera del runtime Tc roles.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No modificar la función auxiliar construirLineasTiempoConcentracionRolesTcExpediente.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No validar valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No decidir competencia hidrológica de Tc.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No tocar Volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0275 — Revalidación runtime salida real helper Tiempo de concentración y roles Tc

--- a/00_ADMIN/bitacora/OT-0274/OT-0274B_correccion_runtime_variable_trdisenoactivoexpediente_salida_real_tc_roles.md
+++ b/00_ADMIN/bitacora/OT-0274/OT-0274B_correccion_runtime_variable_trdisenoactivoexpediente_salida_real_tc_roles.md
@@ -1,0 +1,111 @@
+# OT-0274B — Corrección runtime variable trDisenoActivoExpediente en salida real Tc roles
+
+## Objetivo
+
+Corregir el error runtime `ReferenceError: trDisenoActivoExpediente is not defined` detectado en OT-0273.
+
+## Antecedente
+
+OT-0273 revalidó el acople y confirmó que la función auxiliar estaba delegada al helper, pero la ejecución real del constructor principal fallaba porque `trDisenoActivoExpediente` era usado en el arreglo `texto` sin estar declarado.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Cambio aplicado
+
+Se corrigió el runtime mediante tres ajustes mínimos dentro de `construirExpedienteHidrologicoMinimo.js`:
+
+1. Se agregó `trDisenoActivoExpediente = null` a la firma del constructor principal.
+
+2. Se declaró `trDisenoActivoExpedienteDocumental` dentro del constructor principal, derivado de entradas ya disponibles y sin recálculo hidrológico.
+
+3. La salida real del bloque Tc roles pasa ahora `trDisenoActivoExpedienteDocumental` a la función auxiliar delegada.
+
+## Firma ajustada
+
+```javascript
+export default function construirExpedienteHidrologicoMinimo({
+  contextoBase = {},
+  Tc_final = null,
+  trDisenoActivoExpediente = null,
+  metodos = [],
+  ...
+} = {})
+```
+
+## Variable documental declarada
+
+```javascript
+const trDisenoActivoExpedienteDocumental =
+  trDisenoActivoExpediente ??
+  contextoBase?.trDisenoActivoExpediente ??
+  contextoBase?.trDisenoActivo ??
+  contextoBase?.Tr ??
+  contextoBase?.TR ??
+  contextoBase?.periodoRetorno ??
+  contextoBase?.periodo_retorno ??
+  contextoBase?.periodoRetornoAnos ??
+  contextoBase?.periodoRetornoAnios ??
+  null;
+```
+
+## Salida real ajustada
+
+```javascript
+...construirLineasTiempoConcentracionRolesTcExpediente({
+  Tc_final,
+  trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
+}),
+```
+
+## Alcance mantenido
+
+No se modificó `construirBloqueTiempoConcentracionRolesTcExpediente.js`.
+
+No se modificó la función auxiliar `construirLineasTiempoConcentracionRolesTcExpediente`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se modificó bloque Identificación.
+
+No se modificó bloque Parámetros hidrológicos base.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se recalculó `Tc`.
+
+No se modificó `Tc_final`.
+
+No se seleccionó `Tc` adoptado.
+
+No se emitió dictamen hidrológico.
+
+No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Lectura técnica
+
+La corrección elimina el fallo runtime sin alterar la lógica del helper ni la función auxiliar delegada.
+
+La validez final deberá revalidarse en una OT posterior.
+
+## Próximo frente recomendado
+
+`OT-0275 — Revalidación runtime salida real helper Tiempo de concentración y roles Tc`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el helper validado.
+- No se modificó la función auxiliar delegada.
+- No se recalculó `Tc`.
+- No se emitió dictamen hidrológico.
+- No se tocaron Volumen, Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0274/OT-0274C_cierre_correccion-runtime-variable-trdisenoactivoexpediente-salida-real-tc-roles.md
+++ b/00_ADMIN/bitacora/OT-0274/OT-0274C_cierre_correccion-runtime-variable-trdisenoactivoexpediente-salida-real-tc-roles.md
@@ -1,0 +1,21 @@
+# OT-0274C — Cierre Corrección runtime variable trDisenoActivoExpediente en salida real Tc roles
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0274\OT-0274A_apertura_correccion-runtime-variable-trdisenoactivoexpediente-salida-real-tc-roles.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -170,6 +170,7 @@ export function construirLineasSelloTecnicoAuxiliarExpediente({
 export default function construirExpedienteHidrologicoMinimo({
   contextoBase = {},
   Tc_final = null,
+  trDisenoActivoExpediente = null,
   metodos = [],
   filasMorfologiaQt = [],
   filasDictamenFormaQt = [],
@@ -191,6 +192,17 @@ export default function construirExpedienteHidrologicoMinimo({
     Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
       ? areaKm2 * peTotalMm * 1000
       : null;
+  const trDisenoActivoExpedienteDocumental =
+    trDisenoActivoExpediente ??
+    contextoBase?.trDisenoActivoExpediente ??
+    contextoBase?.trDisenoActivo ??
+    contextoBase?.Tr ??
+    contextoBase?.TR ??
+    contextoBase?.periodoRetorno ??
+    contextoBase?.periodo_retorno ??
+    contextoBase?.periodoRetornoAnos ??
+    contextoBase?.periodoRetornoAnios ??
+    null;
 
   const texto = [
     "# Expediente hidrológico mínimo — Cuenca activa",
@@ -209,7 +221,7 @@ export default function construirExpedienteHidrologicoMinimo({
     "",
     ...construirLineasTiempoConcentracionRolesTcExpediente({
       Tc_final,
-      trDisenoActivoExpediente
+      trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
     }),
     "",
     "## 4. Volumen de referencia",
@@ -504,6 +516,7 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 
 


### PR DESCRIPTION
## Objetivo

Corregir el error runtime `ReferenceError: trDisenoActivoExpediente is not defined` detectado en OT-0273.

## Antecedente

OT-0273 revalidó el acople y confirmó que la función auxiliar estaba delegada al helper, pero la ejecución real del constructor principal fallaba porque `trDisenoActivoExpediente` era usado en el arreglo `texto` sin estar declarado.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js