### PR TITLE
OT-0311 — Acople helper Resumen Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0311/OT-0311A_apertura_acople-minimo-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0311/OT-0311A_apertura_acople-minimo-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,66 @@
+# OT-0311A — Acople mínimo helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Acoplar de forma mínima y quirúrgica el helper puro construirBloqueResumenQ5AuditadoExpediente al constructor del expediente hidrológico mínimo, sustituyendo la función auxiliar preexistente por una delegación controlada al helper, sin modificar el helper, sin modificar comparador ni motor, sin recalcular Q-5 y sin reinterpretar resultados Q-5.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- Modificar únicamente construirExpedienteHidrologicoMinimo.js como archivo funcional existente.
+- No modificar construirBloqueIdentificacionExpedienteMinimo.js.
+- No modificar construirBloqueParametrosHidrologicosBaseExpediente.js.
+- No modificar construirBloqueTiempoConcentracionRolesTcExpediente.js.
+- No modificar construirBloqueVolumenReferenciaExpediente.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper en esta OT.
+- No crear archivo funcional nuevo en esta OT.
+- No modificar validadores existentes.
+- No automatizar commits.
+- No corregir código funcional no relacionado en esta OT.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- Modificar solo el acople del bloque Resumen Q-5 auditado.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0312 — Validación acople helper bloque Resumen Q-5 auditado del expediente

--- a/00_ADMIN/bitacora/OT-0311/OT-0311B_acople_minimo_helper_bloque_resumen_q5_auditado_expediente.md
+++ b/00_ADMIN/bitacora/OT-0311/OT-0311B_acople_minimo_helper_bloque_resumen_q5_auditado_expediente.md
@@ -1,0 +1,122 @@
+# OT-0311B — Acople mínimo helper bloque Resumen Q-5 auditado del expediente
+
+## Objetivo
+
+Acoplar de forma mínima y quirúrgica el helper puro `construirBloqueResumenQ5AuditadoExpediente` al constructor del expediente hidrológico mínimo.
+
+## Antecedente
+
+OT-0310 diseñó el punto de acople futuro del helper `construirBloqueResumenQ5AuditadoExpediente`.
+
+## Archivo funcional modificado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+```
+
+## Helper acoplado
+
+```text
+01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
+```
+
+## Cambios aplicados
+
+Se agregó import único del helper:
+
+```javascript
+import { construirBloqueResumenQ5AuditadoExpediente } from "./construirBloqueResumenQ5AuditadoExpediente";
+```
+
+Se sustituyó la función auxiliar preexistente por una delegación al helper:
+
+```javascript
+export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
+  return construirBloqueResumenQ5AuditadoExpediente({
+    metodosQ5: entrada?.metodosQ5 ?? entrada?.metodos,
+    estadoResumenQ5AuditadoExpediente: entrada?.estadoResumenQ5AuditadoExpediente,
+    faltantesResumenQ5AuditadoExpediente: entrada?.faltantesResumenQ5AuditadoExpediente,
+    incluirTitulo: true
+  });
+}
+```
+
+## Nota de compatibilidad
+
+La delegación acepta `entrada?.metodosQ5` y conserva compatibilidad documental con `entrada?.metodos` como fuente preexistente.
+
+Esto evita recalcular Q-5 y evita modificar llamadas existentes más allá de la delegación mínima.
+
+## Alcance técnico
+
+No se modificó el helper `construirBloqueResumenQ5AuditadoExpediente.js`.
+
+No se modificó `ComparadorMultiMetodo.jsx`.
+
+No se modificó motor.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se seleccionó método Q-5 adoptado.
+
+No se seleccionó caudal Q-5 adoptado.
+
+No se tocó Q-Tr.
+
+No se tocó Método Racional.
+
+No se tocó diagnóstico Q(t).
+
+## Validación en esta OT
+
+Se ejecuta build de producción como control de sintaxis/proyecto.
+
+La validación formal del acople queda reservada para OT-0312.
+
+## Próximo frente recomendado
+
+`OT-0312 — Validación acople helper bloque Resumen Q-5 auditado del expediente`
+
+## Restricciones mantenidas
+
+- No se modificó motor.
+- No se modificó UI.
+- No se modificó `textoExpediente`.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó `construirBloqueResumenQ5AuditadoExpediente.js`.
+- No se modificaron helpers existentes fuera del constructor.
+- No se modificaron validadores existentes.
+- No se recalculó `Tc`.
+- No se recalculó Q-Tr.
+- No se recalculó Q-5.
+- No se reinterpretaron resultados Q-5.
+- No se seleccionó método Q-5 adoptado.
+- No se seleccionó caudal Q-5 adoptado.
+- No se recalculó volumen.
+- No se emitió dictamen hidrológico.
+- No se tocaron Q-Tr funcionalmente, Q-5 funcionalmente, Método Racional ni diagnóstico Q(t).
+
+## Nota de recuperación pre-commit
+
+Durante el acople mínimo se detectaron intentos iniciales de sustitución parcial de la función auxiliar `construirLineasResumenQ5AuditadoExpediente`, que dejaban sintaxis inválida en el constructor.
+
+La recuperación se realizó antes de commit mediante:
+
+- restauración de `construirExpedienteHidrologicoMinimo.js` desde HEAD;
+- reescritura del script de acople para sustituir la función auxiliar desde su inicio hasta el siguiente export o fin de archivo;
+- reaplicación del acople con controles defensivos;
+- validación posterior mediante build.
+
+La versión final conserva:
+
+- import único del helper;
+- función auxiliar delegada limpia;
+- uso de la función auxiliar en la salida real;
+- sin duplicación del archivo;
+- sin patrón inválido `}) {`;
+- sin modificación del helper;
+- sin modificación del comparador;
+- sin modificación del motor.
+

--- a/00_ADMIN/bitacora/OT-0311/OT-0311C_cierre_acople-minimo-helper-bloque-resumen-q5-auditado-expediente.md
+++ b/00_ADMIN/bitacora/OT-0311/OT-0311C_cierre_acople-minimo-helper-bloque-resumen-q5-auditado-expediente.md
@@ -1,0 +1,21 @@
+# OT-0311C — Cierre Acople mínimo helper bloque Resumen Q-5 auditado del expediente
+
+## Resultado
+
+Se creó la estructura documental mínima para la OT.
+
+## Evidencia principal
+
+Documento de apertura:
+
+```text
+00_ADMIN\bitacora\OT-0311\OT-0311A_apertura_acople-minimo-helper-bloque-resumen-q5-auditado-expediente.md
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+## Decisión
+
+Cualquier avance posterior debe realizarse mediante una OT explícita.

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -4,6 +4,7 @@ import { construirBloqueParametrosHidrologicosBaseExpediente } from "./construir
 import { construirBloqueTiempoConcentracionRolesTcExpediente } from "./construirBloqueTiempoConcentracionRolesTcExpediente";
 import { construirBloqueVolumenReferenciaExpediente } from "./construirBloqueVolumenReferenciaExpediente";
 import { construirBloqueEscenarioQTrActivoExpediente } from "./construirBloqueEscenarioQTrActivoExpediente";
+import { construirBloqueResumenQ5AuditadoExpediente } from "./construirBloqueResumenQ5AuditadoExpediente";
 // OT-0110B — Helper puro inicial del expediente hidrológico mínimo.
 // Este helper NO está integrado todavía al botón de copiado.
 // No modifica UI, no copia al portapapeles, no recalcula hidrogramas y no toca motor.
@@ -248,9 +249,10 @@ export default function construirExpedienteHidrologicoMinimo({
       trDisenoActivoExpediente: trDisenoActivoExpedienteDocumental
     }),
     "",
-    "## 6. Resumen Q-5 auditado",
-    `Métodos recibidos: ${Array.isArray(metodos) ? metodos.length : 0}`,
-    "Estado: sección contractual inicial del helper puro.",
+    ...construirLineasResumenQ5AuditadoExpediente({
+      metodosQ5: metodos,
+      estadoResumenQ5AuditadoExpediente: "sección contractual inicial del helper puro"
+    }),
     "",
     "## 7. Método Racional — contraste global independiente",
     "Uso: contraste global independiente de caudal pico.",
@@ -359,55 +361,10 @@ export function construirLineasEscenarioQTrActivoExpediente(entrada = {}) {
   });
 }
 export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
-  const entradaSegura = entrada && typeof entrada === "object" ? entrada : {};
-
-  const { tablaQ5Markdown = [] } = entradaSegura;
-
-  const normalizarLinea = (valor) => {
-    if (valor === undefined || valor === null) {
-      return "—";
-    }
-
-    if (typeof valor === "string") {
-      return valor;
-    }
-
-    if (typeof valor === "number" && Number.isFinite(valor)) {
-      return String(valor);
-    }
-
-    return "—";
-  };
-
-  const tabla = Array.isArray(tablaQ5Markdown)
-    ? tablaQ5Markdown
-        .map((linea) => normalizarLinea(linea))
-        .filter((linea) => linea.trim().length > 0)
-    : [];
-
-  const lineasTabla = tabla.length > 0
-    ? tabla
-    : ["sin tabla Q-5 disponible"];
-
-  return [
-    "## 6. Resumen Q-5 auditado",
-    "Estado general: diagnóstico no adoptivo.",
-    "SCS Unit Hydrograph: candidato principal de referencia.",
-    "SCS Mod.: variante ajustable.",
-    "Snyder, Williams & Hann y Clark IUH: métodos comparativos/referenciales.",
-    "Masa y volumen: controlados frente a referencia física.",
-    "Qp y Tp: sujetos a revisión temporal antes de adopción técnica.",
-    "",
-    "Tabla Q-5 auditada:",
-    ...lineasTabla,
-    "",
-    ""
-  ];
+  return construirBloqueResumenQ5AuditadoExpediente({
+    metodosQ5: entrada?.metodosQ5 ?? entrada?.metodos,
+    estadoResumenQ5AuditadoExpediente: entrada?.estadoResumenQ5AuditadoExpediente,
+    faltantesResumenQ5AuditadoExpediente: entrada?.faltantesResumenQ5AuditadoExpediente,
+    incluirTitulo: true
+  });
 }
-
-
-
-
-
-
-

--- a/07_TOOLBOX/validaciones/acoplar_ot0311_helper_resumen_q5.cjs
+++ b/07_TOOLBOX/validaciones/acoplar_ot0311_helper_resumen_q5.cjs
@@ -1,0 +1,153 @@
+const fs = require("fs");
+const path = require("path");
+
+const rutaExpediente = path.join(
+  process.cwd(),
+  "01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js"
+);
+
+if (!fs.existsSync(rutaExpediente)) {
+  throw new Error(`No existe el constructor del expediente: ${rutaExpediente}`);
+}
+
+let fuente = fs.readFileSync(rutaExpediente, "utf8");
+
+const importHelper =
+  'import { construirBloqueResumenQ5AuditadoExpediente } from "./construirBloqueResumenQ5AuditadoExpediente";';
+
+function contarOcurrencias(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function insertarImportUnico(texto) {
+  if (texto.includes(importHelper)) {
+    return texto;
+  }
+
+  const lineas = texto.split(/\r?\n/);
+  let ultimoImport = -1;
+
+  for (let i = 0; i < lineas.length; i += 1) {
+    if (/^\s*import\s+/.test(lineas[i])) {
+      ultimoImport = i;
+    }
+  }
+
+  if (ultimoImport < 0) {
+    throw new Error("No se encontró bloque de imports para insertar el helper Resumen Q-5.");
+  }
+
+  lineas.splice(ultimoImport + 1, 0, importHelper);
+  return lineas.join("\n");
+}
+
+function reemplazarBloqueInlineResumenQ5(texto) {
+  const bloqueInline = `    "## 6. Resumen Q-5 auditado",
+    \`Métodos recibidos: \${Array.isArray(metodos) ? metodos.length : 0}\`,
+    "Estado: sección contractual inicial del helper puro.",`;
+
+  const bloqueDelegado = `    ...construirLineasResumenQ5AuditadoExpediente({
+      metodosQ5: metodos,
+      estadoResumenQ5AuditadoExpediente: "sección contractual inicial del helper puro"
+    }),`;
+
+  if (!texto.includes(bloqueInline)) {
+    throw new Error("No se encontró el bloque inline exacto de Resumen Q-5 para sustituir.");
+  }
+
+  return texto.replace(bloqueInline, bloqueDelegado);
+}
+
+function reemplazarFuncionResumenQ5HastaSiguienteExportOFin(texto) {
+  const nombreFuncion = "export function construirLineasResumenQ5AuditadoExpediente";
+  const inicio = texto.indexOf(nombreFuncion);
+
+  if (inicio < 0) {
+    throw new Error("No se encontró construirLineasResumenQ5AuditadoExpediente.");
+  }
+
+  const siguienteExportFuncion = texto.indexOf("\nexport function ", inicio + 1);
+  const siguienteExportDefault = texto.indexOf("\nexport default function ", inicio + 1);
+
+  const candidatos = [siguienteExportFuncion, siguienteExportDefault]
+    .filter((indice) => indice > inicio)
+    .sort((a, b) => a - b);
+
+  const fin = candidatos.length > 0 ? candidatos[0] : texto.length;
+
+  const funcionDelegada = `export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
+  return construirBloqueResumenQ5AuditadoExpediente({
+    metodosQ5: entrada?.metodosQ5 ?? entrada?.metodos,
+    estadoResumenQ5AuditadoExpediente: entrada?.estadoResumenQ5AuditadoExpediente,
+    faltantesResumenQ5AuditadoExpediente: entrada?.faltantesResumenQ5AuditadoExpediente,
+    incluirTitulo: true
+  });
+}
+`;
+
+  return `${texto.slice(0, inicio)}${funcionDelegada}${texto.slice(fin)}`;
+}
+
+fuente = insertarImportUnico(fuente);
+fuente = reemplazarBloqueInlineResumenQ5(fuente);
+fuente = reemplazarFuncionResumenQ5HastaSiguienteExportOFin(fuente);
+
+const ocurrenciasImport = contarOcurrencias(fuente, importHelper);
+const ocurrenciasFuncion = contarOcurrencias(
+  fuente,
+  "export function construirLineasResumenQ5AuditadoExpediente"
+);
+const ocurrenciasHelper = contarOcurrencias(
+  fuente,
+  "construirBloqueResumenQ5AuditadoExpediente"
+);
+const ocurrenciasVersion = contarOcurrencias(
+  fuente,
+  "export const VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO"
+);
+const ocurrenciasBloqueInlineAntiguo = contarOcurrencias(
+  fuente,
+  `    "## 6. Resumen Q-5 auditado",
+    \`Métodos recibidos: \${Array.isArray(metodos) ? metodos.length : 0}\`,
+    "Estado: sección contractual inicial del helper puro.",`
+);
+
+if (ocurrenciasImport !== 1) {
+  throw new Error(`Import del helper Resumen Q-5 no quedó único. Ocurrencias: ${ocurrenciasImport}`);
+}
+
+if (ocurrenciasFuncion !== 1) {
+  throw new Error(`Función auxiliar Resumen Q-5 no quedó única. Ocurrencias: ${ocurrenciasFuncion}`);
+}
+
+if (ocurrenciasHelper < 3) {
+  throw new Error(`El helper no parece estar importado y usado. Ocurrencias: ${ocurrenciasHelper}`);
+}
+
+if (ocurrenciasVersion !== 1) {
+  throw new Error(`Posible duplicación del archivo detectada. VERSION aparece ${ocurrenciasVersion} veces.`);
+}
+
+if (ocurrenciasBloqueInlineAntiguo !== 0) {
+  throw new Error(`El bloque inline antiguo sigue presente. Ocurrencias: ${ocurrenciasBloqueInlineAntiguo}`);
+}
+
+if (fuente.includes("}import {")) {
+  throw new Error("Patrón inválido detectado: }import {");
+}
+
+if (fuente.includes("}) {\n  const entradaSegura")) {
+  throw new Error("Patrón inválido detectado: }) { const entradaSegura");
+}
+
+fs.writeFileSync(rutaExpediente, fuente, "utf8");
+
+console.log("ACOPLE_OT_0311_RESUMEN_Q5_COMPLETADO_SEGURO");
+console.log(JSON.stringify({
+  rutaExpediente,
+  ocurrenciasImport,
+  ocurrenciasFuncion,
+  ocurrenciasHelper,
+  ocurrenciasVersion,
+  ocurrenciasBloqueInlineAntiguo
+}, null, 2));


### PR DESCRIPTION
## Objetivo

Acoplar de forma mínima y quirúrgica el helper puro `construirBloqueResumenQ5AuditadoExpediente` al constructor del expediente hidrológico mínimo.

## Antecedente

OT-0310 diseñó el punto de acople futuro del helper `construirBloqueResumenQ5AuditadoExpediente`.

El diseño estableció que el acople debía limitarse al constructor del expediente, sin modificar el helper, sin modificar comparador, sin tocar motor, sin recalcular Q-5 y sin reinterpretar resultados Q-5.

## Archivo funcional modificado

```text
01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js