### PR TITLE
OT-0326 — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo

### DIFF
--- a/00_ADMIN/bitacora/OT-0326/OT-0326A_apertura_revalidacion-salida-real-diagnostico-temporal-qt-no-adoptivo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0326/OT-0326A_apertura_revalidacion-salida-real-diagnostico-temporal-qt-no-adoptivo-expediente.md
@@ -1,0 +1,70 @@
+# OT-0326A — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo
+
+## Objetivo
+
+Revalidar desde main la salida real/exportable del bloque Diagnóstico temporal Q(t) no adoptivo del expediente hidrológico mínimo, comprobando que el bloque existe, aparece una sola vez, queda después del control de consistencia Pe–Área–Volumen/Q-5, queda antes de la validación interna del expediente exportado, conserva su restricción no adoptiva, no selecciona método, no levanta No coherente, no recalcula hidrogramas, no modifica motor, no modifica UI, no modifica ComparadorMultiMetodo.jsx y no altera otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo salvo necesidad estricta.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0326 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No modificar bloque Validación interna del expediente exportado.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0327 — Revalidación salida real Validación interna del expediente exportado

--- a/00_ADMIN/bitacora/OT-0326/OT-0326B_revalidacion_salida_real_diagnostico_temporal_qt_no_adoptivo.md
+++ b/00_ADMIN/bitacora/OT-0326/OT-0326B_revalidacion_salida_real_diagnostico_temporal_qt_no_adoptivo.md
@@ -1,0 +1,55 @@
+# OT-0326B — Revalidación salida real Diagnóstico temporal Q(t) no adoptivo
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0326",
+  "bloque": "Diagnóstico temporal Q(t) no adoptivo",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealDiagnosticoTemporalQtRevalidada": true,
+  "buildAprobado": true,
+  "recalculaHidrogramas": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Diagnóstico temporal Q(t) extraído de salida real
+
+```text
+## Diagnóstico temporal Q(t) no adoptivo
+Filas morfológicas recibidas: 1
+Filas de forma recibidas: 1
+Filas de riesgo recibidas: 1
+Síntesis de riesgo temporal: recibida
+Restricción: diagnóstico no adoptivo; no selecciona método ni levanta No coherente.
+```
+
+## Nota de criterio
+
+La validación inline inicial detectó un falso negativo en el control `bloque_diagnostico_no_levanta_no_coherente`, porque el bloque usa la frase `ni levanta No coherente` en lugar de la forma literal `no levanta No coherente`.
+
+La lectura técnica se conserva como válida: el bloque declara explícitamente que el diagnóstico es no adoptivo, no selecciona método y no levanta `No coherente`.
+
+## Lectura técnica
+
+- La salida real/exportable conserva el bloque `Diagnóstico temporal Q(t) no adoptivo`.
+- El bloque aparece después del control `Pe–Área–Volumen/Q-5`.
+- El bloque aparece antes de la validación interna del expediente exportado.
+- El bloque conserva su restricción no adoptiva.
+- El bloque declara que no selecciona método.
+- El bloque declara que no levanta `No coherente`.
+- El bloque expone conteo de filas morfológicas, de forma y de riesgo.
+- El bloque expone recepción de síntesis de riesgo temporal.
+- No se recalculan hidrogramas.
+- No se modifica código funcional en OT-0326.
+- Build Vite aprobado.
+
+## Decisión
+
+La salida real/exportable del bloque `Diagnóstico temporal Q(t) no adoptivo` queda revalidada desde main en el alcance de OT-0326.

--- a/00_ADMIN/bitacora/OT-0326/OT-0326C_cierre_revalidacion-salida-real-diagnostico-temporal-qt-no-adoptivo-expediente.md
+++ b/00_ADMIN/bitacora/OT-0326/OT-0326C_cierre_revalidacion-salida-real-diagnostico-temporal-qt-no-adoptivo-expediente.md
@@ -1,0 +1,80 @@
+# OT-0326C — Cierre Revalidación salida real Diagnóstico temporal Q(t) no adoptivo
+
+## Resultado
+
+Se revalidó desde `main` la salida real/exportable del bloque `Diagnóstico temporal Q(t) no adoptivo` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del control de consistencia `Pe–Área–Volumen/Q-5`, queda antes de la validación interna del expediente exportado, conserva su restricción no adoptiva, no selecciona método, no levanta `No coherente`, no recalcula hidrogramas, no modifica motor, no modifica UI y no modifica ComparadorMultiMetodo.jsx.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0326\OT-0326A_apertura_revalidacion-salida-real-diagnostico-temporal-qt-no-adoptivo-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0326\OT-0326B_revalidacion_salida_real_diagnostico_temporal_qt_no_adoptivo.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0326",
+  "bloque": "Diagnóstico temporal Q(t) no adoptivo",
+  "totalControles": 17,
+  "controlesAprobados": 17,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealDiagnosticoTemporalQtRevalidada": true,
+  "buildAprobado": true,
+  "recalculaHidrogramas": false,
+  "seleccionaMetodoAdoptado": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## Diagnóstico temporal Q(t) no adoptivo
+Filas morfológicas recibidas: 1
+Filas de forma recibidas: 1
+Filas de riesgo recibidas: 1
+Síntesis de riesgo temporal: recibida
+Restricción: diagnóstico no adoptivo; no selecciona método ni levanta No coherente.
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalcularon hidrogramas.
+
+No se seleccionó método adoptado.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0326 queda cerrada como revalidación limpia del bloque `Diagnóstico temporal Q(t) no adoptivo`.
+
+## Próximo frente recomendado
+
+OT-0327 — Revalidación salida real Validación interna del expediente exportado


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` la salida real/exportable del bloque `Diagnóstico temporal Q(t) no adoptivo`.

## Resultado

El bloque conserva:

```text
## Diagnóstico temporal Q(t) no adoptivo
Filas morfológicas recibidas: 1
Filas de forma recibidas: 1
Filas de riesgo recibidas: 1
Síntesis de riesgo temporal: recibida
Restricción: diagnóstico no adoptivo; no selecciona método ni levanta No coherente.