### PR TITLE
OT-0309 — Decisión integración helper Resumen Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0309/OT-0309A_apertura_decision-integracion-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0309/OT-0309A_apertura_decision-integracion-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,68 @@
+# OT-0309A — Decisión integración helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Documentar la decisión de integrar posteriormente el helper puro construirBloqueResumenQ5AuditadoExpediente al expediente hidrológico mínimo, con base en el contrato, diseño, implementación aislada y validación aislada con criterio ajustado, sin acoplar todavía el helper ni modificar código funcional.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No corregir código funcional en esta OT.
+- No implementar acople al constructor principal.
+- No acoplar nuevos helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+- Crear únicamente documentación OT-0309.
+
+## Próximo frente recomendado
+
+OT-0310 — Diseño punto acople helper bloque Resumen Q-5 auditado del expediente

--- a/00_ADMIN/bitacora/OT-0309/OT-0309B_decision_integracion_helper_bloque_resumen_q5_auditado_expediente.md
+++ b/00_ADMIN/bitacora/OT-0309/OT-0309B_decision_integracion_helper_bloque_resumen_q5_auditado_expediente.md
@@ -1,0 +1,176 @@
+# OT-0309B — Decisión integración helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Documentar la decisión de integrar posteriormente el helper puro `construirBloqueResumenQ5AuditadoExpediente` al expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0303 seleccionó el bloque `Resumen Q-5 auditado` como siguiente bloque documental del expediente hidrológico mínimo.
+
+OT-0304 definió el contrato documental del bloque.
+
+OT-0305 diseñó el helper puro `construirBloqueResumenQ5AuditadoExpediente`.
+
+OT-0306 implementó el helper de forma aislada.
+
+OT-0307 ejecutó una primera validación aislada con un hallazgo en el criterio de aislamiento frente al constructor.
+
+OT-0308 ajustó el criterio de validación y cerró con validación limpia del helper en aislamiento.
+
+## Evidencia principal
+
+OT-0308 cerró con:
+
+```json
+{
+  "validacion": "OT-0308",
+  "helper": "construirBloqueResumenQ5AuditadoExpediente",
+  "totalControles": 20,
+  "controlesAprobados": 20,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "buildAprobado": true,
+  "helperValidadoAislado": true,
+  "observacionesNoBloqueantes": 2,
+  "modificaCodigoAplicacion": false,
+  "modificaMotor": false,
+  "modificaTextoExpediente": false
+}
+```
+
+## Evidencia de criterio ajustado
+
+OT-0308 confirmó que el constructor no importa ni usa el helper nuevo:
+
+```json
+{
+  "id": "constructor_sin_acople_helper_nuevo_resumen_q5",
+  "descripcion": "Constructor principal no importa ni usa todavía el helper nuevo construirBloqueResumenQ5AuditadoExpediente",
+  "ocurrenciasHelperNuevoEnConstructor": 0,
+  "ocurrenciasAuxiliarPreexistenteEnConstructor": 1,
+  "aprobado": true
+}
+```
+
+## Estado del helper
+
+El helper queda en estado:
+
+```text
+VALIDADO EN AISLAMIENTO
+```
+
+## Decisión
+
+Se aprueba avanzar hacia la integración futura del helper `construirBloqueResumenQ5AuditadoExpediente` al expediente hidrológico mínimo.
+
+Esta decisión no acopla el helper.
+
+Esta decisión no modifica el constructor principal.
+
+Esta decisión no modifica el helper.
+
+Esta decisión no modifica comparador.
+
+Esta decisión no modifica motor.
+
+Esta decisión no recalcula Q-5.
+
+Esta decisión no reinterpreta resultados Q-5.
+
+Esta decisión no selecciona método Q-5 adoptado.
+
+Esta decisión no selecciona caudal Q-5 adoptado.
+
+## Condición para integración futura
+
+Antes del acople funcional, debe diseñarse explícitamente el punto de acople.
+
+El diseño del acople deberá definir:
+
+- import futuro del helper;
+- función auxiliar delegada dentro del constructor si aplica;
+- sustitución o delegación del bloque inline actual `Resumen Q-5 auditado`;
+- conservación del orden documental;
+- ausencia de contaminación de `SECCIONES_OBLIGATORIAS_EXPEDIENTE_MINIMO`;
+- preservación de la función preexistente si aplica o sustitución controlada;
+- validaciones estructurales mínimas;
+- límites de no recálculo Q-5;
+- límites de no reinterpretación Q-5;
+- límites de no selección de método o caudal adoptado.
+
+## Frontera mantenida
+
+La decisión de integración futura no autoriza:
+
+- acoplar el helper en esta OT;
+- modificar `construirExpedienteHidrologicoMinimo.js`;
+- modificar `construirBloqueResumenQ5AuditadoExpediente.js`;
+- modificar `ComparadorMultiMetodo.jsx`;
+- modificar motor;
+- recalcular Q-5;
+- reinterpretar resultados Q-5;
+- seleccionar método Q-5 adoptado;
+- seleccionar caudal Q-5 adoptado;
+- tocar Q-Tr;
+- tocar Método Racional;
+- tocar diagnóstico Q(t);
+- emitir dictamen hidrológico.
+
+## Próximo frente recomendado
+
+`OT-0310 — Diseño punto acople helper bloque Resumen Q-5 auditado del expediente`
+
+## Alcance mantenido
+
+No se implementa ningún cambio funcional en esta OT.
+
+No se modifica `construirBloqueResumenQ5AuditadoExpediente.js`.
+
+No se modifica `construirExpedienteHidrologicoMinimo.js`.
+
+No se modifica `ComparadorMultiMetodo.jsx`.
+
+No se modifica motor.
+
+No se recalcula `Tc`.
+
+No se recalcula Q-Tr.
+
+No se recalcula Q-5.
+
+No se reinterpretan resultados Q-5.
+
+No se selecciona método Q-5 adoptado.
+
+No se selecciona caudal Q-5 adoptado.
+
+No se recalcula volumen.
+
+No se modifica `Tc_final`.
+
+No se emite dictamen hidrológico.
+
+No se tocan Q-Tr funcionalmente, Q-5 funcionalmente, Método Racional ni diagnóstico Q(t).
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirExpedienteHidrologicoMinimo.js`.
+- No se modificó `construirBloqueResumenQ5AuditadoExpediente.js`.
+- No se modificaron helpers existentes.
+- No se modificaron validadores existentes.
+- No se acopló helper.
+- No se recalculó `Tc`.
+- No se recalculó Q-Tr.
+- No se recalculó Q-5.
+- No se reinterpretaron resultados Q-5.
+- No se seleccionó método Q-5 adoptado.
+- No se seleccionó caudal Q-5 adoptado.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr funcionalmente, Q-5 funcionalmente, Método Racional ni diagnóstico Q(t).

--- a/00_ADMIN/bitacora/OT-0309/OT-0309C_cierre_decision-integracion-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0309/OT-0309C_cierre_decision-integracion-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,21 @@
+# OT-0309C — Cierre Decisión integración helper bloque Resumen Q-5 auditado del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0309\OT-0309A_apertura_decision-integracion-helper-bloque-resumen-q5-auditado-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.


### PR DESCRIPTION
## Objetivo

Documentar la decisión de integrar posteriormente el helper puro `construirBloqueResumenQ5AuditadoExpediente` al expediente hidrológico mínimo.

## Antecedente

OT-0303 seleccionó el bloque `Resumen Q-5 auditado` como siguiente bloque documental del expediente hidrológico mínimo.

OT-0304 definió el contrato documental del bloque.

OT-0305 diseñó el helper puro `construirBloqueResumenQ5AuditadoExpediente`.

OT-0306 implementó el helper de forma aislada.

OT-0307 ejecutó una primera validación aislada con un hallazgo en el criterio de aislamiento frente al constructor.

OT-0308 ajustó el criterio de validación y cerró con validación limpia del helper en aislamiento.

## Evidencia principal

OT-0308 cerró con:

```json
{
  "validacion": "OT-0308",
  "helper": "construirBloqueResumenQ5AuditadoExpediente",
  "totalControles": 20,
  "controlesAprobados": 20,
  "controlesFallidos": 0,
  "controlesFallidosIds": [],
  "buildAprobado": true,
  "helperValidadoAislado": true,
  "observacionesNoBloqueantes": 2,
  "modificaCodigoAplicacion": false,
  "modificaMotor": false,
  "modificaTextoExpediente": false
}