### PR TITLE
OT-0306 — Implementación helper Resumen Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0306/OT-0306A_apertura_implementacion-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0306/OT-0306A_apertura_implementacion-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,66 @@
+# OT-0306A — Implementación helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Implementar de forma aislada el helper puro documental construirBloqueResumenQ5AuditadoExpediente para el bloque Resumen Q-5 auditado del expediente hidrológico mínimo, sin acoplarlo al constructor principal, sin modificar comparador ni motor, sin recalcular Q-5 y sin reinterpretar resultados Q-5.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- Crear únicamente el helper construirBloqueResumenQ5AuditadoExpediente.js como archivo funcional nuevo.
+- No modificar helpers existentes.
+- No modificar validadores existentes.
+- No modificar el acople de restricciones y advertencias.
+- No automatizar commits.
+- No corregir código funcional existente en esta OT.
+- No implementar acople al constructor principal.
+- No acoplar nuevos helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado en el constructor.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0307 — Validación aislada helper bloque Resumen Q-5 auditado del expediente

--- a/00_ADMIN/bitacora/OT-0306/OT-0306B_implementacion_helper_bloque_resumen_q5_auditado_expediente.md
+++ b/00_ADMIN/bitacora/OT-0306/OT-0306B_implementacion_helper_bloque_resumen_q5_auditado_expediente.md
@@ -1,0 +1,104 @@
+# OT-0306B — Implementación helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Implementar de forma aislada el helper puro documental `construirBloqueResumenQ5AuditadoExpediente`.
+
+## Antecedente
+
+OT-0305 diseñó documentalmente el helper del bloque `Resumen Q-5 auditado`.
+
+## Archivo funcional creado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
+```
+
+## Exportaciones implementadas
+
+El archivo exporta:
+
+```javascript
+export function construirBloqueResumenQ5AuditadoExpediente(entrada = {})
+export function contarMetodosQ5Documentales(metodosQ5)
+export function formatearValorResumenQ5Documental(valor)
+export function normalizarEstadoResumenQ5AuditadoDocumental(valor)
+```
+
+## Comportamiento implementado
+
+El helper:
+
+- devuelve `string[]`;
+- permite título opcional mediante `incluirTitulo`;
+- cuenta métodos Q-5 solo si `metodosQ5` es arreglo;
+- usa fallback `0` para métodos recibidos cuando no hay arreglo;
+- usa estado fallback `sección contractual inicial del helper puro`;
+- usa fallback `—` para valores ausentes;
+- no muta entrada;
+- no accede a DOM;
+- no accede a portapapeles;
+- no usa estado global;
+- no recalcula Q-5;
+- no recalcula hidrogramas;
+- no reinterpreta resultados Q-5;
+- no selecciona método Q-5 adoptado;
+- no selecciona caudal Q-5 adoptado;
+- no toca motor;
+- no toca Q-Tr;
+- no toca Método Racional;
+- no toca diagnóstico Q(t).
+
+## Salida mínima esperada
+
+Con entrada vacía produce:
+
+```text
+## 6. Resumen Q-5 auditado
+Métodos recibidos: 0
+Estado: sección contractual inicial del helper puro
+```
+
+## Alcance técnico
+
+No se acopló el helper al constructor principal.
+
+No se modificó `construirExpedienteHidrologicoMinimo.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se seleccionó método Q-5 adoptado.
+
+No se seleccionó caudal Q-5 adoptado.
+
+## Validación en esta OT
+
+La validación formal aislada queda reservada para OT-0307.
+
+## Próximo frente recomendado
+
+`OT-0307 — Validación aislada helper bloque Resumen Q-5 auditado del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se acopló helper.
+- No se recalculó `Tc`.
+- No se recalculó Q-Tr.
+- No se recalculó Q-5.
+- No se reinterpretaron resultados Q-5.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr funcionalmente, Q-5 funcionalmente, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0306/OT-0306C_cierre_implementacion-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0306/OT-0306C_cierre_implementacion-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,21 @@
+# OT-0306C — Cierre Implementación helper bloque Resumen Q-5 auditado del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0306\OT-0306A_apertura_implementacion-helper-bloque-resumen-q5-auditado-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
@@ -1,0 +1,110 @@
+const FALLBACK_TEXTO_RESUMEN_Q5 = "—";
+const ESTADO_RESUMEN_Q5_INICIAL =
+  "sección contractual inicial del helper puro";
+
+export function contarMetodosQ5Documentales(metodosQ5) {
+  return Array.isArray(metodosQ5) ? metodosQ5.length : 0;
+}
+
+export function formatearValorResumenQ5Documental(valor) {
+  if (valor === undefined || valor === null) {
+    return FALLBACK_TEXTO_RESUMEN_Q5;
+  }
+
+  if (typeof valor === "string") {
+    const valorLimpio = valor.trim();
+    return valorLimpio.length > 0 ? valorLimpio : FALLBACK_TEXTO_RESUMEN_Q5;
+  }
+
+  if (typeof valor === "number") {
+    return Number.isFinite(valor) ? String(valor) : FALLBACK_TEXTO_RESUMEN_Q5;
+  }
+
+  if (typeof valor === "boolean") {
+    return valor ? "sí" : "no";
+  }
+
+  return FALLBACK_TEXTO_RESUMEN_Q5;
+}
+
+export function normalizarEstadoResumenQ5AuditadoDocumental(valor) {
+  if (valor === undefined || valor === null) {
+    return ESTADO_RESUMEN_Q5_INICIAL;
+  }
+
+  if (typeof valor === "string") {
+    const valorLimpio = valor.trim();
+    return valorLimpio.length > 0 ? valorLimpio : ESTADO_RESUMEN_Q5_INICIAL;
+  }
+
+  if (typeof valor === "number" || typeof valor === "boolean") {
+    return String(valor);
+  }
+
+  if (typeof valor === "object") {
+    const estado =
+      valor.estado ??
+      valor.status ??
+      valor.valor ??
+      valor.codigo ??
+      undefined;
+
+    return normalizarEstadoResumenQ5AuditadoDocumental(estado);
+  }
+
+  return ESTADO_RESUMEN_Q5_INICIAL;
+}
+
+function normalizarEntradaResumenQ5(entrada = {}) {
+  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
+
+  const metodosQ5 = Array.isArray(entradaSegura.metodosQ5)
+    ? [...entradaSegura.metodosQ5]
+    : [];
+
+  const faltantesResumenQ5AuditadoExpediente = Array.isArray(
+    entradaSegura.faltantesResumenQ5AuditadoExpediente
+  )
+    ? [...entradaSegura.faltantesResumenQ5AuditadoExpediente]
+    : [];
+
+  return {
+    metodosQ5,
+    cantidadMetodosQ5: contarMetodosQ5Documentales(metodosQ5),
+    estadoResumenQ5AuditadoExpediente:
+      normalizarEstadoResumenQ5AuditadoDocumental(
+        entradaSegura.estadoResumenQ5AuditadoExpediente
+      ),
+    faltantesResumenQ5AuditadoExpediente
+  };
+}
+
+export function construirBloqueResumenQ5AuditadoExpediente(entrada = {}) {
+  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
+  const incluirTitulo = entradaSegura.incluirTitulo !== false;
+
+  const {
+    cantidadMetodosQ5,
+    estadoResumenQ5AuditadoExpediente,
+    faltantesResumenQ5AuditadoExpediente
+  } = normalizarEntradaResumenQ5(entradaSegura);
+
+  const lineas = [];
+
+  if (incluirTitulo) {
+    lineas.push("## 6. Resumen Q-5 auditado");
+  }
+
+  lineas.push(`Métodos recibidos: ${cantidadMetodosQ5}`);
+  lineas.push(`Estado: ${estadoResumenQ5AuditadoExpediente}`);
+
+  if (faltantesResumenQ5AuditadoExpediente.length > 0) {
+    lineas.push(
+      `Faltantes documentales: ${faltantesResumenQ5AuditadoExpediente
+        .map((faltante) => formatearValorResumenQ5Documental(faltante))
+        .join(", ")}`
+    );
+  }
+
+  return lineas;
+}


### PR DESCRIPTION
## Objetivo

Implementar de forma aislada el helper puro documental `construirBloqueResumenQ5AuditadoExpediente` para el bloque `Resumen Q-5 auditado` del expediente hidrológico mínimo.

## Antecedente

OT-0305 diseñó documentalmente el helper del bloque `Resumen Q-5 auditado`.

El diseño definió nombre, archivo futuro, firma, entradas, salida mínima, fallbacks, exportaciones futuras, restricciones técnicas y validación aislada esperada, sin implementar código funcional.

## Archivo funcional creado

```text
01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js