### PR TITLE
OT-0328 — Revalidación salida real Sello técnico de generación

### DIFF
--- a/00_ADMIN/bitacora/OT-0328/OT-0328A_apertura_revalidacion-salida-real-sello-tecnico-generacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0328/OT-0328A_apertura_revalidacion-salida-real-sello-tecnico-generacion-expediente.md
@@ -1,0 +1,72 @@
+# OT-0328A — Revalidación salida real Sello técnico de generación
+
+## Objetivo
+
+Revalidar desde main la salida real/exportable del bloque Sello técnico de generación del expediente hidrológico mínimo, comprobando que el bloque existe, aparece una sola vez, queda después de la Validación interna del expediente exportado, queda antes de Restricciones y advertencias técnicas, expone autor, fecha de generación, versión del expediente y tipo auxiliar, no recalcula resultados, no modifica motor, no modifica UI, no modifica ComparadorMultiMetodo.jsx y no altera otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo salvo necesidad estricta.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0328 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No modificar bloque Validación interna del expediente exportado.
+- No modificar bloque Sello técnico de generación.
+- No modificar bloque Restricciones y advertencias técnicas.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0329 — Revalidación salida real Restricciones y advertencias técnicas

--- a/00_ADMIN/bitacora/OT-0328/OT-0328B_revalidacion_salida_real_sello_tecnico_generacion.md
+++ b/00_ADMIN/bitacora/OT-0328/OT-0328B_revalidacion_salida_real_sello_tecnico_generacion.md
@@ -1,0 +1,37 @@
+# OT-0328B — Revalidación salida real Sello técnico de generación
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0328",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 16,
+  "controlesAprobados": 14,
+  "controlesFallidos": 2,
+  "controlesFallidosIds": [
+    "bloque_sello_expone_autor",
+    "bloque_sello_expone_tipo_auxiliar"
+  ],
+  "salidaRealSelloTecnicoRevalidada": false,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Sello técnico extraído de salida real
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Tipo de salida: Expediente hidrológico mínimo.
+Versión del expediente: OT-0328
+Fecha de generación: OT-0328
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Decisión
+
+La salida real/exportable del bloque `Sello técnico de generación` requiere revisión antes de avanzar.

--- a/00_ADMIN/bitacora/OT-0328/OT-0328C_cierre_revalidacion-salida-real-sello-tecnico-generacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0328/OT-0328C_cierre_revalidacion-salida-real-sello-tecnico-generacion-expediente.md
@@ -1,0 +1,95 @@
+# OT-0328C — Cierre Revalidación salida real Sello técnico de generación
+
+## Resultado
+
+Se revalidó desde `main` la salida real/exportable del bloque `Sello técnico de generación` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque existe, aparece una sola vez, queda después de la `Validación interna del expediente exportado`, queda antes de `Restricciones y advertencias técnicas`, expone herramienta, tipo de salida, versión del expediente, fecha de generación y alcance.
+
+Sin embargo, la revalidación detectó dos brechas técnicas:
+
+- El bloque no expone explícitamente autor técnico, aunque se suministró `autorTecnico` en el contexto de prueba.
+- El bloque no expone explícitamente `Tipo auxiliar`; actualmente muestra `Tipo de salida`, que no cumple literalmente el contrato evaluado.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0328\OT-0328A_apertura_revalidacion-salida-real-sello-tecnico-generacion-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0328\OT-0328B_revalidacion_salida_real_sello_tecnico_generacion.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0328",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 16,
+  "controlesAprobados": 14,
+  "controlesFallidos": 2,
+  "controlesFallidosIds": [
+    "bloque_sello_expone_autor",
+    "bloque_sello_expone_tipo_auxiliar"
+  ],
+  "salidaRealSelloTecnicoRevalidada": false,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque extraído de salida real
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Tipo de salida: Expediente hidrológico mínimo.
+Versión del expediente: OT-0328
+Fecha de generación: OT-0328
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Hallazgos principales
+
+### 1. Autor técnico no expuesto
+
+El bloque no muestra explícitamente el autor técnico del expediente.
+
+### 2. Tipo auxiliar no expuesto literalmente
+
+El bloque muestra `Tipo de salida`, pero no `Tipo auxiliar`, que era el campo esperado por el contrato de revalidación.
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modifició:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalcularon resultados.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0328 queda cerrada como revalidación con hallazgo. El siguiente frente debe corregir la salida real del bloque `Sello técnico de generación`, exponiendo autor técnico y tipo auxiliar, sin modificar motor, UI ni ComparadorMultiMetodo.jsx.
+
+## Próximo frente recomendado
+
+OT-0329 — Corrección salida real Sello técnico de generación


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` la salida real/exportable del bloque `Sello técnico de generación`.

## Resultado

La revalidación confirmó que el bloque existe, aparece una sola vez, queda después de `Validación interna del expediente exportado`, queda antes de `Restricciones y advertencias técnicas`, y expone herramienta, tipo de salida, versión, fecha y alcance.

Sin embargo, detectó dos brechas:

- El bloque no expone autor técnico.
- El bloque no expone literalmente `Tipo auxiliar`; actualmente muestra `Tipo de salida`.

## Evidencia

```json
{
  "validacion": "OT-0328",
  "bloque": "Sello técnico de generación",
  "totalControles": 16,
  "controlesAprobados": 14,
  "controlesFallidos": 2,
  "controlesFallidosIds": [
    "bloque_sello_expone_autor",
    "bloque_sello_expone_tipo_auxiliar"
  ],
  "salidaRealSelloTecnicoRevalidada": false,
  "buildAprobado": true,
  "recalculaResultados": false,
  "modificaMotor": false,
  "modificaUI": false
}