### PR TITLE
OT-0327 — Revalidación salida real Validación interna del expediente exportado

### DIFF
--- a/00_ADMIN/bitacora/OT-0327/OT-0327A_apertura_revalidacion-salida-real-validacion-interna-expediente-exportado.md
+++ b/00_ADMIN/bitacora/OT-0327/OT-0327A_apertura_revalidacion-salida-real-validacion-interna-expediente-exportado.md
@@ -1,0 +1,71 @@
+# OT-0327A — Revalidación salida real Validación interna del expediente exportado
+
+## Objetivo
+
+Revalidar desde main la salida real/exportable del bloque Validación interna del expediente exportado del expediente hidrológico mínimo, comprobando que el bloque existe, aparece una sola vez, queda después del Diagnóstico temporal Q(t) no adoptivo, queda antes del Sello técnico de generación, conserva lectura de validación estructural, menciona control de secciones y tokens inválidos, no recalcula resultados, no modifica motor, no modifica UI, no modifica ComparadorMultiMetodo.jsx y no altera otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo salvo necesidad estricta.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0327 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No modificar bloque Validación interna del expediente exportado.
+- No modificar bloque Sello técnico de generación.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0328 — Revalidación salida real Sello técnico de generación

--- a/00_ADMIN/bitacora/OT-0327/OT-0327B_revalidacion_salida_real_validacion_interna_expediente_exportado.md
+++ b/00_ADMIN/bitacora/OT-0327/OT-0327B_revalidacion_salida_real_validacion_interna_expediente_exportado.md
@@ -1,0 +1,30 @@
+# OT-0327B — Revalidación salida real Validación interna del expediente exportado
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0327",
+  "bloque": "Validación interna del expediente exportado",
+  "totalControles": 15,
+  "controlesAprobados": 15,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealValidacionInternaRevalidada": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Validación interna extraído de salida real
+
+```text
+## 10. Validación interna del expediente exportado
+Estado de validación estructural: helper puro inicial con control de secciones y tokens inválidos.
+```
+
+## Decisión
+
+La salida real/exportable del bloque `Validación interna del expediente exportado` queda revalidada desde main en el alcance de OT-0327.

--- a/00_ADMIN/bitacora/OT-0327/OT-0327C_cierre_revalidacion-salida-real-validacion-interna-expediente-exportado.md
+++ b/00_ADMIN/bitacora/OT-0327/OT-0327C_cierre_revalidacion-salida-real-validacion-interna-expediente-exportado.md
@@ -1,0 +1,73 @@
+# OT-0327C — Cierre Revalidación salida real Validación interna del expediente exportado
+
+## Resultado
+
+Se revalidó desde `main` la salida real/exportable del bloque `Validación interna del expediente exportado` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después del `Diagnóstico temporal Q(t) no adoptivo`, queda antes del `Sello técnico de generación`, conserva lectura de validación estructural, menciona control de secciones y tokens inválidos, no recalcula resultados, no modifica motor, no modifica UI y no modifica ComparadorMultiMetodo.jsx.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0327\OT-0327A_apertura_revalidacion-salida-real-validacion-interna-expediente-exportado.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0327\OT-0327B_revalidacion_salida_real_validacion_interna_expediente_exportado.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0327",
+  "bloque": "Validación interna del expediente exportado",
+  "totalControles": 15,
+  "controlesAprobados": 15,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealValidacionInternaRevalidada": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 10. Validación interna del expediente exportado
+Estado de validación estructural: helper puro inicial con control de secciones y tokens inválidos.
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalcularon resultados.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0327 queda cerrada como revalidación limpia del bloque `Validación interna del expediente exportado`.
+
+## Próximo frente recomendado
+
+OT-0328 — Revalidación salida real Sello técnico de generación


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` la salida real/exportable del bloque `Validación interna del expediente exportado`.

## Resultado

El bloque conserva:

```text
## 10. Validación interna del expediente exportado
Estado de validación estructural: helper puro inicial con control de secciones y tokens inválidos.