### PR TITLE
OT-0322 — Revalidación salida real Contraste Q-5 vs Método Racional

### DIFF
--- a/00_ADMIN/bitacora/OT-0322/OT-0322A_apertura_revalidacion-salida-real-contraste-q5-vs-metodo-racional-expediente.md
+++ b/00_ADMIN/bitacora/OT-0322/OT-0322A_apertura_revalidacion-salida-real-contraste-q5-vs-metodo-racional-expediente.md
@@ -1,0 +1,67 @@
+# OT-0322A — Revalidación salida real Contraste Q-5 vs Método Racional
+
+## Objetivo
+
+Revalidar la salida real/exportable del expediente hidrológico mínimo para el bloque Contraste Q-5 vs Método Racional, comprobando que el bloque existe, aparece una sola vez, queda después del bloque Método Racional, queda antes del control de consistencia Pe–Área–Volumen/Q-5, declara que Q-5 y Método Racional son complementarios pero no equivalentes, no mezcla la tabla racional dentro de Q-5, no mezcla la tabla Q-5 dentro del contraste, no adopta resultados y no recalcula caudales.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0322 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0323 — Corrección salida real Contraste Q-5 vs Método Racional si aplica

--- a/00_ADMIN/bitacora/OT-0322/OT-0322B_revalidacion_salida_real_contraste_q5_vs_metodo_racional.md
+++ b/00_ADMIN/bitacora/OT-0322/OT-0322B_revalidacion_salida_real_contraste_q5_vs_metodo_racional.md
@@ -1,0 +1,214 @@
+# OT-0322B — Revalidación salida real Contraste Q-5 vs Método Racional
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0322",
+  "bloque": "Contraste Q-5 vs Método Racional",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealContrasteQ5RacionalRevalidada": true,
+  "buildAprobado": true,
+  "recalculaQ5": false,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Contraste Q-5 vs Método Racional extraído de salida real
+
+```text
+## 8. Contraste Q-5 vs Método Racional
+Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.
+```
+
+## Controles evaluados
+
+### constructor_existe
+
+```json
+{
+  "id": "constructor_existe",
+  "aprobado": true
+}
+```
+
+### bloque_contraste_presente
+
+```json
+{
+  "id": "bloque_contraste_presente",
+  "aprobado": true
+}
+```
+
+### bloque_contraste_unico
+
+```json
+{
+  "id": "bloque_contraste_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_contraste_extraible
+
+```json
+{
+  "id": "bloque_contraste_extraible",
+  "bloqueContraste": "## 8. Contraste Q-5 vs Método Racional\nLectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+  "aprobado": true
+}
+```
+
+### bloque_contraste_despues_metodo_racional
+
+```json
+{
+  "id": "bloque_contraste_despues_metodo_racional",
+  "indiceRacional": 1787,
+  "indiceContraste": 2161,
+  "aprobado": true
+}
+```
+
+### bloque_contraste_antes_control_volumen
+
+```json
+{
+  "id": "bloque_contraste_antes_control_volumen",
+  "indiceContraste": 2161,
+  "indiceControlVolumen": 2283,
+  "aprobado": true
+}
+```
+
+### contraste_declara_complementarios_no_equivalentes
+
+```json
+{
+  "id": "contraste_declara_complementarios_no_equivalentes",
+  "bloqueContraste": "## 8. Contraste Q-5 vs Método Racional\nLectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+  "aprobado": true
+}
+```
+
+### contraste_no_incrusta_tabla_racional
+
+```json
+{
+  "id": "contraste_no_incrusta_tabla_racional",
+  "bloqueContraste": "## 8. Contraste Q-5 vs Método Racional\nLectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+  "aprobado": true
+}
+```
+
+### contraste_no_incrusta_resumen_q5
+
+```json
+{
+  "id": "contraste_no_incrusta_resumen_q5",
+  "bloqueContraste": "## 8. Contraste Q-5 vs Método Racional\nLectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
+  "aprobado": true
+}
+```
+
+### bloques_q5_racional_contraste_separados
+
+```json
+{
+  "id": "bloques_q5_racional_contraste_separados",
+  "aprobado": true
+}
+```
+
+### bloque_contraste_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_contraste_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_sin_modificacion_en_ot0322
+
+```json
+{
+  "id": "constructor_sin_modificacion_en_ot0322",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable conserva el bloque `Contraste Q-5 vs Método Racional`.
+- El bloque se mantiene separado de `Resumen Q-5 auditado` y de `Método Racional`.
+- El bloque declara que Q-5 y Método Racional son complementarios, pero no equivalentes.
+- El bloque no incrusta tablas de Q-5 ni Método Racional.
+- No se recalcula Q-5.
+- No se recalcula Método Racional.
+- No se selecciona método adoptado.
+- No se modificó código funcional en OT-0322.
+- Build Vite aprobado.
+
+## Decisión
+
+La salida real/exportable del bloque `Contraste Q-5 vs Método Racional` queda revalidada desde main en el alcance de OT-0322.
+
+## Próximo frente recomendado
+
+`OT-0323 — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5`

--- a/00_ADMIN/bitacora/OT-0322/OT-0322C_cierre_revalidacion-salida-real-contraste-q5-vs-metodo-racional-expediente.md
+++ b/00_ADMIN/bitacora/OT-0322/OT-0322C_cierre_revalidacion-salida-real-contraste-q5-vs-metodo-racional-expediente.md
@@ -1,0 +1,83 @@
+# OT-0322C — Cierre Revalidación salida real Contraste Q-5 vs Método Racional
+
+## Resultado
+
+Se revalidó desde `main` la salida real/exportable del bloque `Contraste Q-5 vs Método Racional` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del bloque `Método Racional`, queda antes del control de consistencia `Pe–Área–Volumen/Q-5`, declara que Q-5 y Método Racional son complementarios pero no equivalentes, no incrusta tablas de Q-5 ni Método Racional, no recalcula caudales y no selecciona método adoptado.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0322\OT-0322A_apertura_revalidacion-salida-real-contraste-q5-vs-metodo-racional-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0322\OT-0322B_revalidacion_salida_real_contraste_q5_vs_metodo_racional.md
+
+Script de revalidación:
+
+07_TOOLBOX\validaciones\validar_ot0322_contraste_q5_racional.mjs
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0322",
+  "bloque": "Contraste Q-5 vs Método Racional",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealContrasteQ5RacionalRevalidada": true,
+  "buildAprobado": true,
+  "recalculaQ5": false,
+  "recalculaMetodoRacional": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 8. Contraste Q-5 vs Método Racional
+Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se recalculó Q-5.
+
+No se recalculó Método Racional.
+
+No se seleccionó Método Racional como adoptado.
+
+No se seleccionó caudal racional adoptado.
+
+No se seleccionó método Q-5 adoptado.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0322 queda cerrada como revalidación limpia del bloque `Contraste Q-5 vs Método Racional` en salida real/exportable.
+
+## Próximo frente recomendado
+
+OT-0323 — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5

--- a/07_TOOLBOX/validaciones/validar_ot0322_contraste_q5_racional.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0322_contraste_q5_racional.mjs
@@ -1,0 +1,348 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { pathToFileURL } from "url";
+import { execSync } from "child_process";
+
+const raiz = process.cwd();
+
+const dirDocumentos = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos"
+);
+
+const rutaConstructor = path.join(
+  dirDocumentos,
+  "construirExpedienteHidrologicoMinimo.js"
+);
+
+const marcadorQ5 = "## 6. Resumen Q-5 auditado";
+const marcadorRacional = "## 7. Método Racional — contraste global independiente";
+const marcadorContraste = "## 8. Contraste Q-5 vs Método Racional";
+const marcadorControlVolumen = "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5";
+
+const tokensInvalidos = ["undefined", "null", "NaN", "[object Object]"];
+
+function contar(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function tokensEn(texto) {
+  return tokensInvalidos
+    .map((token) => ({ token, ocurrencias: contar(texto, token) }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function extraerBloque(texto, inicio, siguiente) {
+  const i = texto.indexOf(inicio);
+  if (i < 0) return "";
+  const j = texto.indexOf(siguiente, i + inicio.length);
+  return (j < 0 ? texto.slice(i) : texto.slice(i, j)).trim();
+}
+
+function normalizarSalidaExpediente(salida) {
+  if (typeof salida === "string") return salida;
+  if (typeof salida?.texto === "string") return salida.texto;
+  if (Array.isArray(salida?.lineas)) return salida.lineas.join("\n");
+  return "";
+}
+
+function crearCopiaTemporalDocumentosConImportsJs() {
+  const dirTemporal = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidroflow-ot0322-contraste-documentos-")
+  );
+
+  const archivos = fs
+    .readdirSync(dirDocumentos)
+    .filter((archivo) => archivo.endsWith(".js"));
+
+  for (const archivo of archivos) {
+    const origen = path.join(dirDocumentos, archivo);
+    const destino = path.join(dirTemporal, archivo);
+
+    let contenido = fs.readFileSync(origen, "utf8");
+
+    contenido = contenido.replace(
+      /from\s+["']\.\/([^"']+)["']/g,
+      (coincidencia, modulo) => {
+        if (modulo.endsWith(".js")) return coincidencia;
+
+        const candidato = path.join(dirDocumentos, `${modulo}.js`);
+        if (fs.existsSync(candidato)) {
+          return coincidencia.replace(`./${modulo}`, `./${modulo}.js`);
+        }
+
+        return coincidencia;
+      }
+    );
+
+    fs.writeFileSync(destino, contenido, "utf8");
+  }
+
+  return dirTemporal;
+}
+
+function gitDiffQuiet(rutaRelativa) {
+  try {
+    execSync(`git diff --quiet -- "${rutaRelativa}"`, {
+      cwd: raiz,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dirTemporal = crearCopiaTemporalDocumentosConImportsJs();
+
+const moduloConstructor = await import(
+  pathToFileURL(path.join(dirTemporal, "construirExpedienteHidrologicoMinimo.js")).href
+);
+
+const construirExpedienteHidrologicoMinimo = moduloConstructor.default;
+
+const contextoBasePrueba = {
+  cuenca: {
+    nombre: "La Iguaná PC_80"
+  },
+  area_km2: 46.8516,
+  lluvia_efectiva_total_mm: 56.65,
+  tr_diseno_activo: 100,
+  q_tr_activo_estado: {
+    estado: "activo",
+    fuente: "contexto de cuenca OT-0322"
+  },
+  q_tr_activo: {
+    tr_activo: 100,
+    etiqueta: "Tr 100 años"
+  },
+  metodo_racional: {
+    resultados: [
+      {
+        Tr: 100,
+        I: 88.12,
+        P: 74.35,
+        C: 0.62,
+        Q: 711.42
+      }
+    ]
+  }
+};
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: contextoBasePrueba,
+  metodos: [
+    { metodo: "SCS", qp: 184.03 },
+    { metodo: "Snyder", qp: 124.65 },
+    { metodo: "Clark IUH", qp: 94.28 },
+    { metodo: "Williams & Hann", qp: 518.09 }
+  ],
+  fechaGeneracion: "OT-0322"
+});
+
+const texto = normalizarSalidaExpediente(salida);
+const bloqueQ5 = extraerBloque(texto, marcadorQ5, marcadorRacional);
+const bloqueRacional = extraerBloque(texto, marcadorRacional, marcadorContraste);
+const bloqueContraste = extraerBloque(texto, marcadorContraste, marcadorControlVolumen);
+
+let buildOk = false;
+
+try {
+  const salidaBuild = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = salidaBuild.includes("built") || salidaBuild.includes("✓ built");
+} catch {
+  buildOk = false;
+}
+
+const controles = [
+  {
+    id: "constructor_existe",
+    aprobado: fs.existsSync(rutaConstructor)
+  },
+  {
+    id: "bloque_contraste_presente",
+    aprobado: texto.includes(marcadorContraste)
+  },
+  {
+    id: "bloque_contraste_unico",
+    ocurrencias: contar(texto, marcadorContraste),
+    aprobado: contar(texto, marcadorContraste) === 1
+  },
+  {
+    id: "bloque_contraste_extraible",
+    bloqueContraste,
+    aprobado: bloqueContraste.length > 0
+  },
+  {
+    id: "bloque_contraste_despues_metodo_racional",
+    indiceRacional: texto.indexOf(marcadorRacional),
+    indiceContraste: texto.indexOf(marcadorContraste),
+    aprobado:
+      texto.indexOf(marcadorRacional) >= 0 &&
+      texto.indexOf(marcadorContraste) > texto.indexOf(marcadorRacional)
+  },
+  {
+    id: "bloque_contraste_antes_control_volumen",
+    indiceContraste: texto.indexOf(marcadorContraste),
+    indiceControlVolumen: texto.indexOf(marcadorControlVolumen),
+    aprobado:
+      texto.indexOf(marcadorContraste) >= 0 &&
+      texto.indexOf(marcadorControlVolumen) > texto.indexOf(marcadorContraste)
+  },
+  {
+    id: "contraste_declara_complementarios_no_equivalentes",
+    bloqueContraste,
+    aprobado:
+      bloqueContraste.toLowerCase().includes("complementarios") &&
+      bloqueContraste.toLowerCase().includes("no equivalentes")
+  },
+  {
+    id: "contraste_no_incrusta_tabla_racional",
+    bloqueContraste,
+    aprobado:
+      !bloqueContraste.includes("Tabla Método Racional") &&
+      !bloqueContraste.includes("| Tr | I | P | C | Q |")
+  },
+  {
+    id: "contraste_no_incrusta_resumen_q5",
+    bloqueContraste,
+    aprobado:
+      !bloqueContraste.includes("## 6. Resumen Q-5 auditado") &&
+      !bloqueContraste.includes("Tabla Q-5 auditada")
+  },
+  {
+    id: "bloques_q5_racional_contraste_separados",
+    aprobado:
+      bloqueQ5.length > 0 &&
+      bloqueRacional.length > 0 &&
+      bloqueContraste.length > 0
+  },
+  {
+    id: "bloque_contraste_sin_tokens_invalidos",
+    hallazgos: tokensEn(bloqueContraste),
+    aprobado: tokensEn(bloqueContraste).length === 0
+  },
+  {
+    id: "salida_real_sin_tokens_invalidos",
+    hallazgos: tokensEn(texto),
+    aprobado: tokensEn(texto).length === 0
+  },
+  {
+    id: "constructor_sin_modificacion_en_ot0322",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js")
+  },
+  {
+    id: "comparador_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx")
+  },
+  {
+    id: "qtr_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js")
+  },
+  {
+    id: "q5_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js")
+  },
+  {
+    id: "build_vite",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0322",
+  bloque: "Contraste Q-5 vs Método Racional",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles
+    .filter((control) => !control.aprobado)
+    .map((control) => control.id),
+  salidaRealContrasteQ5RacionalRevalidada: controles.every((control) => control.aprobado),
+  buildAprobado: buildOk,
+  recalculaQ5: false,
+  recalculaMetodoRacional: false,
+  seleccionaMetodoAdoptado: false,
+  modificaMotor: false,
+  modificaUI: false
+};
+
+const salidaMarkdown = [
+  "# OT-0322B — Revalidación salida real Contraste Q-5 vs Método Racional",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque Contraste Q-5 vs Método Racional extraído de salida real",
+  "",
+  "```text",
+  bloqueContraste,
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+
+if (resumen.salidaRealContrasteQ5RacionalRevalidada) {
+  salidaMarkdown.push("- La salida real/exportable conserva el bloque `Contraste Q-5 vs Método Racional`.");
+  salidaMarkdown.push("- El bloque se mantiene separado de `Resumen Q-5 auditado` y de `Método Racional`.");
+  salidaMarkdown.push("- El bloque declara que Q-5 y Método Racional son complementarios, pero no equivalentes.");
+  salidaMarkdown.push("- El bloque no incrusta tablas de Q-5 ni Método Racional.");
+  salidaMarkdown.push("- No se recalcula Q-5.");
+  salidaMarkdown.push("- No se recalcula Método Racional.");
+  salidaMarkdown.push("- No se selecciona método adoptado.");
+  salidaMarkdown.push("- No se modificó código funcional en OT-0322.");
+  salidaMarkdown.push("- Build Vite aprobado.");
+} else {
+  salidaMarkdown.push("- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.");
+  salidaMarkdown.push("- Los controles fallidos quedan listados en el resumen JSON.");
+  salidaMarkdown.push("- No se aplicó corrección funcional en esta OT.");
+}
+
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealContrasteQ5RacionalRevalidada
+    ? "La salida real/exportable del bloque `Contraste Q-5 vs Método Racional` queda revalidada desde main en el alcance de OT-0322."
+    : "La salida real/exportable del bloque `Contraste Q-5 vs Método Racional` requiere revisión antes de avanzar."
+);
+salidaMarkdown.push("");
+salidaMarkdown.push("## Próximo frente recomendado");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealContrasteQ5RacionalRevalidada
+    ? "`OT-0323 — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5`"
+    : "`OT-0323 — Corrección salida real Contraste Q-5 vs Método Racional`"
+);
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0322", { recursive: true });
+fs.writeFileSync(
+  "00_ADMIN/bitacora/OT-0322/OT-0322B_revalidacion_salida_real_contraste_q5_vs_metodo_racional.md",
+  salidaMarkdown.join("\n"),
+  "utf8"
+);
+
+console.log("VALIDACION_OT_0322_CONTRASTE_Q5_RACIONAL_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` la salida real/exportable del bloque `Contraste Q-5 vs Método Racional` del expediente hidrológico mínimo.

## Resultado

La revalidación confirmó que el bloque conserva:

```text
## 8. Contraste Q-5 vs Método Racional
Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.