### PR TITLE
OT-0325 — Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido

### DIFF
--- a/00_ADMIN/bitacora/OT-0325/OT-0325A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0325/OT-0325A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-corregido-expediente.md
@@ -1,0 +1,69 @@
+# OT-0325A — Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido
+
+## Objetivo
+
+Revalidar desde main que la corrección aplicada en OT-0324 mantiene la salida real/exportable del bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5, comprobando que expone Pe total, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo, sin recalcular volumen, sin recalcular Q-5, sin seleccionar método adoptado, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo salvo necesidad estricta.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0325 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0326 — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo

--- a/00_ADMIN/bitacora/OT-0325/OT-0325B_revalidacion_salida_real_control_pe_area_volumen_q5_corregido.md
+++ b/00_ADMIN/bitacora/OT-0325/OT-0325B_revalidacion_salida_real_control_pe_area_volumen_q5_corregido.md
@@ -1,0 +1,214 @@
+# OT-0325B — Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0325",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealControlPeAreaVolumenQ5Revalidada": true,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Control Pe–Área–Volumen/Q-5 extraído de salida real revalidada
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Lectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.
+Pe total: 56,65 mm
+Área: 46,8516 km²
+Volumen esperado: 2.654.250,9 m³
+Método Q-5 principal: SCS Unit Hydrograph
+Volumen Q-5 principal: 2.654.250,9 m³
+Relación volumen Q-5 / volumen esperado: 1
+Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
+Q-Tr activo: Tr 100 años
+```
+
+## Controles evaluados
+
+### bloque_control_presente
+
+```json
+{
+  "id": "bloque_control_presente",
+  "aprobado": true
+}
+```
+
+### bloque_control_unico
+
+```json
+{
+  "id": "bloque_control_unico",
+  "ocurrencias": 1,
+  "aprobado": true
+}
+```
+
+### bloque_control_extraible
+
+```json
+{
+  "id": "bloque_control_extraible",
+  "bloqueControl": "## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5\nLectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.\nPe total: 56,65 mm\nÁrea: 46,8516 km²\nVolumen esperado: 2.654.250,9 m³\nMétodo Q-5 principal: SCS Unit Hydrograph\nVolumen Q-5 principal: 2.654.250,9 m³\nRelación volumen Q-5 / volumen esperado: 1\nResultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar\nQ-Tr activo: Tr 100 años",
+  "aprobado": true
+}
+```
+
+### bloque_control_despues_contraste_q5_racional
+
+```json
+{
+  "id": "bloque_control_despues_contraste_q5_racional",
+  "indiceContraste": 2173,
+  "indiceControl": 2295,
+  "aprobado": true
+}
+```
+
+### bloque_control_antes_diagnostico_temporal
+
+```json
+{
+  "id": "bloque_control_antes_diagnostico_temporal",
+  "indiceControl": 2295,
+  "indiceDiagnostico": 2821,
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_pe_area_volumen
+
+```json
+{
+  "id": "bloque_control_expone_pe_area_volumen",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_q5_principal
+
+```json
+{
+  "id": "bloque_control_expone_q5_principal",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_resultado_consistencia
+
+```json
+{
+  "id": "bloque_control_expone_resultado_consistencia",
+  "aprobado": true
+}
+```
+
+### bloque_control_expone_qtr_activo
+
+```json
+{
+  "id": "bloque_control_expone_qtr_activo",
+  "aprobado": true
+}
+```
+
+### bloque_control_declara_no_recalculo
+
+```json
+{
+  "id": "bloque_control_declara_no_recalculo",
+  "aprobado": true
+}
+```
+
+### bloque_control_sin_tokens_invalidos
+
+```json
+{
+  "id": "bloque_control_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### salida_real_sin_tokens_invalidos
+
+```json
+{
+  "id": "salida_real_sin_tokens_invalidos",
+  "hallazgos": [],
+  "aprobado": true
+}
+```
+
+### constructor_sin_modificacion_en_ot0325
+
+```json
+{
+  "id": "constructor_sin_modificacion_en_ot0325",
+  "descripcion": "OT-0325 es revalidación desde main; no debe modificar el constructor.",
+  "aprobado": true
+}
+```
+
+### comparador_sin_modificacion
+
+```json
+{
+  "id": "comparador_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### qtr_sin_modificacion
+
+```json
+{
+  "id": "qtr_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### q5_sin_modificacion
+
+```json
+{
+  "id": "q5_sin_modificacion",
+  "aprobado": true
+}
+```
+
+### build_vite
+
+```json
+{
+  "id": "build_vite",
+  "aprobado": true
+}
+```
+
+## Lectura técnica
+
+- La salida real/exportable conserva el bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` corregido.
+- El bloque expone Pe, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo.
+- No se recalcula volumen.
+- No se recalcula Q-5.
+- No se selecciona método adoptado.
+- No se modificó código funcional en OT-0325.
+- Build Vite aprobado.
+
+## Decisión
+
+La salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` queda revalidada desde main en el alcance de OT-0325.

--- a/00_ADMIN/bitacora/OT-0325/OT-0325C_cierre_revalidacion-salida-real-control-pe-area-volumen-q5-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0325/OT-0325C_cierre_revalidacion-salida-real-control-pe-area-volumen-q5-corregido-expediente.md
@@ -1,0 +1,87 @@
+# OT-0325C — Cierre Revalidación salida real Control Pe–Área–Volumen/Q-5 corregido
+
+## Resultado
+
+Se revalidó desde `main` la corrección aplicada en OT-0324 sobre la salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque conserva Pe total, Área, Volumen esperado, Método Q-5 principal, Volumen Q-5 principal, relación Q-5/esperado, resultado de consistencia volumétrica y Q-Tr activo.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0325\OT-0325A_apertura_revalidacion-salida-real-control-pe-area-volumen-q5-corregido-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0325\OT-0325B_revalidacion_salida_real_control_pe_area_volumen_q5_corregido.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0325",
+  "bloque": "Control de consistencia cruzada Pe–Área–Volumen/Q-5",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealControlPeAreaVolumenQ5Revalidada": true,
+  "buildAprobado": true,
+  "recalculaVolumen": false,
+  "recalculaQ5": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 9. Control de consistencia cruzada Pe–Área–Volumen/Q-5
+Lectura técnica: control interno preliminar de consistencia volumétrica; no recalcula volumen, no recalcula Q-5 y no selecciona método adoptado.
+Pe total: 56,65 mm
+Área: 46,8516 km²
+Volumen esperado: 2.654.250,9 m³
+Método Q-5 principal: SCS Unit Hydrograph
+Volumen Q-5 principal: 2.654.250,9 m³
+Relación volumen Q-5 / volumen esperado: 1
+Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
+Q-Tr activo: Tr 100 años
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalculó volumen.
+
+No se recalculó Q-5.
+
+No se seleccionó método adoptado.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0325 queda cerrada como revalidación limpia de la corrección del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5` aplicada en OT-0324.
+
+## Próximo frente recomendado
+
+OT-0326 — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` que la corrección aplicada en OT-0324 mantiene la salida real/exportable del bloque `Control de consistencia cruzada Pe–Área–Volumen/Q-5`.

## Resultado

El bloque conserva:

```text
Pe total: 56,65 mm
Área: 46,8516 km²
Volumen esperado: 2.654.250,9 m³
Método Q-5 principal: SCS Unit Hydrograph
Volumen Q-5 principal: 2.654.250,9 m³
Relación volumen Q-5 / volumen esperado: 1
Resultado de consistencia volumétrica: relación volumétrica documentada para control interno preliminar
Q-Tr activo: Tr 100 años