### PR TITLE
OT-0279 — Diseño helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0279/OT-0279A_apertura_diseno-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0279/OT-0279A_apertura_diseno-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,56 @@
+# OT-0279A — Diseño helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Diseñar el helper puro documental del bloque Volumen de referencia del expediente hidrológico mínimo, definiendo nombre, archivo futuro, firma, entradas permitidas, salida esperada, normalización, fallbacks, tokens prohibidos y restricciones de frontera, sin crear archivo funcional ni modificar código.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional en esta OT.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir código funcional en esta OT.
+- No tocar directamente el arreglo principal texto.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No validar valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Crear únicamente documentación OT-0279.
+
+## Próximo frente recomendado
+
+OT-0280 — Implementación helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0279/OT-0279B_diseno_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0279/OT-0279B_diseno_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,290 @@
+# OT-0279B — Diseño helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Diseñar el helper puro documental del bloque `Volumen de referencia` del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0278 aprobó el contrato documental del bloque `## 4. Volumen de referencia`.
+
+El contrato definió líneas mínimas, campos permitidos, campos no permitidos, reglas de fallback, formato documental, tokens prohibidos y frontera frente a Q-Tr, Q-5, Método Racional y diagnóstico Q(t).
+
+## Helper futuro propuesto
+
+Nombre del helper:
+
+```text
+construirBloqueVolumenReferenciaExpediente
+```
+
+Archivo futuro propuesto:
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+```
+
+## Firma futura propuesta
+
+```javascript
+export function construirBloqueVolumenReferenciaExpediente(entrada = {})
+```
+
+## Entradas permitidas
+
+El helper podrá recibir únicamente:
+
+- `peTotalMm`;
+- `volumenEsperadoM3`;
+- `areaKm2`, solo como campo documental de trazabilidad si se requiere;
+- `incluirTitulo`.
+
+## Entradas no permitidas
+
+El helper no deberá recibir ni manipular:
+
+- hidrogramas;
+- series Q(t);
+- resultados Q-5;
+- resultados Q-Tr;
+- resultados del Método Racional;
+- diagnóstico temporal Q(t);
+- parámetros de selección de Tc;
+- criterios de competencia hidrológica;
+- insumos para recalcular CN, AMC, Pe, área o volumen.
+
+## Salida esperada
+
+El helper deberá devolver:
+
+```javascript
+string[]
+```
+
+## Líneas mínimas esperadas
+
+Cuando `incluirTitulo` sea verdadero, la salida deberá incluir:
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: <valor documental o fallback>
+Volumen esperado: <valor documental o fallback>
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+Cuando `incluirTitulo` sea falso, la salida podrá omitir únicamente el título, conservando las demás líneas mínimas.
+
+## Normalización documental
+
+El helper deberá normalizar valores de entrada sin mutarlos.
+
+Un valor ausente, nulo, indefinido, vacío, no numérico o no finito deberá representarse como:
+
+```text
+—
+```
+
+## Formato de lluvia efectiva
+
+Si `peTotalMm` es un número finito, deberá representarse con unidad:
+
+```text
+mm
+```
+
+Ejemplo documental:
+
+```text
+Lluvia efectiva total: 56,65 mm
+```
+
+El número de decimales podrá definirse durante la implementación, sin alterar el valor recibido.
+
+## Formato de volumen esperado
+
+Si `volumenEsperadoM3` es un número finito, deberá representarse con unidad:
+
+```text
+m³
+```
+
+Ejemplo documental:
+
+```text
+Volumen esperado: 2.654.251 m³
+```
+
+El separador de miles y el número de decimales podrán definirse durante la implementación, sin alterar el valor recibido.
+
+## Fórmula textual
+
+La salida deberá conservar la línea:
+
+```text
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+Esta línea será explicativa y documental.
+
+No deberá ejecutar recálculo.
+
+No deberá modificar la fórmula del motor.
+
+## Tokens prohibidos
+
+La salida no deberá contener:
+
+```text
+undefined
+null
+NaN
+[object Object]
+```
+
+## Reglas de pureza
+
+El helper deberá ser puro:
+
+- no mutar entradas;
+- no consultar motor;
+- no acceder a DOM;
+- no acceder a portapapeles;
+- no ejecutar efectos secundarios;
+- no consultar datos externos;
+- no modificar estado global;
+- no recalcular volumen.
+
+## Frontera con otros bloques
+
+El helper deberá mantenerse separado de:
+
+- `Escenario Q-Tr activo`;
+- `Resumen Q-5 auditado`;
+- `Método Racional`;
+- `Contraste Q-5 vs Método Racional`;
+- `Control de consistencia cruzada Pe–Área–Volumen/Q-5`;
+- `Diagnóstico temporal Q(t) no adoptivo`.
+
+No deberá incluir lectura de Q-Tr.
+
+No deberá incluir lectura de Q-5.
+
+No deberá incluir contraste con Método Racional.
+
+No deberá emitir juicio de consistencia Pe–Área–Volumen/Q-5.
+
+No deberá incluir diagnóstico temporal Q(t).
+
+## Diseño funcional futuro sugerido
+
+La implementación futura podrá estructurarse así:
+
+```javascript
+function normalizarNumeroDocumental(valor) {
+  // normaliza sin recalcular
+}
+
+function formatearLluviaEfectivaDocumental(valor) {
+  // devuelve "—" o "<número> mm"
+}
+
+function formatearVolumenEsperadoDocumental(valor) {
+  // devuelve "—" o "<número> m³"
+}
+
+export function construirBloqueVolumenReferenciaExpediente(entrada = {}) {
+  const {
+    peTotalMm,
+    volumenEsperadoM3,
+    incluirTitulo = true
+  } = entrada ?? {};
+
+  const lineas = [];
+
+  if (incluirTitulo) {
+    lineas.push("## 4. Volumen de referencia");
+  }
+
+  lineas.push(`Lluvia efectiva total: ${formatearLluviaEfectivaDocumental(peTotalMm)}`);
+  lineas.push(`Volumen esperado: ${formatearVolumenEsperadoDocumental(volumenEsperadoM3)}`);
+  lineas.push("Fórmula: Pe(mm) × Área(km²) × 1000.");
+
+  return lineas;
+}
+```
+
+Este diseño es orientativo.
+
+No autoriza implementación en esta OT.
+
+## Criterios de aceptación futuros
+
+Cuando el helper sea implementado, deberá validarse que:
+
+- el archivo existe;
+- exporta `construirBloqueVolumenReferenciaExpediente`;
+- devuelve `string[]`;
+- incluye título cuando `incluirTitulo` es verdadero;
+- omite únicamente el título cuando `incluirTitulo` es falso;
+- conserva las líneas mínimas esperadas;
+- aplica fallback `—` ante valores ausentes o inválidos;
+- no emite tokens prohibidos;
+- no muta entradas;
+- no toca motor;
+- no recalcula volumen;
+- no mezcla Q-Tr, Q-5, Método Racional ni diagnóstico Q(t);
+- el build permanece aprobado.
+
+## Decisión de diseño
+
+Se aprueba el diseño del helper puro documental `construirBloqueVolumenReferenciaExpediente`.
+
+No se autoriza crear el archivo en esta OT.
+
+No se autoriza implementar el helper en esta OT.
+
+No se autoriza acoplar el helper en esta OT.
+
+No se autoriza modificar el constructor principal en esta OT.
+
+## Próximo frente recomendado
+
+`OT-0280 — Implementación helper bloque Volumen de referencia del expediente`
+
+## Alcance mantenido
+
+No se implementa ningún cambio funcional en esta OT.
+
+No se crea helper.
+
+No se modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No se modifica `construirBloqueTiempoConcentracionRolesTcExpediente.js`.
+
+No se modifica `ComparadorMultiMetodo.jsx`.
+
+No se modifica motor.
+
+No se recalcula `Tc`.
+
+No se recalcula volumen.
+
+No se modifica `Tc_final`.
+
+No se emite dictamen hidrológico.
+
+No se tocan Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se recalculó `Tc`.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0279/OT-0279C_cierre_diseno-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0279/OT-0279C_cierre_diseno-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0279C — Cierre Diseño helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0279\OT-0279A_apertura_diseno-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Diseñar el helper puro documental del bloque `Volumen de referencia` del expediente hidrológico mínimo.

## Antecedente

OT-0278 aprobó el contrato documental del bloque `## 4. Volumen de referencia`.

El contrato definió líneas mínimas, campos permitidos, campos no permitidos, reglas de fallback, formato documental, tokens prohibidos y frontera frente a Q-Tr, Q-5, Método Racional y diagnóstico Q(t).

## Helper futuro propuesto

Nombre del helper:

```text
construirBloqueVolumenReferenciaExpediente