### PR TITLE
OT-0318 — Revalidación salida real Escenario Q-Tr activo corregido del expediente

### DIFF
--- a/00_ADMIN/bitacora/OT-0318/OT-0318A_apertura_revalidacion-salida-real-escenario-qtr-activo-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0318/OT-0318A_apertura_revalidacion-salida-real-escenario-qtr-activo-corregido-expediente.md
@@ -1,0 +1,64 @@
+# OT-0318A — Revalidación salida real Escenario Q-Tr activo corregido del expediente
+
+## Objetivo
+
+Revalidar desde main que la corrección aplicada en OT-0317 mantiene la trazabilidad de salida real/exportable del bloque Escenario Q-Tr activo del expediente hidrológico mínimo, comprobando que el periodo de retorno activo y el Q-Tr activo se exponen explícitamente, sin recalcular Q-Tr, sin seleccionar periodo de retorno adoptado, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0318 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0319 — Revalidación salida real Método Racional como contraste global independiente

--- a/00_ADMIN/bitacora/OT-0318/OT-0318B_revalidacion_salida_real_escenario_qtr_activo_corregido_expediente.md
+++ b/00_ADMIN/bitacora/OT-0318/OT-0318B_revalidacion_salida_real_escenario_qtr_activo_corregido_expediente.md
@@ -1,0 +1,158 @@
+# OT-0318B — Revalidación salida real Escenario Q-Tr activo corregido del expediente
+
+## Propósito
+
+Revalidar desde main que la corrección aplicada en OT-0317 mantiene visible la trazabilidad del bloque `Escenario Q-Tr activo` en la salida real/exportable del expediente hidrológico mínimo.
+
+## Evidencia reutilizada
+
+Se ejecutó el validador existente:
+
+`07_TOOLBOX\validaciones\validar_ot0317_correccion_qtr_activo.mjs`
+
+La evidencia técnica generada por el validador se conserva a continuación.
+
+---
+
+# OT-0317B — Corrección trazabilidad salida real Escenario Q-Tr activo del expediente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0317",
+  "bloque": "Escenario Q-Tr activo",
+  "totalControles": 10,
+  "controlesAprobados": 10,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealQTrCorregida": true,
+  "buildAprobado": true,
+  "recalculaQTr": false,
+  "seleccionaPeriodoRetornoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Q-Tr activo extraído de salida real corregida
+
+```text
+## 5. Escenario Q-Tr activo — control de trazabilidad
+Estado: activo
+Lectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.
+Periodo de retorno activo: 100
+Q-Tr activo: Tr 100 años
+```
+
+## Controles evaluados
+
+### bloque_qtr_presente
+
+```json
+{
+  "id": "bloque_qtr_presente",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_unico
+
+```json
+{
+  "id": "bloque_qtr_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_qtr_extraible
+
+```json
+{
+  "id": "bloque_qtr_extraible",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_expone_periodo_retorno_100
+
+```json
+{
+  "id": "bloque_qtr_expone_periodo_retorno_100",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_activo_no_es_fallback
+
+```json
+{
+  "id": "bloque_qtr_activo_no_es_fallback",
+  "bloqueQTr": "## 5. Escenario Q-Tr activo — control de trazabilidad\nEstado: activo\nLectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.\nPeriodo de retorno activo: 100\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_qtr_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_qtr_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### resumen_q5_sin_modificacion
+
+```json
+{
+  "id": "resumen_q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable expone el periodo de retorno activo.
+- La salida real/exportable ya no deja `Q-Tr activo` como fallback vacío.
+- La corrección no recalcula Q-Tr.
+- La corrección no selecciona periodo de retorno adoptado.
+- No se modificó `ComparadorMultiMetodo.jsx`.
+- No se modificó el bloque `Resumen Q-5 auditado`.
+- Build Vite aprobado.
+
+## Decisión
+
+La trazabilidad de salida real del bloque `Escenario Q-Tr activo` queda corregida en el alcance de OT-0317.

--- a/00_ADMIN/bitacora/OT-0318/OT-0318C_cierre_revalidacion-salida-real-escenario-qtr-activo-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0318/OT-0318C_cierre_revalidacion-salida-real-escenario-qtr-activo-corregido-expediente.md
@@ -1,0 +1,83 @@
+# OT-0318C — Cierre Revalidación salida real Escenario Q-Tr activo corregido del expediente
+
+## Resultado
+
+Se revalidó desde `main` la corrección aplicada en OT-0317 sobre la salida real/exportable del bloque `Escenario Q-Tr activo` del expediente hidrológico mínimo.
+
+La revalidación confirmó que la salida mantiene explícitamente el periodo de retorno activo y el Q-Tr activo, sin regresar al fallback documental.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0318\OT-0318A_apertura_revalidacion-salida-real-escenario-qtr-activo-corregido-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0318\OT-0318B_revalidacion_salida_real_escenario_qtr_activo_corregido_expediente.md
+
+Validador reutilizado:
+
+07_TOOLBOX\validaciones\validar_ot0317_correccion_qtr_activo.mjs
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0317",
+  "bloque": "Escenario Q-Tr activo",
+  "totalControles": 10,
+  "controlesAprobados": 10,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealQTrCorregida": true,
+  "buildAprobado": true,
+  "recalculaQTr": false,
+  "seleccionaPeriodoRetornoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 5. Escenario Q-Tr activo — control de trazabilidad
+Estado: activo
+Lectura técnica: escenario Q-Tr activo documentado como trazabilidad sin recálculo.
+Periodo de retorno activo: 100
+Q-Tr activo: Tr 100 años
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se recalculó Q-Tr.
+
+No se seleccionó periodo de retorno adoptado.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0318 queda cerrada como revalidación limpia de la corrección Q-Tr activo aplicada en OT-0317.
+
+## Próximo frente recomendado
+
+OT-0319 — Revalidación salida real Método Racional como contraste global independiente


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` que la corrección aplicada en OT-0317 mantiene la trazabilidad de salida real/exportable del bloque `Escenario Q-Tr activo` del expediente hidrológico mínimo.

## Resultado

La revalidación confirmó que el bloque conserva explícitamente:

```text
Periodo de retorno activo: 100
Q-Tr activo: Tr 100 años
``