### PR TITLE
OT-0288 — Corrección acople helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0288/OT-0288A_apertura_correccion-acople-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0288/OT-0288A_apertura_correccion-acople-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,55 @@
+# OT-0288A — Corrección acople helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Corregir únicamente el paso documental de valores hacia el bloque Volumen de referencia acoplado, permitiendo que el constructor principal use peTotalMm y volumenEsperadoM3 explícitos cuando estén disponibles, sin modificar helper, comparador ni motor, y sin recalcular volumen.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional existente.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir otros códigos funcionales en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- Corregir únicamente bloque Volumen de referencia.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0289 — Revalidación acople helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0288/OT-0288B_correccion_acople_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0288/OT-0288B_correccion_acople_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,100 @@
+# OT-0288B — Corrección acople helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Corregir únicamente el paso documental de valores hacia el bloque `Volumen de referencia` acoplado.
+
+## Antecedente
+
+OT-0287 validó el acople del helper `construirBloqueVolumenReferenciaExpediente` y aprobó 14 de 16 controles.
+
+Los controles fallidos fueron:
+
+```text
+constructor_principal_sin_bloque_inline_volumen
+bloque_volumen_real_lineas_minimas
+```
+
+## Causa técnica principal
+
+La salida directa auxiliar generaba correctamente `56,65 mm` y `2.654.251 m³`, pero la salida real del constructor recibía valores documentales no publicados en el caso validado y terminaba usando fallback `—`.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Corrección aplicada
+
+Se agregaron entradas documentales explícitas al constructor principal:
+
+```javascript
+peTotalMm: peTotalMmEntradaDocumental = null,
+volumenEsperadoM3: volumenEsperadoM3EntradaDocumental = null,
+```
+
+Se agregaron variables documentales de respaldo:
+
+```javascript
+const peTotalMmBloqueVolumenReferenciaDocumental =
+  Number.isFinite(Number(peTotalMmEntradaDocumental))
+    ? Number(peTotalMmEntradaDocumental)
+    : peTotalMm;
+
+const volumenEsperadoM3BloqueVolumenReferenciaDocumental =
+  Number.isFinite(Number(volumenEsperadoM3EntradaDocumental))
+    ? Number(volumenEsperadoM3EntradaDocumental)
+    : volumenEsperadoM3;
+```
+
+La llamada al helper acoplado ahora recibe:
+
+```javascript
+...construirLineasVolumenReferenciaExpediente({
+  peTotalMm: peTotalMmBloqueVolumenReferenciaDocumental,
+  volumenEsperadoM3: volumenEsperadoM3BloqueVolumenReferenciaDocumental
+}),
+```
+
+## Alcance técnico
+
+No se modificó el helper `construirBloqueVolumenReferenciaExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se recalculó volumen.
+
+No se modificó Pe.
+
+No se modificó área.
+
+No se modificó fórmula de volumen.
+
+No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).
+
+## Validación en esta OT
+
+Se ejecuta build de producción como control de sintaxis/proyecto.
+
+La revalidación formal del acople queda reservada para OT-0289.
+
+## Próximo frente recomendado
+
+`OT-0289 — Revalidación acople helper bloque Volumen de referencia del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirBloqueVolumenReferenciaExpediente.js`.
+- No se modificaron helpers existentes distintos del acople auxiliar.
+- No se modificaron validadores existentes.
+- No se recalculó `Tc`.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0288/OT-0288C_cierre_correccion-acople-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0288/OT-0288C_cierre_correccion-acople-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0288C — Cierre Corrección acople helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0288\OT-0288A_apertura_correccion-acople-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -169,7 +169,8 @@ export function construirLineasSelloTecnicoAuxiliarExpediente({
   ];
 }
 export default function construirExpedienteHidrologicoMinimo({
-  contextoBase = {},
+  peTotalMm: peTotalMmEntradaDocumental = null,
+  volumenEsperadoM3: volumenEsperadoM3EntradaDocumental = null,  contextoBase = {},
   Tc_final = null,
   trDisenoActivoExpediente = null,
   metodos = [],
@@ -205,6 +206,15 @@ export default function construirExpedienteHidrologicoMinimo({
     contextoBase?.periodoRetornoAnios ??
     null;
 
+  const peTotalMmBloqueVolumenReferenciaDocumental =
+    Number.isFinite(Number(peTotalMmEntradaDocumental))
+      ? Number(peTotalMmEntradaDocumental)
+      : peTotalMm;
+
+  const volumenEsperadoM3BloqueVolumenReferenciaDocumental =
+    Number.isFinite(Number(volumenEsperadoM3EntradaDocumental))
+      ? Number(volumenEsperadoM3EntradaDocumental)
+      : volumenEsperadoM3;
   const texto = [
     "# Expediente hidrológico mínimo — Cuenca activa",
     "Estado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.",
@@ -226,8 +236,8 @@ export default function construirExpedienteHidrologicoMinimo({
     }),
     "",
     ...construirLineasVolumenReferenciaExpediente({
-      peTotalMm,
-      volumenEsperadoM3
+      peTotalMm: peTotalMmBloqueVolumenReferenciaDocumental,
+      volumenEsperadoM3: volumenEsperadoM3BloqueVolumenReferenciaDocumental
     }),
     "",
     "## 5. Escenario Q-Tr activo — control de trazabilidad",
@@ -470,6 +480,7 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 
 


### PR DESCRIPTION
## Objetivo

Corregir únicamente el paso documental de valores hacia el bloque `Volumen de referencia` acoplado.

## Antecedente

OT-0287 validó el acople del helper `construirBloqueVolumenReferenciaExpediente` y aprobó 14 de 16 controles.

Los controles fallidos fueron:

```text
constructor_principal_sin_bloque_inline_volumen
bloque_volumen_real_lineas_minimas