### PR TITLE
OT-0280 — Helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0280/OT-0280A_apertura_implementacion-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0280/OT-0280A_apertura_implementacion-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,54 @@
+# OT-0280A — Implementación helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Implementar el helper puro documental construirBloqueVolumenReferenciaExpediente para el bloque Volumen de referencia del expediente hidrológico mínimo, sin acoplarlo al constructor principal, sin modificar comparador, sin tocar motor y sin recalcular volumen.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar helpers existentes.
+- Crear únicamente el helper construirBloqueVolumenReferenciaExpediente.js como archivo funcional nuevo.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir código funcional existente en esta OT.
+- No tocar directamente el arreglo principal texto.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No acoplar el bloque Volumen de referencia al constructor principal.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0281 — Validación aislada helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0280/OT-0280B_implementacion_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0280/OT-0280B_implementacion_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,139 @@
+# OT-0280B — Implementación helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Implementar el helper puro documental `construirBloqueVolumenReferenciaExpediente` para el bloque `Volumen de referencia` del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0278 definió el contrato documental del bloque `Volumen de referencia`.
+
+OT-0279 aprobó el diseño del helper puro documental `construirBloqueVolumenReferenciaExpediente`.
+
+## Archivo funcional creado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+```
+
+## Exportaciones implementadas
+
+El archivo nuevo exporta:
+
+```javascript
+formatearLluviaEfectivaDocumental
+formatearVolumenEsperadoDocumental
+construirBloqueVolumenReferenciaExpediente
+```
+
+## Firma principal implementada
+
+```javascript
+export function construirBloqueVolumenReferenciaExpediente(entrada = {})
+```
+
+## Líneas documentales generadas
+
+Cuando `incluirTitulo` es verdadero, el helper genera:
+
+```text
+## 4. Volumen de referencia
+Lluvia efectiva total: <valor documental o fallback>
+Volumen esperado: <valor documental o fallback>
+Fórmula: Pe(mm) × Área(km²) × 1000.
+```
+
+Cuando `incluirTitulo` es falso, omite únicamente el título.
+
+## Fallback documental
+
+Los valores ausentes, nulos, vacíos, no numéricos o no finitos se representan como:
+
+```text
+—
+```
+
+## Alcance técnico
+
+El helper es puro documental.
+
+No consulta motor.
+
+No recalcula volumen.
+
+No modifica Pe.
+
+No modifica área.
+
+No modifica fórmula de volumen.
+
+No accede a DOM.
+
+No accede a portapapeles.
+
+No modifica estado global.
+
+No consulta datos externos.
+
+## Frontera mantenida
+
+El helper no recibe ni manipula:
+
+- hidrogramas;
+- series Q(t);
+- resultados Q-5;
+- resultados Q-Tr;
+- resultados del Método Racional;
+- diagnóstico temporal Q(t);
+- parámetros de selección de Tc;
+- criterios de competencia hidrológica;
+- insumos para recalcular CN, AMC, Pe, área o volumen.
+
+## Alcance mantenido
+
+No se acopló el helper al constructor principal.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se recalculó `Tc`.
+
+No se recalculó volumen.
+
+No se modificó `Tc_final`.
+
+No se emitió dictamen hidrológico.
+
+No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Validación ejecutada en esta OT
+
+La validación formal aislada queda reservada para OT-0281.
+
+En esta OT se ejecuta únicamente build de producción como control de sintaxis/proyecto.
+
+## Próximo frente recomendado
+
+`OT-0281 — Validación aislada helper bloque Volumen de referencia del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se acopló el helper.
+- No se recalculó `Tc`.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0280/OT-0280C_cierre_implementacion-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0280/OT-0280C_cierre_implementacion-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0280C — Cierre Implementación helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0280\OT-0280A_apertura_implementacion-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
@@ -1,0 +1,98 @@
+// OT-0280 — Helper puro documental del bloque Volumen de referencia.
+// No modifica motor.
+// No recalcula volumen.
+// No consulta Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+// No accede a DOM, portapapeles ni estado global.
+
+const FALLBACK_DOCUMENTAL = "—";
+
+function esValorAusente(valor) {
+  return valor === undefined || valor === null;
+}
+
+function normalizarNumeroDocumental(valor) {
+  if (esValorAusente(valor)) {
+    return null;
+  }
+
+  if (typeof valor === "string" && valor.trim().length === 0) {
+    return null;
+  }
+
+  const numero = Number(valor);
+
+  if (!Number.isFinite(numero)) {
+    return null;
+  }
+
+  return numero;
+}
+
+function formatearNumeroDocumental(valor, opciones = {}) {
+  const numero = normalizarNumeroDocumental(valor);
+
+  if (numero === null) {
+    return FALLBACK_DOCUMENTAL;
+  }
+
+  const {
+    minimumFractionDigits = 0,
+    maximumFractionDigits = 2
+  } = opciones;
+
+  return numero.toLocaleString("es-CO", {
+    minimumFractionDigits,
+    maximumFractionDigits
+  });
+}
+
+export function formatearLluviaEfectivaDocumental(valor) {
+  const numero = normalizarNumeroDocumental(valor);
+
+  if (numero === null) {
+    return FALLBACK_DOCUMENTAL;
+  }
+
+  return `${formatearNumeroDocumental(numero, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
+  })} mm`;
+}
+
+export function formatearVolumenEsperadoDocumental(valor) {
+  const numero = normalizarNumeroDocumental(valor);
+
+  if (numero === null) {
+    return FALLBACK_DOCUMENTAL;
+  }
+
+  return `${formatearNumeroDocumental(numero, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+  })} m³`;
+}
+
+export function construirBloqueVolumenReferenciaExpediente(entrada = {}) {
+  const entradaSegura =
+    entrada && typeof entrada === "object"
+      ? entrada
+      : {};
+
+  const {
+    peTotalMm,
+    volumenEsperadoM3,
+    incluirTitulo = true
+  } = entradaSegura;
+
+  const lineas = [];
+
+  if (incluirTitulo) {
+    lineas.push("## 4. Volumen de referencia");
+  }
+
+  lineas.push(`Lluvia efectiva total: ${formatearLluviaEfectivaDocumental(peTotalMm)}`);
+  lineas.push(`Volumen esperado: ${formatearVolumenEsperadoDocumental(volumenEsperadoM3)}`);
+  lineas.push("Fórmula: Pe(mm) × Área(km²) × 1000.");
+
+  return lineas;
+}


### PR DESCRIPTION
## Objetivo

Implementar el helper puro documental `construirBloqueVolumenReferenciaExpediente` para el bloque `Volumen de referencia` del expediente hidrológico mínimo.

## Antecedente

OT-0278 definió el contrato documental del bloque `Volumen de referencia`.

OT-0279 aprobó el diseño del helper puro documental `construirBloqueVolumenReferenciaExpediente`.

## Archivo funcional creado

```text
01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js