### PR TITLE
OT-0319 — Revalidación salida real Método Racional como contraste global independiente

### DIFF
--- a/00_ADMIN/bitacora/OT-0319/OT-0319A_apertura_revalidacion-salida-real-metodo-racional-contraste-expediente.md
+++ b/00_ADMIN/bitacora/OT-0319/OT-0319A_apertura_revalidacion-salida-real-metodo-racional-contraste-expediente.md
@@ -1,0 +1,67 @@
+# OT-0319A — Revalidación salida real Método Racional como contraste global independiente
+
+## Objetivo
+
+Revalidar la salida real/exportable del expediente hidrológico mínimo para el bloque Método Racional como contraste global independiente, comprobando que el bloque está presente, que se mantiene separado del bloque Q-5, que no se adopta como método principal, que expone resultados racionales cuando están disponibles en contexto y que no recalcula caudales, no modifica motor, no modifica UI, no modifica ComparadorMultiMetodo.jsx y no altera otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0319 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0320 — Revalidación salida real Contraste Q-5 vs Método Racional

--- a/00_ADMIN/bitacora/OT-0319/OT-0319B_revalidacion_salida_real_metodo_racional_contraste_expediente.md
+++ b/00_ADMIN/bitacora/OT-0319/OT-0319B_revalidacion_salida_real_metodo_racional_contraste_expediente.md
@@ -1,0 +1,213 @@
+# OT-0319B — Revalidación salida real Método Racional como contraste global independiente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0319",
+  "bloque": "Método Racional — contraste global independiente",
+  "totalControles": 17,
+  "controlesAprobados": 15,
+  "controlesFallidos": 2,
+  "controlesFallidosIds": [
+    "bloque_racional_no_adoptivo",
+    "bloque_racional_expone_tabla_si_hay_resultados"
+  ],
+  "salidaRealMetodoRacionalRevalidada": false,
+  "buildAprobado": true,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoRacionalAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Método Racional extraído de salida real
+
+```text
+## 7. Método Racional — contraste global independiente
+Uso: contraste global independiente de caudal pico.
+Estado: sección contractual inicial del helper puro.
+```
+
+## Controles evaluados
+
+### constructor_existe
+
+```json
+{
+  "id": "constructor_existe",
+  "aprobado": true
+}
+```
+
+### bloque_racional_presente
+
+```json
+{
+  "id": "bloque_racional_presente",
+  "aprobado": true
+}
+```
+
+### bloque_racional_unico
+
+```json
+{
+  "id": "bloque_racional_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_racional_extraible
+
+```json
+{
+  "id": "bloque_racional_extraible",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nEstado: sección contractual inicial del helper puro.",
+  "aprobado": true
+}
+```
+
+### bloque_racional_despues_q5
+
+```json
+{
+  "id": "bloque_racional_despues_q5",
+  "indiceQ5": 1686,
+  "indiceRacional": 1787,
+  "aprobado": true
+}
+```
+
+### bloque_racional_antes_contraste
+
+```json
+{
+  "id": "bloque_racional_antes_contraste",
+  "indiceRacional": 1787,
+  "indiceContraste": 1948,
+  "aprobado": true
+}
+```
+
+### bloque_racional_separado_de_q5
+
+```json
+{
+  "id": "bloque_racional_separado_de_q5",
+  "bloqueQ5": "## 6. Resumen Q-5 auditado\nMétodos recibidos: 4\nEstado: sección contractual inicial del helper puro",
+  "aprobado": true
+}
+```
+
+### bloque_racional_declara_contraste_independiente
+
+```json
+{
+  "id": "bloque_racional_declara_contraste_independiente",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nEstado: sección contractual inicial del helper puro.",
+  "aprobado": true
+}
+```
+
+### bloque_racional_no_adoptivo
+
+```json
+{
+  "id": "bloque_racional_no_adoptivo",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nEstado: sección contractual inicial del helper puro.",
+  "aprobado": false
+}
+```
+
+### bloque_racional_expone_tabla_si_hay_resultados
+
+```json
+{
+  "id": "bloque_racional_expone_tabla_si_hay_resultados",
+  "descripcion": "Si contextoBase.metodo_racional.resultados contiene datos, el bloque racional debe exponer tabla racional.",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nEstado: sección contractual inicial del helper puro.",
+  "aprobado": false
+}
+```
+
+### bloque_racional_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_racional_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_sin_modificacion
+
+```json
+{
+  "id": "constructor_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.
+- Los controles fallidos quedan listados en el resumen JSON.
+- No se aplicó corrección funcional en esta OT.
+
+## Decisión
+
+La salida real/exportable del bloque `Método Racional — contraste global independiente` requiere revisión antes de avanzar.
+
+## Próximo frente recomendado
+
+`OT-0320 — Corrección salida real Método Racional como contraste global independiente`

--- a/00_ADMIN/bitacora/OT-0319/OT-0319C_cierre_revalidacion-salida-real-metodo-racional-contraste-expediente.md
+++ b/00_ADMIN/bitacora/OT-0319/OT-0319C_cierre_revalidacion-salida-real-metodo-racional-contraste-expediente.md
@@ -1,0 +1,101 @@
+# OT-0319C — Cierre Revalidación salida real Método Racional como contraste global independiente
+
+## Resultado
+
+Se ejecutó la revalidación de la salida real/exportable del expediente hidrológico mínimo para el bloque `Método Racional — contraste global independiente`.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del bloque `Resumen Q-5 auditado`, queda antes del bloque `Contraste Q-5 vs Método Racional`, se mantiene separado de Q-5, no contiene tokens inválidos y puede evaluarse sin modificar código funcional.
+
+Sin embargo, la revalidación detectó dos brechas técnicas relevantes:
+
+- El bloque no explicita suficientemente su carácter no adoptivo.
+- El bloque no expone tabla racional aunque el contexto de prueba contiene resultados racionales disponibles.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0319\OT-0319A_apertura_revalidacion-salida-real-metodo-racional-contraste-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0319\OT-0319B_revalidacion_salida_real_metodo_racional_contraste_expediente.md
+
+Script de revalidación:
+
+07_TOOLBOX\validaciones\validar_ot0319_metodo_racional_contraste.mjs
+
+## Resultado de controles
+
+```json
+{
+  "validacion": "OT-0319",
+  "bloque": "Método Racional — contraste global independiente",
+  "totalControles": 17,
+  "controlesAprobados": 15,
+  "controlesFallidos": 2,
+  "controlesFallidosIds": [
+    "bloque_racional_no_adoptivo",
+    "bloque_racional_expone_tabla_si_hay_resultados"
+  ],
+  "salidaRealMetodoRacionalRevalidada": false,
+  "buildAprobado": true,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoRacionalAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque extraído de salida real
+
+```text
+## 7. Método Racional — contraste global independiente
+Uso: contraste global independiente de caudal pico.
+Estado: sección contractual inicial del helper puro.
+```
+
+## Hallazgos principales
+
+### 1. Carácter no adoptivo insuficiente
+
+El bloque declara que el Método Racional es un contraste global independiente, pero no deja explícito en la salida real que no debe adoptarse como método principal ni como caudal final sin revisión técnica.
+
+### 2. Tabla racional no expuesta
+
+El contexto de prueba contiene resultados racionales en `contextoBase.metodo_racional.resultados`, pero la salida real del bloque no expone una tabla racional.
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se recalculó Método Racional.
+
+No se seleccionó Método Racional como adoptado.
+
+No se seleccionó caudal racional adoptado.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0319 queda cerrada como revalidación con hallazgo. El siguiente frente debe corregir la salida real del bloque Método Racional como contraste global independiente, sin recalcular Método Racional, sin adoptarlo como principal y sin mezclarlo con Q-5.
+
+## Próximo frente recomendado
+
+OT-0320 — Corrección salida real Método Racional como contraste global independiente

--- a/07_TOOLBOX/validaciones/validar_ot0319_metodo_racional_contraste.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0319_metodo_racional_contraste.mjs
@@ -1,0 +1,353 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { pathToFileURL } from "url";
+import { execSync } from "child_process";
+
+const raiz = process.cwd();
+
+const dirDocumentos = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos"
+);
+
+const rutaConstructor = path.join(
+  dirDocumentos,
+  "construirExpedienteHidrologicoMinimo.js"
+);
+
+const marcadorRacional = "## 7. Método Racional — contraste global independiente";
+const marcadorContraste = "## 8. Contraste Q-5 vs Método Racional";
+const marcadorQ5 = "## 6. Resumen Q-5 auditado";
+
+const tokensInvalidos = ["undefined", "null", "NaN", "[object Object]"];
+
+function leer(ruta) {
+  return fs.existsSync(ruta) ? fs.readFileSync(ruta, "utf8") : "";
+}
+
+function contar(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function tokensEn(texto) {
+  return tokensInvalidos
+    .map((token) => ({ token, ocurrencias: contar(texto, token) }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function extraerBloque(texto, inicio, siguiente) {
+  const i = texto.indexOf(inicio);
+  if (i < 0) return "";
+  const j = texto.indexOf(siguiente, i + inicio.length);
+  return (j < 0 ? texto.slice(i) : texto.slice(i, j)).trim();
+}
+
+function normalizarSalidaExpediente(salida) {
+  if (typeof salida === "string") return salida;
+  if (typeof salida?.texto === "string") return salida.texto;
+  if (Array.isArray(salida?.lineas)) return salida.lineas.join("\n");
+  return "";
+}
+
+function crearCopiaTemporalDocumentosConImportsJs() {
+  const dirTemporal = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidroflow-ot0319-racional-documentos-")
+  );
+
+  const archivos = fs
+    .readdirSync(dirDocumentos)
+    .filter((archivo) => archivo.endsWith(".js"));
+
+  for (const archivo of archivos) {
+    const origen = path.join(dirDocumentos, archivo);
+    const destino = path.join(dirTemporal, archivo);
+
+    let contenido = fs.readFileSync(origen, "utf8");
+
+    contenido = contenido.replace(
+      /from\s+["']\.\/([^"']+)["']/g,
+      (coincidencia, modulo) => {
+        if (modulo.endsWith(".js")) return coincidencia;
+        const candidato = path.join(dirDocumentos, `${modulo}.js`);
+        if (fs.existsSync(candidato)) {
+          return coincidencia.replace(`./${modulo}`, `./${modulo}.js`);
+        }
+        return coincidencia;
+      }
+    );
+
+    fs.writeFileSync(destino, contenido, "utf8");
+  }
+
+  return dirTemporal;
+}
+
+function gitDiffQuiet(rutaRelativa) {
+  try {
+    execSync(`git diff --quiet -- "${rutaRelativa}"`, {
+      cwd: raiz,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dirTemporal = crearCopiaTemporalDocumentosConImportsJs();
+
+const moduloConstructor = await import(
+  pathToFileURL(path.join(dirTemporal, "construirExpedienteHidrologicoMinimo.js")).href
+);
+
+const construirExpedienteHidrologicoMinimo = moduloConstructor.default;
+
+const contextoBasePrueba = {
+  cuenca: {
+    nombre: "La Iguaná PC_80"
+  },
+  area_km2: 46.8516,
+  lluvia_efectiva_total_mm: 56.65,
+  tr_diseno_activo: 100,
+  q_tr_activo_estado: {
+    estado: "activo",
+    fuente: "contexto de cuenca OT-0319"
+  },
+  q_tr_activo: {
+    tr_activo: 100,
+    etiqueta: "Tr 100 años"
+  },
+  metodo_racional: {
+    resultados: [
+      {
+        Tr: 100,
+        I: 88.12,
+        P: 74.35,
+        C: 0.62,
+        Q: 711.42
+      }
+    ]
+  }
+};
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: contextoBasePrueba,
+  metodos: [
+    { metodo: "SCS", qp: 184.03 },
+    { metodo: "Snyder", qp: 124.65 },
+    { metodo: "Clark IUH", qp: 94.28 },
+    { metodo: "Williams & Hann", qp: 518.09 }
+  ],
+  fechaGeneracion: "OT-0319"
+});
+
+const texto = normalizarSalidaExpediente(salida);
+const bloqueRacional = extraerBloque(texto, marcadorRacional, marcadorContraste);
+const bloqueQ5 = extraerBloque(texto, marcadorQ5, marcadorRacional);
+
+let buildOk = false;
+
+try {
+  const salidaBuild = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = salidaBuild.includes("built") || salidaBuild.includes("✓ built");
+} catch {
+  buildOk = false;
+}
+
+const controles = [
+  {
+    id: "constructor_existe",
+    aprobado: fs.existsSync(rutaConstructor)
+  },
+  {
+    id: "bloque_racional_presente",
+    aprobado: texto.includes(marcadorRacional)
+  },
+  {
+    id: "bloque_racional_unico",
+    ocurrencias: contar(texto, marcadorRacional),
+    aprobado: contar(texto, marcadorRacional) === 1
+  },
+  {
+    id: "bloque_racional_extraible",
+    bloqueRacional,
+    aprobado: bloqueRacional.length > 0
+  },
+  {
+    id: "bloque_racional_despues_q5",
+    indiceQ5: texto.indexOf(marcadorQ5),
+    indiceRacional: texto.indexOf(marcadorRacional),
+    aprobado:
+      texto.indexOf(marcadorQ5) >= 0 &&
+      texto.indexOf(marcadorRacional) > texto.indexOf(marcadorQ5)
+  },
+  {
+    id: "bloque_racional_antes_contraste",
+    indiceRacional: texto.indexOf(marcadorRacional),
+    indiceContraste: texto.indexOf(marcadorContraste),
+    aprobado:
+      texto.indexOf(marcadorRacional) >= 0 &&
+      texto.indexOf(marcadorContraste) > texto.indexOf(marcadorRacional)
+  },
+  {
+    id: "bloque_racional_separado_de_q5",
+    bloqueQ5,
+    aprobado:
+      bloqueQ5.length > 0 &&
+      !bloqueQ5.includes("Método Racional — contraste global independiente") &&
+      !bloqueQ5.includes("Tabla Método Racional")
+  },
+  {
+    id: "bloque_racional_declara_contraste_independiente",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.includes("contraste global independiente") ||
+      bloqueRacional.includes("Contraste global independiente")
+  },
+  {
+    id: "bloque_racional_no_adoptivo",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.toLowerCase().includes("no adopt") ||
+      bloqueRacional.toLowerCase().includes("no pertenece") ||
+      bloqueRacional.toLowerCase().includes("sin revisión")
+  },
+  {
+    id: "bloque_racional_expone_tabla_si_hay_resultados",
+    descripcion:
+      "Si contextoBase.metodo_racional.resultados contiene datos, el bloque racional debe exponer tabla racional.",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.includes("Tabla Método Racional") &&
+      bloqueRacional.includes("| Tr | I | P | C | Q |") &&
+      bloqueRacional.includes("100") &&
+      bloqueRacional.includes("711")
+  },
+  {
+    id: "bloque_racional_sin_tokens_invalidos",
+    hallazgos: tokensEn(bloqueRacional),
+    aprobado: tokensEn(bloqueRacional).length === 0
+  },
+  {
+    id: "salida_real_sin_tokens_invalidos",
+    hallazgos: tokensEn(texto),
+    aprobado: tokensEn(texto).length === 0
+  },
+  {
+    id: "constructor_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js")
+  },
+  {
+    id: "comparador_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx")
+  },
+  {
+    id: "qtr_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js")
+  },
+  {
+    id: "q5_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js")
+  },
+  {
+    id: "build_vite",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0319",
+  bloque: "Método Racional — contraste global independiente",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles
+    .filter((control) => !control.aprobado)
+    .map((control) => control.id),
+  salidaRealMetodoRacionalRevalidada: controles.every((control) => control.aprobado),
+  buildAprobado: buildOk,
+  recalculaMetodoRacional: false,
+  seleccionaMetodoRacionalAdoptado: false,
+  modificaMotor: false,
+  modificaUI: false
+};
+
+const salidaMarkdown = [
+  "# OT-0319B — Revalidación salida real Método Racional como contraste global independiente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque Método Racional extraído de salida real",
+  "",
+  "```text",
+  bloqueRacional,
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+
+if (resumen.salidaRealMetodoRacionalRevalidada) {
+  salidaMarkdown.push("- La salida real/exportable conserva el bloque `Método Racional — contraste global independiente`.");
+  salidaMarkdown.push("- El bloque está separado del bloque `Resumen Q-5 auditado`.");
+  salidaMarkdown.push("- El bloque mantiene lectura no adoptiva.");
+  salidaMarkdown.push("- Si hay resultados racionales en contexto, la tabla racional se expone.");
+  salidaMarkdown.push("- No se recalcula Método Racional.");
+  salidaMarkdown.push("- No se selecciona Método Racional como adoptado.");
+  salidaMarkdown.push("- No se modificó código funcional.");
+  salidaMarkdown.push("- Build Vite aprobado.");
+} else {
+  salidaMarkdown.push("- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.");
+  salidaMarkdown.push("- Los controles fallidos quedan listados en el resumen JSON.");
+  salidaMarkdown.push("- No se aplicó corrección funcional en esta OT.");
+}
+
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealMetodoRacionalRevalidada
+    ? "La salida real/exportable del bloque `Método Racional — contraste global independiente` queda revalidada en el alcance de OT-0319."
+    : "La salida real/exportable del bloque `Método Racional — contraste global independiente` requiere revisión antes de avanzar."
+);
+salidaMarkdown.push("");
+salidaMarkdown.push("## Próximo frente recomendado");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealMetodoRacionalRevalidada
+    ? "`OT-0320 — Revalidación salida real Contraste Q-5 vs Método Racional`"
+    : "`OT-0320 — Corrección salida real Método Racional como contraste global independiente`"
+);
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0319", { recursive: true });
+fs.writeFileSync(
+  "00_ADMIN/bitacora/OT-0319/OT-0319B_revalidacion_salida_real_metodo_racional_contraste_expediente.md",
+
+salidaMarkdown.join("\n"),
+  "utf8"
+);
+
+console.log("VALIDACION_OT_0319_METODO_RACIONAL_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Resumen

Esta OT revalida la salida real/exportable del expediente hidrológico mínimo para el bloque `Método Racional — contraste global independiente`.

## Resultado

La revalidación confirmó que el bloque existe, aparece una sola vez, queda separado del bloque `Resumen Q-5 auditado`, está ubicado antes del bloque `Contraste Q-5 vs Método Racional`, no contiene tokens inválidos y no requiere modificación funcional para ser evaluado.

Sin embargo, detectó dos brechas técnicas relevantes:

- El bloque no explicita suficientemente su carácter no adoptivo.
- El bloque no expone tabla racional aunque el contexto de prueba contiene resultados racionales disponibles.

## Evidencia principal

Script ejecutado:

```text
07_TOOLBOX/validaciones/validar_ot0319_metodo_racional_contraste.mjs