### PR TITLE
OT-0329 — Corrección salida real Sello técnico de generación

### DIFF
--- a/00_ADMIN/bitacora/OT-0329/OT-0329A_apertura_correccion-salida-real-sello-tecnico-generacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0329/OT-0329A_apertura_correccion-salida-real-sello-tecnico-generacion-expediente.md
@@ -1,0 +1,68 @@
+# OT-0329A — Corrección salida real Sello técnico de generación
+
+## Objetivo
+
+Corregir de forma mínima y controlada la salida real/exportable del bloque Sello técnico de generación del expediente hidrológico mínimo, para que exponga autor técnico y tipo auxiliar cuando existan datos disponibles en contexto, conservando herramienta, tipo de salida, versión del expediente, fecha de generación y alcance, sin recalcular resultados, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers no relacionados con Sello técnico de generación.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo.
+- No acoplar otros helpers en esta OT.
+- Modificar únicamente lo estrictamente necesario para que el bloque Sello técnico de generación exponga autor técnico y tipo auxiliar.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No modificar bloque Validación interna del expediente exportado.
+- No modificar bloque Restricciones y advertencias técnicas.
+- No validar formalmente valores hidrológicos.
+- No recalcular Tc.
+- No modificar Tc_final.
+- No seleccionar Tc adoptado.
+- No recalcular Q-Tr.
+- No seleccionar periodo de retorno adoptado.
+- No recalcular Q-5.
+- No reinterpretar resultados Q-5.
+- No recalcular Método Racional.
+- No seleccionar Método Racional como adoptado.
+- No seleccionar caudal racional adoptado.
+- No recalcular hidrogramas.
+- No seleccionar método Q-5 adoptado.
+- No seleccionar caudal Q-5 adoptado.
+- No emitir dictamen de suficiencia hidrológica.
+- No recalcular CN.
+- No recalcular CN base.
+- No recalcular CN efectivo.
+- No recalcular AMC.
+- No recalcular volumen.
+- No modificar Pe.
+- No modificar área.
+- No modificar fórmula de volumen.
+- No tocar Q-Tr funcionalmente.
+- No tocar Q-5 funcionalmente.
+- No tocar Método Racional funcionalmente.
+- No tocar diagnóstico Q(t).
+
+## Próximo frente recomendado
+
+OT-0330 — Revalidación salida real Sello técnico de generación corregido

--- a/00_ADMIN/bitacora/OT-0329/OT-0329B_correccion_salida_real_sello_tecnico_generacion.md
+++ b/00_ADMIN/bitacora/OT-0329/OT-0329B_correccion_salida_real_sello_tecnico_generacion.md
@@ -1,0 +1,36 @@
+# OT-0329B — Corrección salida real Sello técnico de generación
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0329",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 15,
+  "controlesAprobados": 15,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealSelloTecnicoCorregida": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Sello técnico extraído de salida real corregida
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Autor técnico: Luis German Montoya Mejía.
+Tipo de salida: Expediente hidrológico mínimo.
+Tipo auxiliar: expediente_hidrologico_minimo.
+Versión del expediente: OT-0329
+Fecha de generación: OT-0329
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Decisión
+
+La salida real/exportable del bloque `Sello técnico de generación` queda corregida en el alcance de OT-0329.

--- a/00_ADMIN/bitacora/OT-0329/OT-0329C_cierre_correccion-salida-real-sello-tecnico-generacion-expediente.md
+++ b/00_ADMIN/bitacora/OT-0329/OT-0329C_cierre_correccion-salida-real-sello-tecnico-generacion-expediente.md
@@ -1,0 +1,84 @@
+# OT-0329C — Cierre Corrección salida real Sello técnico de generación
+
+## Resultado
+
+Se corrigió de forma mínima y controlada la salida real/exportable del bloque `Sello técnico de generación` del expediente hidrológico mínimo.
+
+La corrección permite que el bloque exponga explícitamente `Autor técnico` y `Tipo auxiliar`, conservando herramienta, tipo de salida, versión del expediente, fecha de generación y alcance.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0329\OT-0329A_apertura_correccion-salida-real-sello-tecnico-generacion-expediente.md
+
+Documento de corrección y validación inline:
+
+00_ADMIN\bitacora\OT-0329\OT-0329B_correccion_salida_real_sello_tecnico_generacion.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0329",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 15,
+  "controlesAprobados": 15,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealSelloTecnicoCorregida": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque corregido extraído de salida real
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Autor técnico: Luis German Montoya Mejía.
+Tipo de salida: Expediente hidrológico mínimo.
+Tipo auxiliar: expediente_hidrologico_minimo.
+Versión del expediente: OT-0329
+Fecha de generación: OT-0329
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Cambios aplicados
+
+Se modificó únicamente:
+
+- `01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js`
+
+El ajuste expone datos ya disponibles en contexto. No recalcula resultados.
+
+## Alcance mantenido
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers no relacionados.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalcularon resultados.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0329 queda cerrada como corrección mínima del bloque `Sello técnico de generación` en salida real/exportable.
+
+## Próximo frente recomendado
+
+OT-0330 — Revalidación salida real Sello técnico de generación corregido

--- a/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirExpedienteHidrologicoMinimo.js
@@ -214,13 +214,27 @@ export default function construirExpedienteHidrologicoMinimo({
   filasRiesgoTemporalQt = [],
   sintesisRiesgoTemporalQt = null,
   fechaGeneracion = null,
-  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO
+  versionExpediente = VERSION_EXPEDIENTE_HIDROLOGICO_MINIMO,
+  autorTecnico = null,
+  tipoAuxiliar = "expediente_hidrologico_minimo"
 } = {}) {
   const metadata = construirMetadataExpediente({
     contextoBase,
     fechaGeneracion,
     versionExpediente
   });
+
+  const autorTecnicoSelloDocumental =
+    autorTecnico ??
+    contextoBase?.autorTecnico ??
+    contextoBase?.responsableTecnico ??
+    contextoBase?.profesionalResponsable ??
+    "—";
+
+  const tipoAuxiliarSelloDocumental =
+    tipoAuxiliar ??
+    metadata?.tipoSalida ??
+    "expediente_hidrologico_minimo";
 
   const areaKm2 = Number(contextoBase?.area_km2);
   const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
@@ -365,7 +379,9 @@ export default function construirExpedienteHidrologicoMinimo({
     "",
     "## 11. Sello técnico de generación",
     "Herramienta: HidroFlow.",
+    `Autor técnico: ${textoSeguro(autorTecnicoSelloDocumental, "—")}.`,
     "Tipo de salida: Expediente hidrológico mínimo.",
+    `Tipo auxiliar: ${textoSeguro(tipoAuxiliarSelloDocumental, "expediente_hidrologico_minimo")}.`,
     `Versión del expediente: ${versionExpediente}`,
     `Fecha de generación: ${fechaGeneracion ?? "—"}`,
     "Alcance: helper puro inicial no integrado al botón de copiado.",


### PR DESCRIPTION
## Resumen

Esta OT corrige de forma mínima la salida real/exportable del bloque `Sello técnico de generación`.

## Resultado

El bloque pasa a exponer explícitamente `Autor técnico` y `Tipo auxiliar`, conservando herramienta, tipo de salida, versión, fecha y alcance.

```text
## 11. Sello técnico de generación
Herramienta: HidroFlow.
Autor técnico: Luis German Montoya Mejía.
Tipo de salida: Expediente hidrológico mínimo.
Tipo auxiliar: expediente_hidrologico_minimo.
Versión del expediente: OT-0329
Fecha de generación: OT-0329
Alcance: helper puro inicial no integrado al botón de copiado.