### PR TITLE
OT-0282 — Corrección helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0282/OT-0282A_apertura_correccion-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0282/OT-0282A_apertura_correccion-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,57 @@
+# OT-0282A — Corrección helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Corregir únicamente la referencia textual prohibida detectada por OT-0281 en la fuente del helper construirBloqueVolumenReferenciaExpediente, sin cambiar comportamiento funcional, sin acoplar el helper, sin modificar constructor, comparador ni motor, y sin recalcular volumen.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- Modificar únicamente comentarios en construirBloqueVolumenReferenciaExpediente.js.
+- No modificar la lógica del helper.
+- No modificar exportaciones del helper.
+- No modificar formateadores del helper.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir otros códigos funcionales en esta OT.
+- No tocar directamente el arreglo principal texto.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia en el constructor.
+- No acoplar el helper al constructor principal.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0283 — Revalidación aislada helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0282/OT-0282B_correccion_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0282/OT-0282B_correccion_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,104 @@
+# OT-0282B — Corrección helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Corregir únicamente la referencia textual prohibida detectada por OT-0281 en la fuente del helper `construirBloqueVolumenReferenciaExpediente`.
+
+## Antecedente
+
+OT-0281 validó el helper en aislamiento y aprobó 18 de 19 controles.
+
+El único control fallido fue:
+
+```text
+sin_referencias_bloques_prohibidos_en_fuente
+```
+
+## Causa
+
+El helper contenía una referencia textual en comentario a bloques externos y módulos comparativos.
+
+La referencia no afectaba comportamiento funcional, pero activaba el control textual estricto de la validación aislada.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+```
+
+## Cambio aplicado
+
+Se sustituyó únicamente el comentario:
+
+```javascript
+// No consulta Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+```
+
+por:
+
+```javascript
+// No consulta bloques hidrologicos externos ni modulos comparativos.
+```
+
+## Alcance técnico
+
+No se modificó la lógica del helper.
+
+No se modificaron exportaciones.
+
+No se modificaron formateadores.
+
+No se modificaron líneas documentales.
+
+No se modificó el fallback documental.
+
+No se modificó la fórmula textual.
+
+## Alcance mantenido
+
+No se acopló el helper al constructor principal.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se modificaron helpers existentes.
+
+No se modificaron validadores existentes.
+
+No se recalculó `Tc`.
+
+No se recalculó volumen.
+
+No se modificó `Tc_final`.
+
+No se emitió dictamen hidrológico.
+
+No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Validación en esta OT
+
+La revalidación formal aislada queda reservada para OT-0283.
+
+En esta OT se ejecuta build de producción como control de sintaxis/proyecto.
+
+## Próximo frente recomendado
+
+`OT-0283 — Revalidación aislada helper bloque Volumen de referencia del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se acopló el helper.
+- No se recalculó `Tc`.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0282/OT-0282C_cierre_correccion-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0282/OT-0282C_cierre_correccion-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0282C — Cierre Corrección helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0282\OT-0282A_apertura_correccion-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
@@ -1,7 +1,7 @@
 // OT-0280 — Helper puro documental del bloque Volumen de referencia.
 // No modifica motor.
 // No recalcula volumen.
-// No consulta Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+// No consulta bloques hidrologicos externos ni modulos comparativos.
 // No accede a DOM, portapapeles ni estado global.
 
 const FALLBACK_DOCUMENTAL = "—";
@@ -96,3 +96,4 @@ export function construirBloqueVolumenReferenciaExpediente(entrada = {}) {
 
   return lineas;
 }
+


### PR DESCRIPTION
## Objetivo

Corregir únicamente la referencia textual prohibida detectada por OT-0281 en la fuente del helper `construirBloqueVolumenReferenciaExpediente`.

## Antecedente

OT-0281 validó el helper en aislamiento y aprobó 18 de 19 controles.

El único control fallido fue:

```text
sin_referencias_bloques_prohibidos_en_fuente