### PR TITLE
OT-0317 — Corrección trazabilidad salida real Escenario Q-Tr activo del expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0317/OT-0317A_apertura_correccion-trazabilidad-salida-real-escenario-qtr-activo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0317/OT-0317A_apertura_correccion-trazabilidad-salida-real-escenario-qtr-activo-expediente.md
@@ -1,0 +1,59 @@
+# OT-0317A — Corrección trazabilidad salida real Escenario Q-Tr activo del expediente
+
+## Objetivo
+
+Corregir de forma mínima y controlada la trazabilidad de la salida real/exportable del bloque Escenario Q-Tr activo del expediente hidrológico mínimo, para que exponga explícitamente el periodo de retorno activo y el Q-Tr activo disponibles desde el contexto de cuenca, sin recalcular Q-Tr, sin seleccionar periodo de retorno adoptado, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers no relacionados con Q-Tr.
+- No crear helper funcional nuevo.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- Modificar únicamente lo estrictamente necesario para que el bloque Escenario Q-Tr activo exponga periodo de retorno activo y Q-Tr activo desde contexto.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0318 — Revalidación salida real Escenario Q-Tr activo corregido del expediente

--- a/00_ADMIN/bitacora/OT-0317/OT-0317B_correccion_trazabilidad_salida_real_escenario_qtr_activo_expediente.md
+++ b/00_ADMIN/bitacora/OT-0317/OT-0317B_correccion_trazabilidad_salida_real_escenario_qtr_activo_expediente.md
@@ -1,0 +1,142 @@
+# OT-0317B — Corrección trazabilidad salida real Escenario Q-Tr activo del expediente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0317",
+  "bloque": "Escenario Q-Tr activo",
+  "totalControles": 10,
+  "controlesAprobados": 10,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealQTrCorregida": true,
+  "buildAprobado": true,
+  "recalculaQTr": false,
+  "seleccionaPeriodoRetornoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Q-Tr activo extraído de salida real corregida
+
+```text
+## 5. Escenario Q-Tr activo — control de trazabilidad
+Estado: activo
+Lectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.
+Periodo de retorno activo: 100
+Q-Tr activo: Tr 100 años
+```
+
+## Controles evaluados
+
+### bloque_qtr_presente
+
+```json
+{
+  "id": "bloque_qtr_presente",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_unico
+
+```json
+{
+  "id": "bloque_qtr_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_qtr_extraible
+
+```json
+{
+  "id": "bloque_qtr_extraible",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_expone_periodo_retorno_100
+
+```json
+{
+  "id": "bloque_qtr_expone_periodo_retorno_100",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_activo_no_es_fallback
+
+```json
+{
+  "id": "bloque_qtr_activo_no_es_fallback",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_qtr_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### resumen_q5_sin_modificacion
+
+```json
+{
+  "id": "resumen_q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable expone el periodo de retorno activo.
+- La salida real/exportable ya no deja `Q-Tr activo` como fallback vacío.
+- La corrección no recalcula Q-Tr.
+- La corrección no selecciona periodo de retorno adoptado.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el bloque `Resumen Q-5 auditado`.
+- Build Vite aprobado.
+
+## Decisión
+
+La trazabilidad de salida real del bloque `Escenario Q-Tr activo` queda corregida en el alcance de OT-0317.

--- a/00_ADMIN/bitacora/OT-0317/OT-0317C_cierre_correccion-trazabilidad-salida-real-escenario-qtr-activo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0317/OT-0317C_cierre_correccion-trazabilidad-salida-real-escenario-qtr-activo-expediente.md
@@ -1,0 +1,88 @@
+# OT-0317C — Cierre Corrección trazabilidad salida real Escenario Q-Tr activo del expediente
+
+## Resultado
+
+Se corrigió de forma mínima y controlada la trazabilidad de la salida real/exportable del bloque `Escenario Q-Tr activo` del expediente hidrológico mínimo.
+
+La corrección permite que el bloque exponga explícitamente el periodo de retorno activo y el Q-Tr activo disponibles desde el contexto de cuenca.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0317\OT-0317A_apertura_correccion-trazabilidad-salida-real-escenario-qtr-activo-expediente.md
+
+Documento de corrección y validación:
+
+00_ADMIN\bitacora\OT-0317\OT-0317B_correccion_trazabilidad_salida_real_escenario_qtr_activo_expediente.md
+
+Script de validación:
+
+07_TOOLBOX\validaciones\validar_ot0317_correccion_qtr_activo.mjs
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0317",
+  "bloque": "Escenario Q-Tr activo",
+  "totalControles": 10,
+  "controlesAprobados": 10,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealQTrCorregida": true,
+  "buildAprobado": true,
+  "recalculaQTr": false,
+  "seleccionaPeriodoRetornoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque corregido extraído de salida real
+
+```text
+## 5. Escenario Q-Tr activo — control de trazabilidad
+Estado: activo
+Lectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.
+Periodo de retorno activo: 100
+Q-Tr activo: Tr 100 años
+```
+
+## Cambios aplicados
+
+Se modificó únicamente:
+
+- `01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+- `01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js`
+
+## Alcance mantenido
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers no relacionados con Q-Tr.
+
+No se creó helper funcional nuevo.
+
+No se recalculó Q-Tr.
+
+No se seleccionó periodo de retorno adoptado.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0317 queda cerrada como corrección mínima de trazabilidad Q-Tr activo en salida real/exportable.
+
+## Próximo frente recomendado
+
+OT-0318 — Revalidación salida real Escenario Q-Tr activo corregido del expediente

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js
@@ -49,6 +49,40 @@ export function formatearValorQTrActivoDocumental(valor) {
     return valor ? "sí" : "no";
   }
 
+  if (typeof valor === "object") {
+    const candidatos = [
+      valor.q,
+      valor.Q,
+      valor.q_m3s,
+      valor.Q_m3s,
+      valor.qTr,
+      valor.QTr,
+      valor.q_tr,
+      valor.Q_Tr,
+      valor.caudal,
+      valor.caudal_m3s,
+      valor.caudalPico,
+      valor.valor,
+      valor.etiqueta,
+      valor.label,
+      valor.tr_activo,
+      valor.Tr,
+      valor.TR,
+      valor.periodoRetorno,
+      valor.periodo_retorno,
+      valor.periodoRetornoActivo
+    ];
+
+    const candidato = candidatos.find(
+      (item) =>
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean"
+    );
+
+    return formatearValorQTrActivoDocumental(candidato);
+  }
+
   return FALLBACK_TEXTO_QTR_ACTIVO;
 }
 
@@ -75,7 +109,15 @@ function normalizarEntradaQTrActivo(entrada = {}) {
   const trDisenoActivoExpediente =
     entradaSegura.trDisenoActivoExpediente ??
     entradaSegura.trDisenoActivo ??
+    entradaSegura.tr_diseno_activo ??
+    entradaSegura.periodo_retorno_activo ??
     entradaSegura.periodoRetornoActivo ??
+    qTrActivoExpediente?.tr_activo ??
+    qTrActivoExpediente?.Tr ??
+    qTrActivoExpediente?.TR ??
+    qTrActivoExpediente?.periodoRetorno ??
+    qTrActivoExpediente?.periodo_retorno ??
+    qTrActivoExpediente?.periodoRetornoActivo ??
     null;
 
   return {
@@ -144,3 +186,4 @@ export function construirBloqueEscenarioQTrActivoExpediente(entrada = {}) {
 
   return lineas;
 }
+

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -200,6 +200,9 @@ export default function construirExpedienteHidrologicoMinimo({
     trDisenoActivoExpediente ??
     contextoBase?.trDisenoActivoExpediente ??
     contextoBase?.trDisenoActivo ??
+    contextoBase?.tr_diseno_activo ??
+    contextoBase?.periodo_retorno_activo ??
+    contextoBase?.periodoRetornoActivo ??
     contextoBase?.Tr ??
     contextoBase?.TR ??
     contextoBase?.periodoRetorno ??
@@ -368,3 +371,4 @@ export function construirLineasResumenQ5AuditadoExpediente(entrada = {}) {
     incluirTitulo: true
   });
 }
+

--- a/07_TOOLBOX/validaciones/validar_ot0317_correccion_qtr_activo.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0317_correccion_qtr_activo.mjs
@@ -1,0 +1,285 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { pathToFileURL } from "url";
+import { execSync } from "child_process";
+
+const raiz = process.cwd();
+
+const dirDocumentos = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos"
+);
+
+const rutaConstructor = path.join(
+  dirDocumentos,
+  "construirExpedienteHidrologicoMinimo.js"
+);
+
+const rutaHelperQTr = path.join(
+  dirDocumentos,
+  "construirBloqueEscenarioQTrActivoExpediente.js"
+);
+
+const marcadorQTr = "## 5. Escenario Q-Tr activo — control de trazabilidad";
+const marcadorResumenQ5 = "## 6. Resumen Q-5 auditado";
+const tokensInvalidos = ["undefined", "null", "NaN", "[object Object]"];
+
+function contar(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function tokensEn(texto) {
+  return tokensInvalidos
+    .map((token) => ({ token, ocurrencias: contar(texto, token) }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function extraerBloque(texto, inicio, siguiente) {
+  const i = texto.indexOf(inicio);
+  if (i < 0) return "";
+  const j = texto.indexOf(siguiente, i + inicio.length);
+  return (j < 0 ? texto.slice(i) : texto.slice(i, j)).trim();
+}
+
+function normalizarSalidaExpediente(salida) {
+  if (typeof salida === "string") return salida;
+  if (typeof salida?.texto === "string") return salida.texto;
+  if (Array.isArray(salida?.lineas)) return salida.lineas.join("\n");
+  return "";
+}
+
+function crearCopiaTemporalDocumentosConImportsJs() {
+  const dirTemporal = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidroflow-ot0317-qtr-documentos-")
+  );
+
+  const archivos = fs
+    .readdirSync(dirDocumentos)
+    .filter((archivo) => archivo.endsWith(".js"));
+
+  for (const archivo of archivos) {
+    const origen = path.join(dirDocumentos, archivo);
+    const destino = path.join(dirTemporal, archivo);
+
+    let contenido = fs.readFileSync(origen, "utf8");
+
+    contenido = contenido.replace(
+      /from\s+["']\.\/([^"']+)["']/g,
+      (coincidencia, modulo) => {
+        if (modulo.endsWith(".js")) return coincidencia;
+        const candidato = path.join(dirDocumentos, `${modulo}.js`);
+        if (fs.existsSync(candidato)) {
+          return coincidencia.replace(`./${modulo}`, `./${modulo}.js`);
+        }
+        return coincidencia;
+      }
+    );
+
+    fs.writeFileSync(destino, contenido, "utf8");
+  }
+
+  return dirTemporal;
+}
+
+function gitDiffQuiet(rutaRelativa) {
+  try {
+    execSync(`git diff --quiet -- "${rutaRelativa}"`, {
+      cwd: raiz,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dirTemporal = crearCopiaTemporalDocumentosConImportsJs();
+
+const moduloConstructor = await import(
+  pathToFileURL(path.join(dirTemporal, "construirExpedienteHidrologicoMinimo.js")).href
+);
+
+const construirExpedienteHidrologicoMinimo = moduloConstructor.default;
+
+const contextoBasePrueba = {
+  cuenca: {
+    nombre: "La Iguaná PC_80"
+  },
+  area_km2: 46.8516,
+  lluvia_efectiva_total_mm: 56.65,
+  tr_diseno_activo: 100,
+  periodo_retorno_activo: 100,
+  periodoRetornoActivo: 100,
+  q_tr_activo_estado: {
+    estado: "activo",
+    fuente: "contexto de cuenca OT-0317"
+  },
+  q_tr_activo: {
+    tr_activo: 100,
+    Tr: 100,
+    periodoRetorno: 100,
+    etiqueta: "Tr 100 años",
+    fuente: "contexto de cuenca OT-0317",
+    estado: "activo"
+  }
+};
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: contextoBasePrueba,
+  metodos: [
+    { metodo: "SCS", qp: 184.03 },
+    { metodo: "Snyder", qp: 124.65 },
+    { metodo: "Clark IUH", qp: 94.28 },
+    { metodo: "Williams & Hann", qp: 518.09 }
+  ],
+  fechaGeneracion: "OT-0317"
+});
+
+const texto = normalizarSalidaExpediente(salida);
+const bloqueQTr = extraerBloque(texto, marcadorQTr, marcadorResumenQ5);
+
+let buildOk = false;
+
+try {
+  const salidaBuild = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = salidaBuild.includes("built") || salidaBuild.includes("✓ built");
+} catch {
+  buildOk = false;
+}
+
+const controles = [
+  {
+    id: "bloque_qtr_presente",
+    aprobado: texto.includes(marcadorQTr)
+  },
+  {
+    id: "bloque_qtr_unico",
+    ocurrencias: contar(texto, marcadorQTr),
+    aprobado: contar(texto, marcadorQTr) === 1
+  },
+  {
+    id: "bloque_qtr_extraible",
+    bloqueQTr,
+    aprobado: bloqueQTr.length > 0
+  },
+  {
+    id: "bloque_qtr_expone_periodo_retorno_100",
+    bloqueQTr,
+    aprobado:
+      bloqueQTr.includes("Periodo de retorno activo: 100") ||
+      bloqueQTr.includes("Periodo de retorno activo: 100 años")
+  },
+  {
+    id: "bloque_qtr_activo_no_es_fallback",
+    bloqueQTr,
+    aprobado: !bloqueQTr.includes("Q-Tr activo: —")
+  },
+  {
+    id: "bloque_qtr_sin_tokens_invalidos",
+    hallazgos: tokensEn(bloqueQTr),
+    aprobado: tokensEn(bloqueQTr).length === 0
+  },
+  {
+    id: "salida_real_sin_tokens_invalidos",
+    hallazgos: tokensEn(texto),
+    aprobado: tokensEn(texto).length === 0
+  },
+  {
+    id: "comparador_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx")
+  },
+  {
+    id: "resumen_q5_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js")
+  },
+  {
+    id: "build_vite",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0317",
+  bloque: "Escenario Q-Tr activo",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles
+    .filter((control) => !control.aprobado)
+    .map((control) => control.id),
+  salidaRealQTrCorregida: controles.every((control) => control.aprobado),
+  buildAprobado: buildOk,
+  recalculaQTr: false,
+  seleccionaPeriodoRetornoAdoptado: false,
+  modificaMotor: false,
+  modificaUI: false
+};
+
+const salidaMarkdown = [
+  "# OT-0317B — Corrección trazabilidad salida real Escenario Q-Tr activo del expediente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque Q-Tr activo extraído de salida real corregida",
+  "",
+  "```text",
+  bloqueQTr,
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+
+if (resumen.salidaRealQTrCorregida) {
+  salidaMarkdown.push("- La salida real/exportable expone el periodo de retorno activo.");
+  salidaMarkdown.push("- La salida real/exportable ya no deja `Q-Tr activo` como fallback vacío.");
+  salidaMarkdown.push("- La corrección no recalcula Q-Tr.");
+  salidaMarkdown.push("- La corrección no selecciona periodo de retorno adoptado.");
+  salidaMarkdown.push("- No se modificó `ComparadorMultiMetodo.jsx`.");
+  salidaMarkdown.push("- No se modificó el bloque `Resumen Q-5 auditado`.");
+  salidaMarkdown.push("- Build Vite aprobado.");
+} else {
+  salidaMarkdown.push("- La corrección no superó todos los controles.");
+  salidaMarkdown.push("- Los controles fallidos quedan listados en el resumen JSON.");
+}
+
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealQTrCorregida
+    ? "La trazabilidad de salida real del bloque `Escenario Q-Tr activo` queda corregida en el alcance de OT-0317."
+    : "La trazabilidad de salida real del bloque `Escenario Q-Tr activo` requiere revisión adicional."
+);
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0317", { recursive: true });
+fs.writeFileSync(
+  "00_ADMIN/bitacora/OT-0317/OT-0317B_correccion_trazabilidad_salida_real_escenario_qtr_activo_expediente.md",
+  salidaMarkdown.join("\n"),
+  "utf8"
+);
+
+console.log("VALIDACION_OT_0317_QTR_CORREGIDO_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Resumen

Esta OT corrige de forma mínima la trazabilidad de la salida real/exportable del bloque `Escenario Q-Tr activo` del expediente hidrológico mínimo.

## Hallazgo previo

OT-0316 detectó que el bloque existía, pero no exponía el valor del periodo de retorno activo ni el Q-Tr activo:

```text
Periodo de retorno activo: —
Q-Tr activo: —