### PR TITLE
OT-0299 — Acople helper Escenario Q-Tr

### DIFF
--- a/00_ADMIN/bitacora/OT-0299/OT-0299A_apertura_acople-minimo-helper-bloque-escenario-qtr-activo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0299/OT-0299A_apertura_acople-minimo-helper-bloque-escenario-qtr-activo-expediente.md
@@ -1,0 +1,59 @@
+# OT-0299A — Acople mínimo helper bloque Escenario Q-Tr activo del expediente
+
+## Objetivo
+
+Acoplar de forma mínima y quirúrgica el helper puro construirBloqueEscenarioQTrActivoExpediente al constructor del expediente hidrológico mínimo, mediante import único, función auxiliar delegada y sustitución del bloque inline actual, sin modificar helper, comparador ni motor, y sin recalcular Q-Tr.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional existente.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir otros códigos funcionales en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- Corregir únicamente el acople del bloque Escenario Q-Tr activo.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0300 — Validación acople helper bloque Escenario Q-Tr activo del expediente

--- a/00_ADMIN/bitacora/OT-0299/OT-0299B_acople_minimo_helper_bloque_escenario_qtr_activo_expediente.md
+++ b/00_ADMIN/bitacora/OT-0299/OT-0299B_acople_minimo_helper_bloque_escenario_qtr_activo_expediente.md
@@ -1,0 +1,98 @@
+# OT-0299B — Acople mínimo helper bloque Escenario Q-Tr activo del expediente
+
+## Objetivo
+
+Acoplar de forma mínima y quirúrgica el helper puro `construirBloqueEscenarioQTrActivoExpediente` al constructor del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0298 diseñó el punto de acople futuro del helper Q-Tr y autorizó avanzar al acople mínimo en una OT explícita.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Helper acoplado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js
+```
+
+## Cambios aplicados
+
+Se agregó import único del helper:
+
+```javascript
+import { construirBloqueEscenarioQTrActivoExpediente } from "./construirBloqueEscenarioQTrActivoExpediente";
+```
+
+Se agregó o sustituyó la función auxiliar delegada:
+
+```javascript
+export function construirLineasEscenarioQTrActivoExpediente(entrada = {}) {
+  return construirBloqueEscenarioQTrActivoExpediente({
+    estadoQTrActivoExpediente: entrada?.estadoQTrActivoExpediente,
+    qTrActivoExpediente: entrada?.qTrActivoExpediente,
+    faltantesQTrActivoExpediente: entrada?.faltantesQTrActivoExpediente,
+    trDisenoActivoExpediente: entrada?.trDisenoActivoExpediente,
+    incluirTitulo: true
+  });
+}
+```
+
+Se sustituyó el bloque inline antiguo por llamada a la función auxiliar:
+
+```javascript
+...construirLineasEscenarioQTrActivoExpediente({
+  estadoQTrActivoExpediente: contextoBase?.q_tr_activo_estado?.estado,
+  qTrActivoExpediente: contextoBase?.q_tr_activo,
+  faltantesQTrActivoExpediente: contextoBase?.q_tr_activo_faltantes,
+  trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
+}),
+```
+
+## Alcance técnico
+
+No se modificó el helper `construirBloqueEscenarioQTrActivoExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se recalculó Q-Tr.
+
+No se seleccionó Tr adoptado.
+
+No se tocó Q-5.
+
+No se tocó Método Racional.
+
+No se tocó diagnóstico Q(t).
+
+## Validación en esta OT
+
+Se ejecuta build de producción como control de sintaxis/proyecto.
+
+La validación formal del acople queda reservada para OT-0300.
+
+## Próximo frente recomendado
+
+`OT-0300 — Validación acople helper bloque Escenario Q-Tr activo del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirBloqueEscenarioQTrActivoExpediente.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se recalculó `Tc`.
+- No se recalculó Q-Tr.
+- No se seleccionó Tr adoptado.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr funcionalmente, Q-5, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0299/OT-0299C_cierre_acople-minimo-helper-bloque-escenario-qtr-activo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0299/OT-0299C_cierre_acople-minimo-helper-bloque-escenario-qtr-activo-expediente.md
@@ -1,0 +1,21 @@
+# OT-0299C — Cierre Acople mínimo helper bloque Escenario Q-Tr activo del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0299\OT-0299A_apertura_acople-minimo-helper-bloque-escenario-qtr-activo-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -3,6 +3,7 @@ import { construirBloqueIdentificacionExpedienteMinimo } from "./construirBloque
 import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construirBloqueParametrosHidrologicosBaseExpediente";
 import { construirBloqueTiempoConcentracionRolesTcExpediente } from "./construirBloqueTiempoConcentracionRolesTcExpediente";
 import { construirBloqueVolumenReferenciaExpediente } from "./construirBloqueVolumenReferenciaExpediente";
+import { construirBloqueEscenarioQTrActivoExpediente } from "./construirBloqueEscenarioQTrActivoExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -240,9 +241,12 @@ export default function construirExpedienteHidrologicoMinimo({
       volumenEsperadoM3: volumenEsperadoM3BloqueVolumenReferenciaDocumental
     }),
     "",
-    "## 5. Escenario Q-Tr activo — control de trazabilidad",
-    `Estado: ${contextoBase?.q_tr_activo_estado?.estado ?? "no_publicado"}`,
-    "Lectura técnica: bloque reservado para integración posterior sin recálculo.",
+    ...construirLineasEscenarioQTrActivoExpediente({
+      estadoQTrActivoExpediente: contextoBase?.q_tr_activo_estado?.estado,
+      qTrActivoExpediente: contextoBase?.q_tr_activo,
+      faltantesQTrActivoExpediente: contextoBase?.q_tr_activo_faltantes,
+      trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
+    }),
     "",
     "## 6. Resumen Q-5 auditado",
     `Métodos recibidos: ${Array.isArray(metodos) ? metodos.length : 0}`,
@@ -346,94 +350,14 @@ export function construirLineasVolumenReferenciaExpediente(entrada = {}) {
 }
 
 export function construirLineasEscenarioQTrActivoExpediente(entrada = {}) {
-  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
-
-  const {
-    estadoQTrActivoExpediente = {},
-    qTrActivoExpediente = {},
-    faltantesQTrActivoExpediente = [],
-    formatearValorQTrExpediente
-  } = entradaSegura;
-
-  const normalizarTexto = (valor, fallback = "—") => {
-    if (valor === undefined || valor === null) {
-      return fallback;
-    }
-
-    if (typeof valor === "string" && valor.trim().length === 0) {
-      return fallback;
-    }
-
-    if (typeof valor === "object") {
-      return fallback;
-    }
-
-    return String(valor);
-  };
-
-  const formatearValorSeguro = (valor, unidad = "", decimales) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "string" && valor.trim().length === 0) {
-      return "—";
-    }
-
-    if (typeof valor === "object") {
-      return "—";
-    }
-
-    const numero = Number(valor);
-
-    if (Number.isFinite(numero) && typeof decimales === "number") {
-      return `${numero.toFixed(decimales)}${unidad}`;
-    }
-
-    if (Number.isFinite(numero) && typeof valor === "number") {
-      return `${numero}${unidad}`;
-    }
-
-    if (typeof valor === "string") {
-      return valor;
-    }
-
-    return "—";
-  };
-
-  const formatear = (valor, unidad = "", decimales) => {
-    if (typeof formatearValorQTrExpediente === "function") {
-      const formateado = formatearValorQTrExpediente(valor, unidad, decimales);
-      return normalizarTexto(formateado);
-    }
-
-    return formatearValorSeguro(valor, unidad, decimales);
-  };
-
-  const faltantes = Array.isArray(faltantesQTrActivoExpediente)
-    ? faltantesQTrActivoExpediente.filter((item) => normalizarTexto(item, "").length > 0)
-    : [];
-
-  return [
-    "## 5. Escenario Q-Tr activo — control de trazabilidad",
-    `Estado: ${normalizarTexto(estadoQTrActivoExpediente?.estado, "no_publicado")}`,
-    `Tr activo: ${formatear(qTrActivoExpediente?.tr_activo, " años", 2)}`,
-    `Estación IDF: ${formatear(qTrActivoExpediente?.estacion_idf)}`,
-    `Método IDF: ${formatear(qTrActivoExpediente?.metodo_idf)}`,
-    `Distribución temporal: ${formatear(qTrActivoExpediente?.distribucion_temporal)}`,
-    `Área: ${formatear(qTrActivoExpediente?.area_km2, " km²", 4)}`,
-    `CN efectivo: ${formatear(qTrActivoExpediente?.cn_efectivo, "", 2)}`,
-    `S: ${formatear(qTrActivoExpediente?.s_mm, " mm", 2)}`,
-    `Ia: ${formatear(qTrActivoExpediente?.ia_mm, " mm", 2)}`,
-    `Impermeabilidad: ${formatear(qTrActivoExpediente?.porcentaje_impermeable, " %", 2)}`,
-    `Tc: ${formatear(qTrActivoExpediente?.tc_min, " min", 4)}`,
-    `Pe total: ${formatear(qTrActivoExpediente?.lluvia_efectiva_total_mm, " mm", 4)}`,
-    `Campos mínimos: ${faltantes.length > 0 ? "faltantes — " + faltantes.join(", ") : "completos"}`,
-    `Fuente: ${normalizarTexto(estadoQTrActivoExpediente?.fuente)}`,
-    "Lectura técnica: bloque no adoptivo; no recalcula caudales, no modifica Q-5 y queda subordinado a validación hidrológica del expediente."
-  ];
+  return construirBloqueEscenarioQTrActivoExpediente({
+    estadoQTrActivoExpediente: entrada?.estadoQTrActivoExpediente,
+    qTrActivoExpediente: entrada?.qTrActivoExpediente,
+    faltantesQTrActivoExpediente: entrada?.faltantesQTrActivoExpediente,
+    trDisenoActivoExpediente: entrada?.trDisenoActivoExpediente,
+    incluirTitulo: true
+  });
 }
-
 export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
   const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
 
@@ -480,6 +404,7 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     ""
   ];
 }
+
 
 
 


### PR DESCRIPTION
## Objetivo

Acoplar de forma mínima y quirúrgica el helper puro `construirBloqueEscenarioQTrActivoExpediente` al constructor del expediente hidrológico mínimo.

## Antecedente

OT-0298 diseñó el punto de acople futuro del helper Q-Tr y autorizó avanzar al acople mínimo en una OT explícita.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js