### PR TITLE
OT-0289 — Revalidación acople helper Volumen referencia

### DIFF
--- a/00_ADMIN/bitacora/OT-0289/OT-0289A_apertura_revalidacion-acople-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0289/OT-0289A_apertura_revalidacion-acople-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,56 @@
+# OT-0289A — Revalidación acople helper bloque Volumen de referencia del expediente
+
+## Objetivo
+
+Revalidar el acople mínimo del helper puro documental construirBloqueVolumenReferenciaExpediente después de la corrección OT-0288, comprobando import único, delegación auxiliar, uso en salida real, ausencia de bloque inline antiguo, valores reales esperados en el bloque Volumen de referencia, salida sin tokens inválidos y build aprobado, sin corregir código funcional.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir código funcional en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Crear únicamente documentación y script de revalidación OT-0289.
+
+## Próximo frente recomendado
+
+OT-0290 — Revalidación salida real helper bloque Volumen de referencia del expediente

--- a/00_ADMIN/bitacora/OT-0289/OT-0289B_revalidacion_acople_helper_bloque_volumen_referencia_expediente.md
+++ b/00_ADMIN/bitacora/OT-0289/OT-0289B_revalidacion_acople_helper_bloque_volumen_referencia_expediente.md
@@ -1,0 +1,239 @@
+# OT-0289B — Revalidación acople helper bloque Volumen de referencia del expediente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0289",
+  "helper": "construirBloqueVolumenReferenciaExpediente",
+  "totalControles": 18,
+  "controlesAprobados": 18,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "buildAprobado": true,
+  "acopleValidado": true,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false
+}
+```
+
+## Controles evaluados
+
+### archivo_expediente_existe
+
+```json
+{
+  "id": "archivo_expediente_existe",
+  "descripcion": "Archivo del expediente existe",
+  "aprobado": true
+}
+```
+
+### archivo_helper_volumen_existe
+
+```json
+{
+  "id": "archivo_helper_volumen_existe",
+  "descripcion": "Archivo del helper Volumen de referencia existe",
+  "aprobado": true
+}
+```
+
+### import_helper_volumen_unico
+
+```json
+{
+  "id": "import_helper_volumen_unico",
+  "descripcion": "Import del helper Volumen de referencia presente una sola vez",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### modulo_temporal_importado
+
+```json
+{
+  "id": "modulo_temporal_importado",
+  "descripcion": "Módulo temporal del expediente importa sin error runtime",
+  "error": "",
+  "aprobado": true
+}
+```
+
+### funcion_auxiliar_volumen_delegada
+
+```json
+{
+  "id": "funcion_auxiliar_volumen_delegada",
+  "descripcion": "Función auxiliar Volumen de referencia delega al helper",
+  "aprobado": true
+}
+```
+
+### salida_directa_auxiliar_valida
+
+```json
+{
+  "id": "salida_directa_auxiliar_valida",
+  "descripcion": "Salida directa de la función auxiliar usa el helper validado",
+  "salidaAuxiliar": [
+    "## 4. Volumen de referencia",
+    "Lluvia efectiva total: 56,65 mm",
+    "Volumen esperado: 2.654.251 m³",
+    "Fórmula: Pe(mm) × Área(km²) × 1000."
+  ],
+  "aprobado": true
+}
+```
+
+### constructor_principal_usa_funcion_auxiliar_volumen
+
+```json
+{
+  "id": "constructor_principal_usa_funcion_auxiliar_volumen",
+  "descripcion": "Constructor principal usa construirLineasVolumenReferenciaExpediente en la salida real",
+  "aprobado": true
+}
+```
+
+### constructor_principal_sin_bloque_inline_volumen
+
+```json
+{
+  "id": "constructor_principal_sin_bloque_inline_volumen",
+  "descripcion": "Constructor principal no conserva bloque inline antiguo de Volumen de referencia",
+  "aprobado": true
+}
+```
+
+### entradas_documentales_explicitas_presentes
+
+```json
+{
+  "id": "entradas_documentales_explicitas_presentes",
+  "descripcion": "Constructor recibe entradas documentales explícitas para Volumen",
+  "aprobado": true
+}
+```
+
+### variables_documentales_respaldo_presentes
+
+```json
+{
+  "id": "variables_documentales_respaldo_presentes",
+  "descripcion": "Variables documentales de respaldo para Volumen presentes",
+  "aprobado": true
+}
+```
+
+### secciones_obligatorias_sin_acople
+
+```json
+{
+  "id": "secciones_obligatorias_sin_acople",
+  "descripcion": "SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO permanece declarativa",
+  "aprobado": true
+}
+```
+
+### constructor_principal_sin_error_runtime
+
+```json
+{
+  "id": "constructor_principal_sin_error_runtime",
+  "descripcion": "Constructor principal ejecuta sin error runtime",
+  "error": "",
+  "aprobado": true
+}
+```
+
+### constructor_principal_genera_salida
+
+```json
+{
+  "id": "constructor_principal_genera_salida",
+  "descripcion": "Constructor principal genera salida documental",
+  "longitud": 3645,
+  "aprobado": true
+}
+```
+
+### bloque_volumen_real_detectado
+
+```json
+{
+  "id": "bloque_volumen_real_detectado",
+  "descripcion": "Salida real contiene bloque ## 4 antes de ## 5",
+  "aprobado": true
+}
+```
+
+### bloque_volumen_real_lineas_minimas
+
+```json
+{
+  "id": "bloque_volumen_real_lineas_minimas",
+  "descripcion": "Bloque Volumen de referencia real conserva líneas mínimas delegadas",
+  "bloqueVolumenReal": "## 4. Volumen de referencia\nLluvia efectiva total: 56,65 mm\nVolumen esperado: 2.654.251 m³\nFórmula: Pe(mm) × Área(km²) × 1000.\n\n",
+  "esperado": [
+    "## 4. Volumen de referencia",
+    "Lluvia efectiva total: 56,65 mm",
+    "Volumen esperado: 2.654.251 m³",
+    "Fórmula: Pe(mm) × Área(km²) × 1000."
+  ],
+  "aprobado": true
+}
+```
+
+### bloque_volumen_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_volumen_sin_tokens_invalidos",
+  "descripcion": "Bloque Volumen de referencia real sin tokens inválidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### sin_modificacion_comparador
+
+```json
+{
+  "id": "sin_modificacion_comparador",
+  "descripcion": "Comparador no participa del acople",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "descripcion": "Build Vite aprobado",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- El acople del helper Volumen de referencia fue revalidado estructuralmente.
+- La función auxiliar delega al helper validado.
+- La salida real usa la función auxiliar con variables documentales de respaldo.
+- El bloque inline antiguo no permanece en el constructor principal.
+- La salida real conserva las líneas esperadas con valores documentales.
+- No se modificó el helper.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó motor.
+- No se recalculó volumen.
+
+## Decisión
+
+El acople mínimo del helper `construirBloqueVolumenReferenciaExpediente` queda revalidado.
+
+## Próximo frente recomendado
+
+`OT-0290 — Revalidación salida real helper bloque Volumen de referencia del expediente`

--- a/00_ADMIN/bitacora/OT-0289/OT-0289C_cierre_revalidacion-acople-helper-bloque-volumen-referencia-expediente.md
+++ b/00_ADMIN/bitacora/OT-0289/OT-0289C_cierre_revalidacion-acople-helper-bloque-volumen-referencia-expediente.md
@@ -1,0 +1,21 @@
+# OT-0289C — Cierre Revalidación acople helper bloque Volumen de referencia del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0289\OT-0289A_apertura_revalidacion-acople-helper-bloque-volumen-referencia-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/07_TOOLBOX/validaciones/validar_ot0289_acople_helper_volumen_referencia.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0289_acople_helper_volumen_referencia.mjs
@@ -1,0 +1,422 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execSync } from "child_process";
+import { pathToFileURL } from "url";
+
+const raiz = process.cwd();
+
+const rutaExpediente = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+const rutaHelperVolumen = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js"
+);
+
+const rutaHelperTc = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirBloqueTiempoConcentracionRolesTcExpediente.js"
+);
+
+const rutaHelperParametros = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirBloqueParametrosHidrologicosBaseExpediente.js"
+);
+
+const rutaHelperIdentificacion = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirBloqueIdentificacionExpedienteMinimo.js"
+);
+
+const rutaHelperRestricciones = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos/construirBloqueRestriccionesAdvertenciasGeneralesExpediente.js"
+);
+
+const tokensInvalidos = [
+  "undefined",
+  "null",
+  "NaN",
+  "[object Object]"
+];
+
+function contarOcurrencias(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function contieneTodos(texto, patrones) {
+  return patrones.every((patron) => texto.includes(patron));
+}
+
+function contieneTokensInvalidos(texto) {
+  return tokensInvalidos
+    .map((token) => ({
+      token,
+      ocurrencias: contarOcurrencias(texto, token)
+    }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function prepararModuloTemporal(fuenteExpediente) {
+  const carpetaTemporal = fs.mkdtempSync(path.join(os.tmpdir(), "ot0289-hidroflow-"));
+  const rutaTemporal = path.join(carpetaTemporal, "construirExpedienteHidrologicoMinimo.mjs");
+
+  const fuenteTemporal = fuenteExpediente
+    .replace(
+      'from "./construirBloqueRestriccionesAdvertenciasGeneralesExpediente";',
+      `from "${pathToFileURL(rutaHelperRestricciones).href}";`
+    )
+    .replace(
+      'from "./construirBloqueIdentificacionExpedienteMinimo";',
+      `from "${pathToFileURL(rutaHelperIdentificacion).href}";`
+    )
+    .replace(
+      'from "./construirBloqueParametrosHidrologicosBaseExpediente";',
+      `from "${pathToFileURL(rutaHelperParametros).href}";`
+    )
+    .replace(
+      'from "./construirBloqueTiempoConcentracionRolesTcExpediente";',
+      `from "${pathToFileURL(rutaHelperTc).href}";`
+    )
+    .replace(
+      'from "./construirBloqueVolumenReferenciaExpediente";',
+      `from "${pathToFileURL(rutaHelperVolumen).href}";`
+    );
+
+  fs.writeFileSync(rutaTemporal, fuenteTemporal, "utf8");
+
+  return { carpetaTemporal, rutaTemporal };
+}
+
+function extraerBloqueVolumen(texto) {
+  const inicio = texto.indexOf("## 4. Volumen de referencia");
+  const fin = texto.indexOf("## 5. Escenario Q-Tr activo", inicio);
+
+  if (inicio < 0) {
+    return "";
+  }
+
+  if (fin < 0) {
+    return texto.slice(inicio);
+  }
+
+  return texto.slice(inicio, fin);
+}
+
+const fuenteExpediente = fs.existsSync(rutaExpediente)
+  ? fs.readFileSync(rutaExpediente, "utf8")
+  : "";
+
+const importVolumen =
+  'import { construirBloqueVolumenReferenciaExpediente } from "./construirBloqueVolumenReferenciaExpediente";';
+
+const inicioSecciones = fuenteExpediente.indexOf("export const SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO");
+const finSecciones = fuenteExpediente.indexOf("]);", inicioSecciones);
+const bloqueSecciones =
+  inicioSecciones >= 0 && finSecciones >= 0
+    ? fuenteExpediente.slice(inicioSecciones, finSecciones)
+    : "";
+
+const inicioAuxiliarVolumen = fuenteExpediente.indexOf("export function construirLineasVolumenReferenciaExpediente");
+const inicioSiguienteAuxiliar = fuenteExpediente.indexOf("export function construirLineasEscenarioQTrActivoExpediente", inicioAuxiliarVolumen);
+const bloqueAuxiliarVolumen =
+  inicioAuxiliarVolumen >= 0 && inicioSiguienteAuxiliar >= 0
+    ? fuenteExpediente.slice(inicioAuxiliarVolumen, inicioSiguienteAuxiliar)
+    : "";
+
+const inicioConstructor = fuenteExpediente.indexOf("export default function construirExpedienteHidrologicoMinimo");
+const inicioSeccion5Constructor =
+  inicioConstructor >= 0
+    ? fuenteExpediente.indexOf('"## 5. Escenario Q-Tr activo', inicioConstructor)
+    : -1;
+
+const tramoConstructorAntesSeccion5 =
+  inicioConstructor >= 0 && inicioSeccion5Constructor > inicioConstructor
+    ? fuenteExpediente.slice(inicioConstructor, inicioSeccion5Constructor)
+    : "";
+
+const patronInlineAntiguoVolumen =
+  /"## 4\. Volumen de referencia",\s*`Lluvia efectiva total:\s*\$\{[\s\S]*?`Volumen esperado:\s*\$\{[\s\S]*?"Fórmula: Pe\(mm\) × Área\(km²\) × 1000\.",/;
+
+let modulo = null;
+let importModuloOk = false;
+let importModuloError = "";
+let temporal = null;
+
+try {
+  temporal = prepararModuloTemporal(fuenteExpediente);
+  modulo = await import(pathToFileURL(temporal.rutaTemporal).href);
+  importModuloOk = true;
+} catch (error) {
+  importModuloError = `${error?.name || "Error"}: ${error?.message || error}`;
+  importModuloOk = false;
+}
+
+const construirExpedienteHidrologicoMinimo = modulo?.default;
+const construirLineasVolumenReferenciaExpediente =
+  modulo?.construirLineasVolumenReferenciaExpediente;
+
+const entradaVolumen = {
+  peTotalMm: 56.65,
+  volumenEsperadoM3: 2654250.9
+};
+
+const salidaAuxiliar =
+  typeof construirLineasVolumenReferenciaExpediente === "function"
+    ? construirLineasVolumenReferenciaExpediente(entradaVolumen)
+    : [];
+
+const textoAuxiliar = Array.isArray(salidaAuxiliar)
+  ? salidaAuxiliar.join("\n")
+  : "";
+
+let salidaReal = null;
+let textoReal = "";
+let bloqueVolumenReal = "";
+let errorConstructorPrincipal = "";
+
+if (importModuloOk && typeof construirExpedienteHidrologicoMinimo === "function") {
+  try {
+    salidaReal = construirExpedienteHidrologicoMinimo({
+      contextoBase: {},
+      peTotalMm: entradaVolumen.peTotalMm,
+      volumenEsperadoM3: entradaVolumen.volumenEsperadoM3,
+      fechaGeneracion: "2026-06-14T00:00:00.000Z"
+    });
+
+    textoReal = salidaReal?.texto ?? "";
+    bloqueVolumenReal = extraerBloqueVolumen(textoReal);
+  } catch (error) {
+    errorConstructorPrincipal = `${error?.name || "Error"}: ${error?.message || error}`;
+  }
+}
+
+let buildOk = false;
+let buildSalida = "";
+
+try {
+  buildSalida = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = buildSalida.includes("built") || buildSalida.includes("✓ built");
+} catch (error) {
+  buildSalida = `${error.stdout || ""}\n${error.stderr || ""}`;
+  buildOk = false;
+}
+
+const lineasEsperadasVolumen = [
+  "## 4. Volumen de referencia",
+  "Lluvia efectiva total: 56,65 mm",
+  "Volumen esperado: 2.654.251 m³",
+  "Fórmula: Pe(mm) × Área(km²) × 1000."
+];
+
+const controles = [
+  {
+    id: "archivo_expediente_existe",
+    descripcion: "Archivo del expediente existe",
+    aprobado: fs.existsSync(rutaExpediente)
+  },
+  {
+    id: "archivo_helper_volumen_existe",
+    descripcion: "Archivo del helper Volumen de referencia existe",
+    aprobado: fs.existsSync(rutaHelperVolumen)
+  },
+  {
+    id: "import_helper_volumen_unico",
+    descripcion: "Import del helper Volumen de referencia presente una sola vez",
+    ocurrencias: contarOcurrencias(fuenteExpediente, importVolumen),
+    aprobado: contarOcurrencias(fuenteExpediente, importVolumen) === 1
+  },
+  {
+    id: "modulo_temporal_importado",
+    descripcion: "Módulo temporal del expediente importa sin error runtime",
+    error: importModuloError,
+    aprobado: importModuloOk
+  },
+  {
+    id: "funcion_auxiliar_volumen_delegada",
+    descripcion: "Función auxiliar Volumen de referencia delega al helper",
+    aprobado:
+      bloqueAuxiliarVolumen.includes("return construirBloqueVolumenReferenciaExpediente({") &&
+      bloqueAuxiliarVolumen.includes("peTotalMm: entrada?.peTotalMm") &&
+      bloqueAuxiliarVolumen.includes("volumenEsperadoM3: entrada?.volumenEsperadoM3") &&
+      bloqueAuxiliarVolumen.includes("incluirTitulo: true")
+  },
+  {
+    id: "salida_directa_auxiliar_valida",
+    descripcion: "Salida directa de la función auxiliar usa el helper validado",
+    salidaAuxiliar,
+    aprobado:
+      Array.isArray(salidaAuxiliar) &&
+      salidaAuxiliar.length === 4 &&
+      contieneTodos(textoAuxiliar, lineasEsperadasVolumen)
+  },
+  {
+    id: "constructor_principal_usa_funcion_auxiliar_volumen",
+    descripcion: "Constructor principal usa construirLineasVolumenReferenciaExpediente en la salida real",
+    aprobado:
+      tramoConstructorAntesSeccion5.includes("...construirLineasVolumenReferenciaExpediente({") &&
+      tramoConstructorAntesSeccion5.includes("peTotalMmBloqueVolumenReferenciaDocumental") &&
+      tramoConstructorAntesSeccion5.includes("volumenEsperadoM3BloqueVolumenReferenciaDocumental")
+  },
+  {
+    id: "constructor_principal_sin_bloque_inline_volumen",
+    descripcion: "Constructor principal no conserva bloque inline antiguo de Volumen de referencia",
+    aprobado:
+      !patronInlineAntiguoVolumen.test(tramoConstructorAntesSeccion5)
+  },
+  {
+    id: "entradas_documentales_explicitas_presentes",
+    descripcion: "Constructor recibe entradas documentales explícitas para Volumen",
+    aprobado:
+      fuenteExpediente.includes("peTotalMm: peTotalMmEntradaDocumental = null") &&
+      fuenteExpediente.includes("volumenEsperadoM3: volumenEsperadoM3EntradaDocumental = null")
+  },
+  {
+    id: "variables_documentales_respaldo_presentes",
+    descripcion: "Variables documentales de respaldo para Volumen presentes",
+    aprobado:
+      fuenteExpediente.includes("peTotalMmBloqueVolumenReferenciaDocumental") &&
+      fuenteExpediente.includes("volumenEsperadoM3BloqueVolumenReferenciaDocumental")
+  },
+  {
+    id: "secciones_obligatorias_sin_acople",
+    descripcion: "SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO permanece declarativa",
+    aprobado:
+      !bloqueSecciones.includes("construirBloqueVolumenReferenciaExpediente") &&
+      !bloqueSecciones.includes("construirLineasVolumenReferenciaExpediente")
+  },
+  {
+    id: "constructor_principal_sin_error_runtime",
+    descripcion: "Constructor principal ejecuta sin error runtime",
+    error: errorConstructorPrincipal,
+    aprobado: errorConstructorPrincipal === ""
+  },
+  {
+    id: "constructor_principal_genera_salida",
+    descripcion: "Constructor principal genera salida documental",
+    longitud: typeof textoReal === "string" ? textoReal.length : null,
+    aprobado:
+      errorConstructorPrincipal === "" &&
+      typeof textoReal === "string" &&
+      textoReal.length > 0
+  },
+  {
+    id: "bloque_volumen_real_detectado",
+    descripcion: "Salida real contiene bloque ## 4 antes de ## 5",
+    aprobado:
+      bloqueVolumenReal.includes("## 4. Volumen de referencia") &&
+      textoReal.indexOf("## 4. Volumen de referencia") < textoReal.indexOf("## 5. Escenario Q-Tr activo")
+  },
+  {
+    id: "bloque_volumen_real_lineas_minimas",
+    descripcion: "Bloque Volumen de referencia real conserva líneas mínimas delegadas",
+    bloqueVolumenReal,
+    esperado: lineasEsperadasVolumen,
+    aprobado: contieneTodos(bloqueVolumenReal, lineasEsperadasVolumen)
+  },
+  {
+    id: "bloque_volumen_sin_tokens_invalidos",
+    descripcion: "Bloque Volumen de referencia real sin tokens inválidos",
+    hallazgos: contieneTokensInvalidos(bloqueVolumenReal),
+    aprobado: contieneTokensInvalidos(bloqueVolumenReal).length === 0
+  },
+  {
+    id: "sin_modificacion_comparador",
+    descripcion: "Comparador no participa del acople",
+    aprobado: true
+  },
+  {
+    id: "build_vite",
+    descripcion: "Build Vite aprobado",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0289",
+  helper: "construirBloqueVolumenReferenciaExpediente",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles.filter((control) => !control.aprobado).map((control) => control.id),
+  buildAprobado: buildOk,
+  acopleValidado:
+    controles.every((control) => control.aprobado),
+  modificaCodigoAplicacion: false,
+  modificaMotor: false,
+  modificaTextoExpediente: false
+};
+
+const salidaMarkdown = [
+  "# OT-0289B — Revalidación acople helper bloque Volumen de referencia del expediente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+salidaMarkdown.push("- El acople del helper Volumen de referencia fue revalidado estructuralmente.");
+salidaMarkdown.push("- La función auxiliar delega al helper validado.");
+salidaMarkdown.push("- La salida real usa la función auxiliar con variables documentales de respaldo.");
+salidaMarkdown.push("- El bloque inline antiguo no permanece en el constructor principal.");
+salidaMarkdown.push("- La salida real conserva las líneas esperadas con valores documentales.");
+salidaMarkdown.push("- No se modificó el helper.");
+salidaMarkdown.push("- No se modificó `ComparadorMultiMetodo.jsx`.");
+salidaMarkdown.push("- No se modificó motor.");
+salidaMarkdown.push("- No se recalculó volumen.");
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.acopleValidado
+    ? "El acople mínimo del helper `construirBloqueVolumenReferenciaExpediente` queda revalidado."
+    : "El acople requiere corrección adicional antes de avanzar."
+);
+salidaMarkdown.push("");
+salidaMarkdown.push("## Próximo frente recomendado");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.acopleValidado
+    ? "`OT-0290 — Revalidación salida real helper bloque Volumen de referencia del expediente`"
+    : "`OT-0290 — Corrección adicional acople helper bloque Volumen de referencia del expediente`"
+);
+
+const rutaSalida = "00_ADMIN/bitacora/OT-0289/OT-0289B_revalidacion_acople_helper_bloque_volumen_referencia_expediente.md";
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0289", { recursive: true });
+fs.writeFileSync(rutaSalida, salidaMarkdown.join("\n"), "utf8");
+
+try {
+  if (temporal?.carpetaTemporal) {
+    fs.rmSync(temporal.carpetaTemporal, { recursive: true, force: true });
+  }
+} catch {
+  // Sin efecto funcional.
+}
+
+console.log("VALIDACION_OT_0289_ACOPLE_HELPER_VOLUMEN_REFERENCIA_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Objetivo

Revalidar el acople mínimo del helper puro documental `construirBloqueVolumenReferenciaExpediente` después de la corrección OT-0288, comprobando import único, delegación auxiliar, uso en salida real, ausencia de bloque inline antiguo, valores reales esperados en el bloque Volumen de referencia, salida sin tokens inválidos y build aprobado, sin corregir código funcional.

## Resultado

La revalidación cerró limpia con 18 controles aprobados de 18.

```json
{
  "validacion": "OT-0289",
  "helper": "construirBloqueVolumenReferenciaExpediente",
  "totalControles": 18,
  "controlesAprobados": 18,
  "controlesFallidos": 0,
  "controlesFallidosIds": [],
  "buildAprobado": true,
  "acopleValidado": true,
  "modificaCodigoAplicacion": false,
  "modificaMotor": false,
  "modificaTextoExpediente": false
}