### PR TITLE
OT-0321 — Revalidación salida real Método Racional corregido como contraste global independiente

### DIFF
--- a/00_ADMIN/bitacora/OT-0321/OT-0321A_apertura_revalidacion-salida-real-metodo-racional-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0321/OT-0321A_apertura_revalidacion-salida-real-metodo-racional-corregido-expediente.md
@@ -1,0 +1,67 @@
+# OT-0321A — Revalidación salida real Método Racional corregido como contraste global independiente
+
+## Objetivo
+
+Revalidar desde main que la corrección aplicada en OT-0320 mantiene la salida real/exportable del bloque Método Racional como contraste global independiente, comprobando que explicita su carácter no adoptivo principal, mantiene separación frente a Q-5 y expone tabla racional cuando existen resultados disponibles en contexto, sin recalcular Método Racional, sin seleccionarlo como adoptado, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0321 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0322 — Revalidación salida real Contraste Q-5 vs Método Racional

--- a/00_ADMIN/bitacora/OT-0321/OT-0321B_revalidacion_salida_real_metodo_racional_corregido_expediente.md
+++ b/00_ADMIN/bitacora/OT-0321/OT-0321B_revalidacion_salida_real_metodo_racional_corregido_expediente.md
@@ -1,0 +1,222 @@
+# OT-0321B — Revalidación salida real Método Racional corregido como contraste global independiente
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0321",
+  "bloque": "Método Racional — contraste global independiente",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealMetodoRacionalRevalidada": true,
+  "buildAprobado": true,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoRacionalAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Método Racional extraído de salida real revalidada
+
+```text
+## 7. Método Racional — contraste global independiente
+Uso: contraste global independiente de caudal pico.
+Carácter: no adoptivo principal; requiere revisión técnica antes de adopción.
+Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.
+
+Tabla Método Racional:
+| Tr | I | P | C | Q |
+|---:|---:|---:|---:|---:|
+| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |
+```
+
+## Controles evaluados
+
+### constructor_existe
+
+```json
+{
+  "id": "constructor_existe",
+  "aprobado": true
+}
+```
+
+### bloque_racional_presente
+
+```json
+{
+  "id": "bloque_racional_presente",
+  "aprobado": true
+}
+```
+
+### bloque_racional_unico
+
+```json
+{
+  "id": "bloque_racional_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_racional_extraible
+
+```json
+{
+  "id": "bloque_racional_extraible",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nCarácter: no adoptivo principal; requiere revisión técnica antes de adopción.\nRelación con Q-5: no pertenece al bloque Q-5 de hidrogramas.\n\nTabla Método Racional:\n| Tr | I | P | C | Q |\n|---:|---:|---:|---:|---:|\n| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |",
+  "aprobado": true
+}
+```
+
+### bloque_racional_despues_q5
+
+```json
+{
+  "id": "bloque_racional_despues_q5",
+  "indiceQ5": 1686,
+  "indiceRacional": 1787,
+  "aprobado": true
+}
+```
+
+### bloque_racional_antes_contraste
+
+```json
+{
+  "id": "bloque_racional_antes_contraste",
+  "indiceRacional": 1787,
+  "indiceContraste": 2161,
+  "aprobado": true
+}
+```
+
+### bloque_racional_separado_de_q5
+
+```json
+{
+  "id": "bloque_racional_separado_de_q5",
+  "bloqueQ5": "## 6. Resumen Q-5 auditado\nMétodos recibidos: 4\nEstado: sección contractual inicial del helper puro",
+  "aprobado": true
+}
+```
+
+### bloque_racional_declara_contraste_independiente
+
+```json
+{
+  "id": "bloque_racional_declara_contraste_independiente",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nCarácter: no adoptivo principal; requiere revisión técnica antes de adopción.\nRelación con Q-5: no pertenece al bloque Q-5 de hidrogramas.\n\nTabla Método Racional:\n| Tr | I | P | C | Q |\n|---:|---:|---:|---:|---:|\n| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |",
+  "aprobado": true
+}
+```
+
+### bloque_racional_no_adoptivo
+
+```json
+{
+  "id": "bloque_racional_no_adoptivo",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nCarácter: no adoptivo principal; requiere revisión técnica antes de adopción.\nRelación con Q-5: no pertenece al bloque Q-5 de hidrogramas.\n\nTabla Método Racional:\n| Tr | I | P | C | Q |\n|---:|---:|---:|---:|---:|\n| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |",
+  "aprobado": true
+}
+```
+
+### bloque_racional_expone_tabla_si_hay_resultados
+
+```json
+{
+  "id": "bloque_racional_expone_tabla_si_hay_resultados",
+  "descripcion": "Si contextoBase.metodo_racional.resultados contiene datos, el bloque racional debe exponer tabla racional.",
+  "bloqueRacional": "## 7. Método Racional — contraste global independiente\nUso: contraste global independiente de caudal pico.\nCarácter: no adoptivo principal; requiere revisión técnica antes de adopción.\nRelación con Q-5: no pertenece al bloque Q-5 de hidrogramas.\n\nTabla Método Racional:\n| Tr | I | P | C | Q |\n|---:|---:|---:|---:|---:|\n| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |",
+  "aprobado": true
+}
+```
+
+### bloque_racional_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_racional_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_sin_modificacion_en_ot0321
+
+```json
+{
+  "id": "constructor_sin_modificacion_en_ot0321",
+  "descripcion": "OT-0321 es revalidación desde main; no debe modificar el constructor.",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable conserva el bloque `Método Racional — contraste global independiente`.
+- El bloque está separado del bloque `Resumen Q-5 auditado`.
+- El bloque mantiene lectura no adoptiva.
+- Si hay resultados racionales en contexto, la tabla racional se expone.
+- No se recalcula Método Racional.
+- No se selecciona Método Racional como adoptado.
+- No se modificó código funcional en OT-0321.
+- Build Vite aprobado.
+
+## Decisión
+
+La salida real/exportable del bloque `Método Racional — contraste global independiente` queda revalidada desde main en el alcance de OT-0321.
+
+## Próximo frente recomendado
+
+`OT-0322 — Revalidación salida real Contraste Q-5 vs Método Racional`

--- a/00_ADMIN/bitacora/OT-0321/OT-0321C_cierre_revalidacion-salida-real-metodo-racional-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0321/OT-0321C_cierre_revalidacion-salida-real-metodo-racional-corregido-expediente.md
@@ -1,0 +1,89 @@
+# OT-0321C — Cierre Revalidación salida real Método Racional corregido como contraste global independiente
+
+## Resultado
+
+Se revalidó desde `main` la corrección aplicada en OT-0320 sobre la salida real/exportable del bloque `Método Racional — contraste global independiente` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque mantiene explícitamente su carácter no adoptivo principal, conserva separación frente a Q-5 y expone tabla racional cuando existen resultados disponibles en contexto.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0321\OT-0321A_apertura_revalidacion-salida-real-metodo-racional-corregido-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0321\OT-0321B_revalidacion_salida_real_metodo_racional_corregido_expediente.md
+
+Script de revalidación:
+
+07_TOOLBOX\validaciones\validar_ot0321_metodo_racional_revalidado.mjs
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0321",
+  "bloque": "Método Racional — contraste global independiente",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealMetodoRacionalRevalidada": true,
+  "buildAprobado": true,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoRacionalAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 7. Método Racional — contraste global independiente
+Uso: contraste global independiente de caudal pico.
+Carácter: no adoptivo principal; requiere revisión técnica antes de adopción.
+Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.
+
+Tabla Método Racional:
+| Tr | I | P | C | Q |
+|---:|---:|---:|---:|---:|
+| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se recalculó Método Racional.
+
+No se seleccionó Método Racional como adoptado.
+
+No se seleccionó caudal racional adoptado.
+
+No se recalculó Q-5.
+
+No se reinterpretaron resultados Q-5.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0321 queda cerrada como revalidación limpia de la corrección del bloque Método Racional aplicada en OT-0320.
+
+## Próximo frente recomendado
+
+OT-0322 — Revalidación salida real Contraste Q-5 vs Método Racional

--- a/07_TOOLBOX/validaciones/validar_ot0321_metodo_racional_revalidado.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0321_metodo_racional_revalidado.mjs
@@ -1,0 +1,351 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { pathToFileURL } from "url";
+import { execSync } from "child_process";
+
+const raiz = process.cwd();
+
+const dirDocumentos = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos"
+);
+
+const rutaConstructor = path.join(
+  dirDocumentos,
+  "construirExpedienteHidrologicoMinimo.js"
+);
+
+const marcadorRacional = "## 7. Método Racional — contraste global independiente";
+const marcadorContraste = "## 8. Contraste Q-5 vs Método Racional";
+const marcadorQ5 = "## 6. Resumen Q-5 auditado";
+
+const tokensInvalidos = ["undefined", "null", "NaN", "[object Object]"];
+
+function contar(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function tokensEn(texto) {
+  return tokensInvalidos
+    .map((token) => ({ token, ocurrencias: contar(texto, token) }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function extraerBloque(texto, inicio, siguiente) {
+  const i = texto.indexOf(inicio);
+  if (i < 0) return "";
+  const j = texto.indexOf(siguiente, i + inicio.length);
+  return (j < 0 ? texto.slice(i) : texto.slice(i, j)).trim();
+}
+
+function normalizarSalidaExpediente(salida) {
+  if (typeof salida === "string") return salida;
+  if (typeof salida?.texto === "string") return salida.texto;
+  if (Array.isArray(salida?.lineas)) return salida.lineas.join("\n");
+  return "";
+}
+
+function crearCopiaTemporalDocumentosConImportsJs() {
+  const dirTemporal = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidroflow-ot0321-racional-documentos-")
+  );
+
+  const archivos = fs
+    .readdirSync(dirDocumentos)
+    .filter((archivo) => archivo.endsWith(".js"));
+
+  for (const archivo of archivos) {
+    const origen = path.join(dirDocumentos, archivo);
+    const destino = path.join(dirTemporal, archivo);
+
+    let contenido = fs.readFileSync(origen, "utf8");
+
+    contenido = contenido.replace(
+      /from\s+["']\.\/([^"']+)["']/g,
+      (coincidencia, modulo) => {
+        if (modulo.endsWith(".js")) return coincidencia;
+
+        const candidato = path.join(dirDocumentos, `${modulo}.js`);
+        if (fs.existsSync(candidato)) {
+          return coincidencia.replace(`./${modulo}`, `./${modulo}.js`);
+        }
+
+        return coincidencia;
+      }
+    );
+
+    fs.writeFileSync(destino, contenido, "utf8");
+  }
+
+  return dirTemporal;
+}
+
+function gitDiffQuiet(rutaRelativa) {
+  try {
+    execSync(`git diff --quiet -- "${rutaRelativa}"`, {
+      cwd: raiz,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dirTemporal = crearCopiaTemporalDocumentosConImportsJs();
+
+const moduloConstructor = await import(
+  pathToFileURL(path.join(dirTemporal, "construirExpedienteHidrologicoMinimo.js")).href
+);
+
+const construirExpedienteHidrologicoMinimo = moduloConstructor.default;
+
+const contextoBasePrueba = {
+  cuenca: {
+    nombre: "La Iguaná PC_80"
+  },
+  area_km2: 46.8516,
+  lluvia_efectiva_total_mm: 56.65,
+  tr_diseno_activo: 100,
+  q_tr_activo_estado: {
+    estado: "activo",
+    fuente: "contexto de cuenca OT-0321"
+  },
+  q_tr_activo: {
+    tr_activo: 100,
+    etiqueta: "Tr 100 años"
+  },
+  metodo_racional: {
+    resultados: [
+      {
+        Tr: 100,
+        I: 88.12,
+        P: 74.35,
+        C: 0.62,
+        Q: 711.42
+      }
+    ]
+  }
+};
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: contextoBasePrueba,
+  metodos: [
+    { metodo: "SCS", qp: 184.03 },
+    { metodo: "Snyder", qp: 124.65 },
+    { metodo: "Clark IUH", qp: 94.28 },
+    { metodo: "Williams & Hann", qp: 518.09 }
+  ],
+  fechaGeneracion: "OT-0321"
+});
+
+const texto = normalizarSalidaExpediente(salida);
+const bloqueRacional = extraerBloque(texto, marcadorRacional, marcadorContraste);
+const bloqueQ5 = extraerBloque(texto, marcadorQ5, marcadorRacional);
+
+let buildOk = false;
+
+try {
+  const salidaBuild = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = salidaBuild.includes("built") || salidaBuild.includes("✓ built");
+} catch {
+  buildOk = false;
+}
+
+const controles = [
+  {
+    id: "constructor_existe",
+    aprobado: fs.existsSync(rutaConstructor)
+  },
+  {
+    id: "bloque_racional_presente",
+    aprobado: texto.includes(marcadorRacional)
+  },
+  {
+    id: "bloque_racional_unico",
+    ocurrencias: contar(texto, marcadorRacional),
+    aprobado: contar(texto, marcadorRacional) === 1
+  },
+  {
+    id: "bloque_racional_extraible",
+    bloqueRacional,
+    aprobado: bloqueRacional.length > 0
+  },
+  {
+    id: "bloque_racional_despues_q5",
+    indiceQ5: texto.indexOf(marcadorQ5),
+    indiceRacional: texto.indexOf(marcadorRacional),
+    aprobado:
+      texto.indexOf(marcadorQ5) >= 0 &&
+      texto.indexOf(marcadorRacional) > texto.indexOf(marcadorQ5)
+  },
+  {
+    id: "bloque_racional_antes_contraste",
+    indiceRacional: texto.indexOf(marcadorRacional),
+    indiceContraste: texto.indexOf(marcadorContraste),
+    aprobado:
+      texto.indexOf(marcadorRacional) >= 0 &&
+      texto.indexOf(marcadorContraste) > texto.indexOf(marcadorRacional)
+  },
+  {
+    id: "bloque_racional_separado_de_q5",
+    bloqueQ5,
+    aprobado:
+      bloqueQ5.length > 0 &&
+      !bloqueQ5.includes("Método Racional — contraste global independiente") &&
+      !bloqueQ5.includes("Tabla Método Racional")
+  },
+  {
+    id: "bloque_racional_declara_contraste_independiente",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.includes("contraste global independiente") ||
+      bloqueRacional.includes("Contraste global independiente")
+  },
+  {
+    id: "bloque_racional_no_adoptivo",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.toLowerCase().includes("no adopt") ||
+      bloqueRacional.toLowerCase().includes("no pertenece") ||
+      bloqueRacional.toLowerCase().includes("sin revisión")
+  },
+  {
+    id: "bloque_racional_expone_tabla_si_hay_resultados",
+    descripcion:
+      "Si contextoBase.metodo_racional.resultados contiene datos, el bloque racional debe exponer tabla racional.",
+    bloqueRacional,
+    aprobado:
+      bloqueRacional.includes("Tabla Método Racional") &&
+      bloqueRacional.includes("| Tr | I | P | C | Q |") &&
+      bloqueRacional.includes("100") &&
+      bloqueRacional.includes("711")
+  },
+  {
+    id: "bloque_racional_sin_tokens_invalidos",
+    hallazgos: tokensEn(bloqueRacional),
+    aprobado: tokensEn(bloqueRacional).length === 0
+  },
+  {
+    id: "salida_real_sin_tokens_invalidos",
+    hallazgos: tokensEn(texto),
+    aprobado: tokensEn(texto).length === 0
+  },
+  {
+    id: "constructor_sin_modificacion_en_ot0321",
+    descripcion: "OT-0321 es revalidación desde main; no debe modificar el constructor.",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js")
+  },
+  {
+    id: "comparador_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx")
+  },
+  {
+    id: "qtr_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js")
+  },
+  {
+    id: "q5_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js")
+  },
+  {
+    id: "build_vite",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0321",
+  bloque: "Método Racional — contraste global independiente",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles
+    .filter((control) => !control.aprobado)
+    .map((control) => control.id),
+  salidaRealMetodoRacionalRevalidada: controles.every((control) => control.aprobado),
+  buildAprobado: buildOk,
+  recalculaMetodoRacional: false,
+  seleccionaMetodoRacionalAdoptado: false,
+  modificaMotor: false,
+  modificaUI: false
+};
+
+const salidaMarkdown = [
+  "# OT-0321B — Revalidación salida real Método Racional corregido como contraste global independiente",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque Método Racional extraído de salida real revalidada",
+  "",
+  "```text",
+  bloqueRacional,
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+
+if (resumen.salidaRealMetodoRacionalRevalidada) {
+  salidaMarkdown.push("- La salida real/exportable conserva el bloque `Método Racional — contraste global independiente`.");
+  salidaMarkdown.push("- El bloque está separado del bloque `Resumen Q-5 auditado`.");
+  salidaMarkdown.push("- El bloque mantiene lectura no adoptiva.");
+  salidaMarkdown.push("- Si hay resultados racionales en contexto, la tabla racional se expone.");
+  salidaMarkdown.push("- No se recalcula Método Racional.");
+  salidaMarkdown.push("- No se selecciona Método Racional como adoptado.");
+  salidaMarkdown.push("- No se modificó código funcional en OT-0321.");
+  salidaMarkdown.push("- Build Vite aprobado.");
+} else {
+  salidaMarkdown.push("- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.");
+  salidaMarkdown.push("- Los controles fallidos quedan listados en el resumen JSON.");
+  salidaMarkdown.push("- No se aplicó corrección funcional en esta OT.");
+}
+
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealMetodoRacionalRevalidada
+    ? "La salida real/exportable del bloque `Método Racional — contraste global independiente` queda revalidada desde main en el alcance de OT-0321."
+    : "La salida real/exportable del bloque `Método Racional — contraste global independiente` requiere revisión antes de avanzar."
+);
+salidaMarkdown.push("");
+salidaMarkdown.push("## Próximo frente recomendado");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealMetodoRacionalRevalidada
+    ? "`OT-0322 — Revalidación salida real Contraste Q-5 vs Método Racional`"
+    : "`OT-0322 — Revisión adicional Método Racional corregido`"
+);
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0321", { recursive: true });
+fs.writeFileSync(
+  "00_ADMIN/bitacora/OT-0321/OT-0321B_revalidacion_salida_real_metodo_racional_corregido_expediente.md",
+  salidaMarkdown.join("\n"),
+  "utf8"
+);
+
+console.log("VALIDACION_OT_0321_METODO_RACIONAL_REVALIDADO_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` que la corrección aplicada en OT-0320 mantiene la salida real/exportable del bloque `Método Racional — contraste global independiente`.

## Resultado

La revalidación confirmó que el bloque conserva:

```text
## 7. Método Racional — contraste global independiente
Uso: contraste global independiente de caudal pico.
Carácter: no adoptivo principal; requiere revisión técnica antes de adopción.
Relación con Q-5: no pertenece al bloque Q-5 de hidrogramas.

Tabla Método Racional:
| Tr | I | P | C | Q |
|---:|---:|---:|---:|---:|
| 100 | 88,12 mm/h | 74,35 mm | 0,62 | 711,42 m³/s |