### PR TITLE
OT-0324 — Corrección salida real Control Pe–Área–Volumen/Q-5

### DIFF
--- a/00_ADMIN/bitacora/OT-0324/OT-0324A_apertura_correccion-salida-real-control-pe-area-volumen-q5-expediente.md
+++ b/00_ADMIN/bitacora/OT-0324/OT-0324A_apertura_correccion-salida-real-control-pe-area-volumen-q5-expediente.md
@@ -1,0 +1,64 @@
+# OT-0324A — Corrección salida real Control Pe–Área–Volumen/Q-5
+
+## Objetivo
+
+Corregir de forma mínima y controlada la salida real/exportable del bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5 del expediente hidrológico mínimo, para que exponga Pe total, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo cuando existan datos disponibles en contexto, sin recalcular volumen, sin recalcular Q-5, sin seleccionar método adoptado, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers no relacionados con Control Pe–Área–Volumen/Q-5.
+- No crear helper funcional nuevo.
+- No acoplar otros helpers en esta OT.
+- Modificar únicamente lo estrictamente necesario para que el bloque Control Pe–Área–Volumen/Q-5 exponga datos ya disponibles en contexto.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0325 — Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido

--- a/00_ADMIN/bitacora/OT-0324/OT-0324B_correccion_salida_real_control_pe_area_volumen_q5.md
+++ b/00_ADMIN/bitacora/OT-0324/OT-0324B_correccion_salida_real_control_pe_area_volumen_q5.md
@@ -1,0 +1,213 @@
+# OT-0324B — Corrección salida real Control Pe–Área–Volumen/Q-5
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0324",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealControlPeAreaVolumenQ5Corregida": true,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Control Pe–Área–Volumen/Q-5 extraído de salida real corregida
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Lectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.
+Pe total: 56,65 mm
+Área: 46,8516 km²
+Volumen esperado: 2.654.250,9 m³
+Método Q-5 principal: SCS Unit Hydrograph
+Volumen Q-5 principal: 2.654.250,9 m³
+Relación volumen Q-5 / volumen esperado: 1
+Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
+Q-Tr activo: Tr 100 años
+```
+
+## Controles evaluados
+
+### bloque_control_presente
+
+```json
+{
+  "id": "bloque_control_presente",
+  "aprobado": true
+}
+```
+
+### bloque_control_unico
+
+```json
+{
+  "id": "bloque_control_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_control_extraible
+
+```json
+{
+  "id": "bloque_control_extraible",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nLectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.\nPe total: 56,65 mm\nÁrea: 46,8516 km²\nVolumen esperado: 2.654.250,9 m³\nMétodo Q-5 principal: SCS Unit Hydrograph\nVolumen Q-5 principal: 2.654.250,9 m³\nRelación volumen Q-5 / volumen esperado: 1\nResultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_control_despues_contraste_q5_racional
+
+```json
+{
+  "id": "bloque_control_despues_contraste_q5_racional",
+  "indiceContraste": 2173,
+  "indiceControl": 2295,
+  "aprobado": true
+}
+```
+
+### bloque_control_antes_diagnostico_temporal
+
+```json
+{
+  "id": "bloque_control_antes_diagnostico_temporal",
+  "indiceControl": 2295,
+  "indiceDiagnostico": 2821,
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_pe_area_volumen
+
+```json
+{
+  "id": "bloque_control_expone_pe_area_volumen",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_q5_principal
+
+```json
+{
+  "id": "bloque_control_expone_q5_principal",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_resultado_consistencia
+
+```json
+{
+  "id": "bloque_control_expone_resultado_consistencia",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_qtr_activo
+
+```json
+{
+  "id": "bloque_control_expone_qtr_activo",
+  "aprobado": true
+}
+```
+
+### bloque_control_declara_no_recalculo
+
+```json
+{
+  "id": "bloque_control_declara_no_recalculo",
+  "aprobado": true
+}
+```
+
+### bloque_control_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_control_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_modificado_en_alcance_ot0324
+
+```json
+{
+  "id": "constructor_modificado_en_alcance_ot0324",
+  "descripcion": "El constructor puede modificarse en OT-0324 porque el bloque vive inline allí.",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable expone Pe, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo.
+- La corrección no recalcula volumen.
+- La corrección no recalcula Q-5.
+- La corrección no selecciona método adoptado.
+- La modificación funcional se limita al constructor documental del expediente.
+- Build Vite aprobado.
+
+## Decisión
+
+La salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` queda corregida en el alcance de OT-0324.

--- a/00_ADMIN/bitacora/OT-0324/OT-0324C_cierre_correccion-salida-real-control-pe-area-volumen-q5-expediente.md
+++ b/00_ADMIN/bitacora/OT-0324/OT-0324C_cierre_correccion-salida-real-control-pe-area-volumen-q5-expediente.md
@@ -1,0 +1,94 @@
+# OT-0324C — Cierre Corrección salida real Control Pe–Área–Volumen/Q-5
+
+## Resultado
+
+Se corrigió de forma mínima y controlada la salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` del expediente hidrológico mínimo.
+
+La corrección permite que el bloque exponga datos ya disponibles en contexto: Pe total, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0324\OT-0324A_apertura_correccion-salida-real-control-pe-area-volumen-q5-expediente.md
+
+Documento de corrección y validación inline:
+
+00_ADMIN\bitacora\OT-0324\OT-0324B_correccion_salida_real_control_pe_area_volumen_q5.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0324",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealControlPeAreaVolumenQ5Corregida": true,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque corregido extraído de salida real
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Lectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.
+Pe total: 56,65 mm
+Área: 46,8516 km²
+Volumen esperado: 2.654.250,9 m³
+Método Q-5 principal: SCS Unit Hydrograph
+Volumen Q-5 principal: 2.654.250,9 m³
+Relación volumen Q-5 / volumen esperado: 1
+Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
+Q-Tr activo: Tr 100 años
+```
+
+## Cambios aplicados
+
+Se modificó únicamente:
+
+- `01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+El ajuste expone datos ya disponibles en contexto. No recalcula volumen ni Q-5.
+
+## Alcance mantenido
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers no relacionados.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalculó volumen.
+
+No se recalculó Q-5.
+
+No se seleccionó método Q-5 adoptado.
+
+No se seleccionó caudal Q-5 adoptado.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0324 queda cerrada como corrección mínima del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` en salida real/exportable.
+
+## Próximo frente recomendado
+
+OT-0325 — Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -253,6 +253,46 @@ export default function construirExpedienteHidrologicoMinimo({
     Number.isFinite(Number(volumenEsperadoM3EntradaDocumental))
       ? Number(volumenEsperadoM3EntradaDocumental)
       : volumenEsperadoM3;
+
+  const metodoQ5PrincipalControlDocumental = Array.isArray(metodos)
+    ? metodos.find((metodo) =>
+        Number.isFinite(Number(metodo?.volumen)) ||
+        Number.isFinite(Number(metodo?.volTotal)) ||
+        Number.isFinite(Number(metodo?.volumenTotal)) ||
+        Number.isFinite(Number(metodo?.volTotalM3))
+      )
+    : null;
+
+  const volumenQ5PrincipalControlDocumental =
+    Number(metodoQ5PrincipalControlDocumental?.volumen) ||
+    Number(metodoQ5PrincipalControlDocumental?.volTotal) ||
+    Number(metodoQ5PrincipalControlDocumental?.volumenTotal) ||
+    Number(metodoQ5PrincipalControlDocumental?.volTotalM3);
+
+  const relacionVolumenQ5EsperadoControlDocumental =
+    Number.isFinite(Number(volumenQ5PrincipalControlDocumental)) &&
+    Number.isFinite(Number(volumenEsperadoM3BloqueVolumenReferenciaDocumental)) &&
+    Number(volumenEsperadoM3BloqueVolumenReferenciaDocumental) !== 0
+      ? Number(volumenQ5PrincipalControlDocumental) /
+        Number(volumenEsperadoM3BloqueVolumenReferenciaDocumental)
+      : null;
+
+  const resultadoConsistenciaVolumetricaControlDocumental =
+    Number.isFinite(Number(relacionVolumenQ5EsperadoControlDocumental))
+      ? "relación volumétrica documentada para control interno preliminar"
+      : "relación volumétrica no disponible en contexto";
+
+  const qTrActivoControlDocumental =
+    contextoBase?.q_tr_activo?.etiqueta ??
+    contextoBase?.q_tr_activo?.label ??
+    contextoBase?.q_tr_activo?.tr_activo ??
+    contextoBase?.q_tr_activo?.Tr ??
+    contextoBase?.q_tr_activo?.TR ??
+    contextoBase?.q_tr_activo?.periodoRetorno ??
+    contextoBase?.q_tr_activo?.periodo_retorno ??
+    trDisenoActivoExpedienteDocumental ??
+    null;
+
   const texto = [
     "# Expediente hidrológico mínimo — Cuenca activa",
     "Estado técnico del expediente: BORRADOR GENERADO POR HELPER PURO INICIAL.",
@@ -303,7 +343,15 @@ export default function construirExpedienteHidrologicoMinimo({
     "Lectura técnica: Q-5 y Método Racional son complementarios, pero no equivalentes.",
     "",
     "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5",
-    "Estado: pendiente de integración completa con datos derivados del expediente operativo.",
+    "Lectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.",
+    `Pe total: ${formatearValorRacionalExpediente(peTotalMmBloqueVolumenReferenciaDocumental, " mm")}`,
+    `Área: ${formatearValorRacionalExpediente(areaKm2, " km²", 4)}`,
+    `Volumen esperado: ${formatearValorRacionalExpediente(volumenEsperadoM3BloqueVolumenReferenciaDocumental, " m³")}`,
+    `Método Q-5 principal: ${metodoQ5PrincipalControlDocumental?.metodo ?? metodoQ5PrincipalControlDocumental?.nombre ?? "—"}`,
+    `Volumen Q-5 principal: ${formatearValorRacionalExpediente(volumenQ5PrincipalControlDocumental, " m³")}`,
+    `Relación volumen Q-5 / volumen esperado: ${formatearValorRacionalExpediente(relacionVolumenQ5EsperadoControlDocumental, "", 4)}`,
+    `Resultado de consistencia volumétrica: ${resultadoConsistenciaVolumetricaControlDocumental}`,
+    `Q-Tr activo: ${formatearValorRacionalExpediente(qTrActivoControlDocumental)}`,
     "",
     "## Diagnóstico temporal Q(t) no adoptivo",
     `Filas morfológicas recibidas: ${Array.isArray(filasMorfologiaQt) ? filasMorfologiaQt.length : 0}`,


### PR DESCRIPTION
## Resumen

Esta OT corrige de forma mínima la salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5`.

## Resultado

El bloque pasa a exponer datos ya disponibles en contexto:

```text
Pe total: 56,65 mm
Área: 46,8516 km²
Volumen esperado: 2.654.250,9 m³
Método Q-5 principal: SCS Unit Hydrograph
Volumen Q-5 principal: 2.654.250,9 m³
Relación volumen Q-5 / volumen esperado: 1
Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
Q-Tr activo: Tr 100 años