### PR TITLE
OT-0323 — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0323/OT-0323A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-expediente.md
+++ b/00_ADMIN/bitacora/OT-0323/OT-0323A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-expediente.md
@@ -1,0 +1,67 @@
+# OT-0323A — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5
+
+## Objetivo
+
+Revalidar la salida real/exportable del expediente hidrológico mínimo para el bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5, comprobando que el bloque existe, aparece una sola vez, queda después del bloque Contraste Q-5 vs Método Racional, queda antes del Diagnóstico temporal Q(t), expone la lectura de control interno preliminar, no contiene tokens inválidos, no recalcula volumen, no recalcula Q-5, no modifica motor, no modifica UI, no modifica ComparadorMultiMetodo.jsx y no altera otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0323 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0324 — Corrección salida real Control Pe–Área–Volumen/Q-5 si aplica

--- a/00_ADMIN/bitacora/OT-0323/OT-0323B_revalidacion_salida_real_control_pe_area_volumen_q5.md
+++ b/00_ADMIN/bitacora/OT-0323/OT-0323B_revalidacion_salida_real_control_pe_area_volumen_q5.md
@@ -1,0 +1,226 @@
+# OT-0323B — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0323",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 18,
+  "controlesAprobados": 15,
+  "controlesFallidos": 3,
+  "controlesFallidosIds": [
+    "bloque_control_expone_pe_area_volumen",
+    "bloque_control_expone_q5_principal",
+    "bloque_control_expone_qtr_activo"
+  ],
+  "salidaRealControlPeAreaVolumenQ5Revalidada": false,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Control Pe–Área–Volumen/Q-5 extraído de salida real
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Estado: pendiente de integración completa con datos derivados del expediente operativo.
+```
+
+## Controles evaluados
+
+### constructor_existe
+
+```json
+{
+  "id": "constructor_existe",
+  "aprobado": true
+}
+```
+
+### bloque_control_presente
+
+```json
+{
+  "id": "bloque_control_presente",
+  "aprobado": true
+}
+```
+
+### bloque_control_unico
+
+```json
+{
+  "id": "bloque_control_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_control_extraible
+
+```json
+{
+  "id": "bloque_control_extraible",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": true
+}
+```
+
+### bloque_control_despues_contraste_q5_racional
+
+```json
+{
+  "id": "bloque_control_despues_contraste_q5_racional",
+  "indiceContraste": 2173,
+  "indiceControl": 2295,
+  "aprobado": true
+}
+```
+
+### bloque_control_antes_diagnostico_temporal
+
+```json
+{
+  "id": "bloque_control_antes_diagnostico_temporal",
+  "indiceControl": 2295,
+  "indiceDiagnostico": 2442,
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_lectura_control_interno
+
+```json
+{
+  "id": "bloque_control_expone_lectura_control_interno",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_pe_area_volumen
+
+```json
+{
+  "id": "bloque_control_expone_pe_area_volumen",
+  "descripcion": "El bloque debe exponer explícitamente Pe, Área y Volumen esperado si esos datos están disponibles.",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": false
+}
+```
+
+### bloque_control_expone_q5_principal
+
+```json
+{
+  "id": "bloque_control_expone_q5_principal",
+  "descripcion": "El bloque debe exponer Método Q-5 principal, Volumen Q-5 principal y relación Q-5/esperado si esos datos están disponibles.",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": false
+}
+```
+
+### bloque_control_expone_qtr_activo
+
+```json
+{
+  "id": "bloque_control_expone_qtr_activo",
+  "descripcion": "El bloque debe conservar referencia al Q-Tr activo como parte del control cruzado.",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": false
+}
+```
+
+### bloque_control_no_incrusta_contraste
+
+```json
+{
+  "id": "bloque_control_no_incrusta_contraste",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nEstado: pendiente de integración completa con datos derivados del expediente operativo.",
+  "aprobado": true
+}
+```
+
+### bloque_control_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_control_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_sin_modificacion_en_ot0323
+
+```json
+{
+  "id": "constructor_sin_modificacion_en_ot0323",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.
+- Los controles fallidos quedan listados en el resumen JSON.
+- No se aplicó corrección funcional en esta OT.
+
+## Decisión
+
+La salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` requiere revisión antes de avanzar.
+
+## Próximo frente recomendado
+
+`OT-0324 — Corrección salida real Control Pe–Área–Volumen/Q-5`

--- a/00_ADMIN/bitacora/OT-0323/OT-0323C_cierre_revalidacion-salida-real-control-pe-area-volumen-q5-expediente.md
+++ b/00_ADMIN/bitacora/OT-0323/OT-0323C_cierre_revalidacion-salida-real-control-pe-area-volumen-q5-expediente.md
@@ -1,0 +1,105 @@
+# OT-0323C — Cierre Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5
+
+## Resultado
+
+Se ejecutó la revalidación de la salida real/exportable del expediente hidrológico mínimo para el bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5`.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del bloque `Contraste Q-5 vs Método Racional`, queda antes del `Diagnóstico temporal Q(t) no adoptivo`, no contiene tokens inválidos, no modifica código funcional, no recalcula volumen, no recalcula Q-5, no modifica motor y no modifica UI.
+
+Sin embargo, la revalidación detectó tres brechas técnicas relevantes:
+
+- El bloque no expone explícitamente Pe, Área y Volumen esperado, aunque esos datos se suministran al constructor en el contexto de prueba.
+- El bloque no expone Método Q-5 principal, Volumen Q-5 principal ni relación Q-5/esperado, aunque existen datos Q-5 disponibles en la entrada de prueba.
+- El bloque no conserva referencia al Q-Tr activo como parte del control cruzado.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0323\OT-0323A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0323\OT-0323B_revalidacion_salida_real_control_pe_area_volumen_q5.md
+
+Script de revalidación:
+
+07_TOOLBOX\validaciones\validar_ot0323_control_pe_area_volumen_q5.mjs
+
+## Resultado de controles
+
+```json
+{
+  "validacion": "OT-0323",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 18,
+  "controlesAprobados": 15,
+  "controlesFallidos": 3,
+  "controlesFallidosIds": [
+    "bloque_control_expone_pe_area_volumen",
+    "bloque_control_expone_q5_principal",
+    "bloque_control_expone_qtr_activo"
+  ],
+  "salidaRealControlPeAreaVolumenQ5Revalidada": false,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque extraído de salida real
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Estado: pendiente de integración completa con datos derivados del expediente operativo.
+```
+
+## Hallazgos principales
+
+### 1. Pe–Área–Volumen no expuesto
+
+El bloque no muestra explícitamente Pe total, Área ni Volumen esperado, aunque son datos necesarios para el control físico básico del volumen.
+
+### 2. Q-5 principal no expuesto
+
+El bloque no muestra Método Q-5 principal, Volumen Q-5 principal ni relación volumen Q-5 / volumen esperado.
+
+### 3. Q-Tr activo no referenciado
+
+El bloque no conserva referencia al Q-Tr activo dentro del control cruzado, aunque este dato ya fue corregido y revalidado en OTs anteriores.
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se recalculó volumen.
+
+No se recalculó Q-5.
+
+No se seleccionó método Q-5 adoptado.
+
+No se seleccionó caudal Q-5 adoptado.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0323 queda cerrada como revalidación con hallazgo. El siguiente frente debe corregir la salida real del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5`, exponiendo datos ya disponibles en contexto, sin recalcular volumen, sin recalcular Q-5 y sin modificar motor, UI ni ComparadorMultiMetodo.jsx.
+
+## Próximo frente recomendado
+
+OT-0324 — Corrección salida real Control Pe–Área–Volumen/Q-5

--- a/07_TOOLBOX/validaciones/validar_ot0323_control_pe_area_volumen_q5.mjs
+++ b/07_TOOLBOX/validaciones/validar_ot0323_control_pe_area_volumen_q5.mjs
@@ -1,0 +1,392 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { pathToFileURL } from "url";
+import { execSync } from "child_process";
+
+const raiz = process.cwd();
+
+const dirDocumentos = path.join(
+  raiz,
+  "01_APP/HIDROFLOW/src/services/documentos"
+);
+
+const rutaConstructor = path.join(
+  dirDocumentos,
+  "construirExpedienteHidrologicoMinimo.js"
+);
+
+const marcadorContraste = "## 8. Contraste Q-5 vs Método Racional";
+const marcadorControlVolumen = "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5";
+const marcadorDiagnosticoTemporal = "## Diagnóstico temporal Q(t) no adoptivo";
+
+const tokensInvalidos = ["undefined", "null", "NaN", "[object Object]"];
+
+function contar(texto, patron) {
+  return texto.split(patron).length - 1;
+}
+
+function tokensEn(texto) {
+  return tokensInvalidos
+    .map((token) => ({ token, ocurrencias: contar(texto, token) }))
+    .filter((item) => item.ocurrencias > 0);
+}
+
+function extraerBloque(texto, inicio, siguiente) {
+  const i = texto.indexOf(inicio);
+  if (i < 0) return "";
+  const j = texto.indexOf(siguiente, i + inicio.length);
+  return (j < 0 ? texto.slice(i) : texto.slice(i, j)).trim();
+}
+
+function normalizarSalidaExpediente(salida) {
+  if (typeof salida === "string") return salida;
+  if (typeof salida?.texto === "string") return salida.texto;
+  if (Array.isArray(salida?.lineas)) return salida.lineas.join("\n");
+  return "";
+}
+
+function crearCopiaTemporalDocumentosConImportsJs() {
+  const dirTemporal = fs.mkdtempSync(
+    path.join(os.tmpdir(), "hidroflow-ot0323-control-volumen-documentos-")
+  );
+
+  const archivos = fs
+    .readdirSync(dirDocumentos)
+    .filter((archivo) => archivo.endsWith(".js"));
+
+  for (const archivo of archivos) {
+    const origen = path.join(dirDocumentos, archivo);
+    const destino = path.join(dirTemporal, archivo);
+
+    let contenido = fs.readFileSync(origen, "utf8");
+
+    contenido = contenido.replace(
+      /from\s+["']\.\/([^"']+)["']/g,
+      (coincidencia, modulo) => {
+        if (modulo.endsWith(".js")) return coincidencia;
+
+        const candidato = path.join(dirDocumentos, `${modulo}.js`);
+        if (fs.existsSync(candidato)) {
+          return coincidencia.replace(`./${modulo}`, `./${modulo}.js`);
+        }
+
+        return coincidencia;
+      }
+    );
+
+    fs.writeFileSync(destino, contenido, "utf8");
+  }
+
+  return dirTemporal;
+}
+
+function gitDiffQuiet(rutaRelativa) {
+  try {
+    execSync(`git diff --quiet -- "${rutaRelativa}"`, {
+      cwd: raiz,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const dirTemporal = crearCopiaTemporalDocumentosConImportsJs();
+
+const moduloConstructor = await import(
+  pathToFileURL(path.join(dirTemporal, "construirExpedienteHidrologicoMinimo.js")).href
+);
+
+const construirExpedienteHidrologicoMinimo = moduloConstructor.default;
+
+const contextoBasePrueba = {
+  cuenca: {
+    nombre: "La Iguaná PC_80"
+  },
+  area_km2: 46.8516,
+  lluvia_efectiva_total_mm: 56.65,
+  tr_diseno_activo: 100,
+  q_tr_activo_estado: {
+    estado: "activo",
+    fuente: "contexto de cuenca OT-0323"
+  },
+  q_tr_activo: {
+    tr_activo: 100,
+    etiqueta: "Tr 100 años"
+  },
+  metodo_racional: {
+    resultados: [
+      {
+        Tr: 100,
+        I: 88.12,
+        P: 74.35,
+        C: 0.62,
+        Q: 711.42
+      }
+    ]
+  }
+};
+
+const salida = construirExpedienteHidrologicoMinimo({
+  contextoBase: contextoBasePrueba,
+  peTotalMm: 56.65,
+  volumenEsperadoM3: 2654250.9,
+  metodos: [
+    {
+      metodo: "SCS Unit Hydrograph",
+      nombre: "SCS Unit Hydrograph",
+      Qp: 184.03,
+      Tp: 210,
+      volumen: 2654250.9
+    },
+    {
+      metodo: "Snyder",
+      nombre: "Snyder",
+      Qp: 124.65,
+      Tp: 405,
+      volumen: 2654250.9
+    },
+    {
+      metodo: "Clark IUH",
+      nombre: "Clark IUH",
+      Qp: 94.28,
+      Tp: 300,
+      volumen: 2654250.9
+    },
+    {
+      metodo: "Williams & Hann",
+      nombre: "Williams & Hann",
+      Qp: 518.09,
+      Tp: 20,
+      volumen: 2654250.9
+    }
+  ],
+  fechaGeneracion: "OT-0323"
+});
+
+const texto = normalizarSalidaExpediente(salida);
+const bloqueContraste = extraerBloque(texto, marcadorContraste, marcadorControlVolumen);
+const bloqueControl = extraerBloque(texto, marcadorControlVolumen, marcadorDiagnosticoTemporal);
+
+let buildOk = false;
+
+try {
+  const salidaBuild = execSync("npm run build", {
+    cwd: "01_APP/HIDROFLOW",
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  buildOk = salidaBuild.includes("built") || salidaBuild.includes("✓ built");
+} catch {
+  buildOk = false;
+}
+
+const controles = [
+  {
+    id: "constructor_existe",
+    aprobado: fs.existsSync(rutaConstructor)
+  },
+  {
+    id: "bloque_control_presente",
+    aprobado: texto.includes(marcadorControlVolumen)
+  },
+  {
+    id: "bloque_control_unico",
+    ocurrencias: contar(texto, marcadorControlVolumen),
+    aprobado: contar(texto, marcadorControlVolumen) === 1
+  },
+  {
+    id: "bloque_control_extraible",
+    bloqueControl,
+    aprobado: bloqueControl.length > 0
+  },
+  {
+    id: "bloque_control_despues_contraste_q5_racional",
+    indiceContraste: texto.indexOf(marcadorContraste),
+    indiceControl: texto.indexOf(marcadorControlVolumen),
+    aprobado:
+      texto.indexOf(marcadorContraste) >= 0 &&
+      texto.indexOf(marcadorControlVolumen) > texto.indexOf(marcadorContraste)
+  },
+  {
+    id: "bloque_control_antes_diagnostico_temporal",
+    indiceControl: texto.indexOf(marcadorControlVolumen),
+    indiceDiagnostico: texto.indexOf(marcadorDiagnosticoTemporal),
+    aprobado:
+      texto.indexOf(marcadorControlVolumen) >= 0 &&
+      texto.indexOf(marcadorDiagnosticoTemporal) > texto.indexOf(marcadorControlVolumen)
+  },
+  {
+    id: "bloque_control_expone_lectura_control_interno",
+    bloqueControl,
+    aprobado:
+      bloqueControl.toLowerCase().includes("control") &&
+      (
+        bloqueControl.toLowerCase().includes("preliminar") ||
+        bloqueControl.toLowerCase().includes("consistencia") ||
+        bloqueControl.toLowerCase().includes("pendiente")
+      )
+  },
+  {
+    id: "bloque_control_expone_pe_area_volumen",
+    descripcion:
+      "El bloque debe exponer explícitamente Pe, Área y Volumen esperado si esos datos están disponibles.",
+    bloqueControl,
+    aprobado:
+      bloqueControl.includes("Pe") &&
+      bloqueControl.includes("Área") &&
+      bloqueControl.includes("Volumen esperado")
+  },
+  {
+    id: "bloque_control_expone_q5_principal",
+    descripcion:
+      "El bloque debe exponer Método Q-5 principal, Volumen Q-5 principal y relación Q-5/esperado si esos datos están disponibles.",
+    bloqueControl,
+    aprobado:
+      bloqueControl.includes("Método Q-5 principal") &&
+      bloqueControl.includes("Volumen Q-5 principal") &&
+      (
+        bloqueControl.includes("Relación volumen Q-5 / volumen esperado") ||
+        bloqueControl.includes("Relación Q-5/esperado")
+      )
+  },
+  {
+    id: "bloque_control_expone_qtr_activo",
+    descripcion:
+      "El bloque debe conservar referencia al Q-Tr activo como parte del control cruzado.",
+    bloqueControl,
+    aprobado:
+      bloqueControl.includes("Q-Tr activo") ||
+      bloqueControl.includes("QTr activo")
+  },
+  {
+    id: "bloque_control_no_incrusta_contraste",
+    bloqueControl,
+    aprobado:
+      !bloqueControl.includes("## 8. Contraste Q-5 vs Método Racional")
+  },
+  {
+    id: "bloque_control_sin_tokens_invalidos",
+    hallazgos: tokensEn(bloqueControl),
+    aprobado: tokensEn(bloqueControl).length === 0
+  },
+  {
+    id: "salida_real_sin_tokens_invalidos",
+    hallazgos: tokensEn(texto),
+    aprobado: tokensEn(texto).length === 0
+  },
+  {
+    id: "constructor_sin_modificacion_en_ot0323",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js")
+  },
+  {
+    id: "comparador_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx")
+  },
+  {
+    id: "qtr_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js")
+  },
+  {
+    id: "q5_sin_modificacion",
+    aprobado: gitDiffQuiet("01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js")
+  },
+  {
+    id: "build_vite",
+    aprobado: buildOk
+  }
+];
+
+const resumen = {
+  validacion: "OT-0323",
+  bloque: "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  totalControles: controles.length,
+  controlesAprobados: controles.filter((control) => control.aprobado).length,
+  controlesFallidos: controles.filter((control) => !control.aprobado).length,
+  controlesFallidosIds: controles
+    .filter((control) => !control.aprobado)
+    .map((control) => control.id),
+  salidaRealControlPeAreaVolumenQ5Revalidada: controles.every((control) => control.aprobado),
+  buildAprobado: buildOk,
+  recalculaVolumen: false,
+  recalculaQ5: false,
+  seleccionaMetodoAdoptado: false,
+  modificaMotor: false,
+  modificaUI: false
+};
+
+const salidaMarkdown = [
+  "# OT-0323B — Revalidación salida real Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "",
+  "## Resumen",
+  "",
+  "```json",
+  JSON.stringify(resumen, null, 2),
+  "```",
+  "",
+  "## Bloque Control Pe–Área–Volumen/Q-5 extraído de salida real",
+  "",
+  "```text",
+  bloqueControl,
+  "```",
+  "",
+  "## Controles evaluados",
+  ""
+];
+
+for (const control of controles) {
+  salidaMarkdown.push(`### ${control.id}`);
+  salidaMarkdown.push("");
+  salidaMarkdown.push("```json");
+  salidaMarkdown.push(JSON.stringify(control, null, 2));
+  salidaMarkdown.push("```");
+  salidaMarkdown.push("");
+}
+
+salidaMarkdown.push("## Lectura técnica");
+salidaMarkdown.push("");
+
+if (resumen.salidaRealControlPeAreaVolumenQ5Revalidada) {
+  salidaMarkdown.push("- La salida real/exportable conserva el bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5`.");
+  salidaMarkdown.push("- El bloque expone Pe, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado y Q-Tr activo.");
+  salidaMarkdown.push("- El bloque mantiene lectura de control interno preliminar.");
+  salidaMarkdown.push("- No se recalcula volumen.");
+  salidaMarkdown.push("- No se recalcula Q-5.");
+  salidaMarkdown.push("- No se selecciona método adoptado.");
+  salidaMarkdown.push("- No se modificó código funcional en OT-0323.");
+  salidaMarkdown.push("- Build Vite aprobado.");
+} else {
+  salidaMarkdown.push("- La revalidación detectó controles fallidos que deben revisarse antes de avanzar.");
+  salidaMarkdown.push("- Los controles fallidos quedan listados en el resumen JSON.");
+  salidaMarkdown.push("- No se aplicó corrección funcional en esta OT.");
+}
+
+salidaMarkdown.push("");
+salidaMarkdown.push("## Decisión");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealControlPeAreaVolumenQ5Revalidada
+    ? "La salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` queda revalidada desde main en el alcance de OT-0323."
+    : "La salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` requiere revisión antes de avanzar."
+);
+salidaMarkdown.push("");
+salidaMarkdown.push("## Próximo frente recomendado");
+salidaMarkdown.push("");
+salidaMarkdown.push(
+  resumen.salidaRealControlPeAreaVolumenQ5Revalidada
+    ? "`OT-0324 — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo`"
+    : "`OT-0324 — Corrección salida real Control Pe–Área–Volumen/Q-5`"
+);
+
+fs.mkdirSync("00_ADMIN/bitacora/OT-0323", { recursive: true });
+fs.writeFileSync(
+  "00_ADMIN/bitacora/OT-0323/OT-0323B_revalidacion_salida_real_control_pe_area_volumen_q5.md",
+  salidaMarkdown.join("\n"),
+  "utf8"
+);
+
+console.log("VALIDACION_OT_0323_CONTROL_PE_AREA_VOLUMEN_Q5_COMPLETADA");
+console.log(JSON.stringify(resumen, null, 2));


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` la salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` del expediente hidrológico mínimo.

## Resultado

La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del bloque `Contraste Q-5 vs Método Racional`, queda antes del `Diagnóstico temporal Q(t) no adoptivo`, no contiene tokens inválidos, no modifica código funcional y no recalcula volumen ni Q-5.

Sin embargo, detectó tres brechas técnicas relevantes:

- El bloque no expone explícitamente Pe, Área y Volumen esperado.
- El bloque no expone Método Q-5 principal, Volumen Q-5 principal ni relación Q-5/esperado.
- El bloque no conserva referencia al Q-Tr activo.

## Evidencia

```json
{
  "validacion": "OT-0323",
  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
  "totalControles": 18,
  "controlesAprobados": 15,
  "controlesFallidos": 3,
  "controlesFallidosIds": [
    "bloque_control_expone_pe_area_volumen",
    "bloque_control_expone_q5_principal",
    "bloque_control_expone_qtr_activo"
  ],
  "salidaRealControlPeAreaVolumenQ5Revalidada": false,
  "buildAprobado": true,
  "recalculaVolumen": false,
  "recalculaQ5": false,
  "seleccionaMetodoAdoptado": false,
  "modificaMotor": false,
  "modificaUI": false
}