### PR TITLE
OT-0286 — Acople helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0286/OT-0286A_apertura_acople-minimo-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0286/OT-0286A_apertura_acople-minimo-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,55 @@
+# OT-0286A — Acople mínimo helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Acoplar mínimamente el helper puro documental construirBloqueVolumenReferenciaExpediente al expediente hidrológico mínimo mediante import, delegación de construirLineasVolumenReferenciaExpediente y sustitución del bloque inline en la salida real, sin modificar helper, comparador ni motor, y sin recalcular volumen.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional existente.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir otros códigos funcionales en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- Acoplar únicamente bloque Volumen de referencia.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0287 — Validación acople helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0286/OT-0286B_acople_minimo_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0286/OT-0286B_acople_minimo_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,90 @@
+# OT-0286B — Acople mínimo helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Acoplar mínimamente el helper puro documental `construirBloqueVolumenReferenciaExpediente` al expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0285 diseñó el punto de acople futuro del helper `construirBloqueVolumenReferenciaExpediente`.
+
+El diseño aprobó el patrón: import del helper, función auxiliar delegada y uso de la función auxiliar en la salida real del constructor principal.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Import agregado
+
+```javascript
+import { construirBloqueVolumenReferenciaExpediente } from "./construirBloqueVolumenReferenciaExpediente";
+```
+
+## Función auxiliar delegada
+
+La función `construirLineasVolumenReferenciaExpediente` delega ahora al helper validado:
+
+```javascript
+export function construirLineasVolumenReferenciaExpediente(entrada = {}) {
+  return construirBloqueVolumenReferenciaExpediente({
+    peTotalMm: entrada?.peTotalMm,
+    volumenEsperadoM3: entrada?.volumenEsperadoM3,
+    incluirTitulo: true
+  });
+}
+```
+
+## Salida real ajustada
+
+El bloque inline de `Volumen de referencia` en la salida real fue sustituido por:
+
+```javascript
+...construirLineasVolumenReferenciaExpediente({
+  peTotalMm,
+  volumenEsperadoM3
+}),
+```
+
+## Alcance técnico
+
+No se modificó el helper `construirBloqueVolumenReferenciaExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se recalculó volumen.
+
+No se modificó Pe.
+
+No se modificó área.
+
+No se modificó fórmula de volumen.
+
+No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Validación en esta OT
+
+Se ejecuta build de producción como control de sintaxis/proyecto.
+
+La validación formal del acople queda reservada para OT-0287.
+
+## Próximo frente recomendado
+
+`OT-0287 — Validación acople helper bloque Volumen de referencia del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirBloqueVolumenReferenciaExpediente.js`.
+- No se modificaron helpers existentes distintos del acople auxiliar.
+- No se modificaron validadores existentes.
+- No se recalculó `Tc`.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0286/OT-0286C_cierre_acople-minimo-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0286/OT-0286C_cierre_acople-minimo-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0286C — Cierre Acople mínimo helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0286\OT-0286A_apertura_acople-minimo-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -224,16 +224,10 @@ export default function construirExpedienteHidrologicoMinimo({
       trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
     }),
     "",
-    "## 4. Volumen de referencia",
-    `Lluvia efectiva total: ${
-      Number.isFinite(peTotalMm) ? formatearNumeroExpediente(peTotalMm, 2) + " mm" : "—"
-    }`,
-    `Volumen esperado: ${
-      Number.isFinite(volumenEsperadoM3)
-        ? formatearNumeroExpediente(volumenEsperadoM3, 0) + " m³"
-        : "—"
-    }`,
-    "Fórmula: Pe(mm) × Área(km²) × 1000.",
+    ...construirLineasVolumenReferenciaExpediente({
+      peTotalMm,
+      volumenEsperadoM3
+    }),
     "",
     "## 5. Escenario Q-Tr activo — control de trazabilidad",
     `Estado: ${contextoBase?.q_tr_activo_estado?.estado ?? "no_publicado"}`,
@@ -333,52 +327,11 @@ export function construirLineasTiempoConcentracionRolesTcExpediente(entrada = {}
   });
 }
 export function construirLineasVolumenReferenciaExpediente(entrada = {}) {
-  const formatearLluviaEfectiva = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "string" && valor.trim().length === 0) {
-      return "—";
-    }
-
-    const numero = Number(valor);
-
-    if (!Number.isFinite(numero)) {
-      return "—";
-    }
-
-    return `${numero.toFixed(2)} mm`;
-  };
-
-  const formatearVolumenEsperado = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "string" && valor.trim().length === 0) {
-      return "—";
-    }
-
-    if (typeof valor === "object") {
-      return "—";
-    }
-
-    const numero = Number(valor);
-
-    if (!Number.isFinite(numero)) {
-      return "—";
-    }
-
-    return `${numero.toLocaleString("es-CO", { maximumFractionDigits: 0 })} m³`;
-  };
-
-  return [
-    "## 4. Volumen de referencia",
-    `Lluvia efectiva total: ${formatearLluviaEfectiva(entrada?.peTotalMm)}`,
-    `Volumen esperado: ${formatearVolumenEsperado(entrada?.volumenEsperadoM3)}`,
-    "Fórmula: Pe(mm) × Área(km²) × 1000."
-  ];
+  return construirBloqueVolumenReferenciaExpediente({
+    peTotalMm: entrada?.peTotalMm,
+    volumenEsperadoM3: entrada?.volumenEsperadoM3,
+    incluirTitulo: true
+  });
 }
 
 export function construirLineasEscenarioQTrActivoExpediente(entrada = {}) {
@@ -516,6 +469,7 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -2,6 +2,7 @@ import { construirBloqueRestriccionesAdvertenciasGeneralesExpediente } from "./c
 import { construirBloqueIdentificacionExpedienteMinimo } from "./construirBloqueIdentificacionExpedienteMinimo";
 import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construirBloqueParametrosHidrologicosBaseExpediente";
 import { construirBloqueTiempoConcentracionRolesTcExpediente } from "./construirBloqueTiempoConcentracionRolesTcExpediente";
+import { construirBloqueVolumenReferenciaExpediente } from "./construirBloqueVolumenReferenciaExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.


### PR DESCRIPTION
## Objetivo

Acoplar mínimamente el helper puro documental `construirBloqueVolumenReferenciaExpediente` al expediente hidrológico mínimo mediante import, delegación de `construirLineasVolumenReferenciaExpediente` y sustitución del bloque inline en la salida real.

## Antecedente

OT-0285 diseñó el punto de acople futuro del helper `construirBloqueVolumenReferenciaExpediente`.

El diseño aprobó el patrón:

```text
import del helper
↓
función auxiliar delegada
↓
uso de la función auxiliar en la salida real del constructor principal
↓
validación de ausencia de bloque inline antiguo