### PR TITLE
OT-0330 — Revalidación salida real Sello técnico de generación corregido

### DIFF
--- a/00_ADMIN/bitacora/OT-0330/OT-0330A_apertura_revalidacion-salida-real-sello-tecnico-generacion-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0330/OT-0330A_apertura_revalidacion-salida-real-sello-tecnico-generacion-corregido-expediente.md
@@ -1,0 +1,48 @@
+# OT-0330A — Revalidación salida real Sello técnico de generación corregido
+
+## Objetivo
+
+Revalidar desde main que la corrección aplicada en OT-0329 mantiene la salida real/exportable del bloque Sello técnico de generación, comprobando que expone herramienta, autor técnico, tipo de salida, tipo auxiliar, versión del expediente, fecha de generación y alcance, sin recalcular resultados, sin modificar motor, sin modificar UI, sin modificar ComparadorMultiMetodo.jsx y sin alterar otros bloques del expediente.
+
+## Alcance
+
+Esta OT fue generada mediante Nueva-OTDocumentalHidroFlow como estructura documental mínima.
+
+No implementa cambios funcionales por sí misma.
+
+## Restricciones
+
+- No modificar motor.
+- No modificar UI.
+- No modificar textoExpediente.
+- No modificar ComparadorMultiMetodo.jsx.
+- No modificar construirExpedienteHidrologicoMinimo.js.
+- No modificar construirBloqueEscenarioQTrActivoExpediente.js.
+- No modificar construirBloqueResumenQ5AuditadoExpediente.js.
+- No modificar helpers existentes.
+- No crear helper funcional nuevo.
+- No crear validador permanente nuevo salvo necesidad estricta.
+- No corregir código funcional en esta OT.
+- Crear únicamente documentación OT-0330 y reporte de revalidación.
+- No automatizar commits.
+- No acoplar otros helpers en esta OT.
+- No modificar bloque Identificación.
+- No modificar bloque Parámetros hidrológicos base.
+- No modificar bloque Tiempo de concentración y roles Tc.
+- No modificar bloque Volumen de referencia.
+- No modificar bloque Escenario Q-Tr activo.
+- No modificar bloque Resumen Q-5 auditado.
+- No modificar bloque Método Racional.
+- No modificar bloque Contraste Q-5 vs Método Racional.
+- No modificar bloque Control de consistencia cruzada Pe–Área–Volumen/Q-5.
+- No modificar bloque Diagnóstico temporal Q(t).
+- No modificar bloque Validación interna del expediente exportado.
+- No modificar bloque Sello técnico de generación.
+- No modificar bloque Restricciones y advertencias técnicas.
+- No recalcular resultados.
+- No recalcular hidrogramas.
+- No emitir dictamen de suficiencia hidrológica.
+
+## Próximo frente recomendado
+
+OT-0331 — Revalidación salida real Restricciones y advertencias técnicas

--- a/00_ADMIN/bitacora/OT-0330/OT-0330B_revalidacion_salida_real_sello_tecnico_generacion_corregido.md
+++ b/00_ADMIN/bitacora/OT-0330/OT-0330B_revalidacion_salida_real_sello_tecnico_generacion_corregido.md
@@ -1,0 +1,36 @@
+# OT-0330B — Revalidación salida real Sello técnico de generación corregido
+
+## Resumen
+
+```json
+{
+  "validacion": "OT-0330",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 13,
+  "controlesAprobados": 13,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealSelloTecnicoRevalidada": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque Sello técnico extraído de salida real revalidada
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Autor técnico: Luis German Montoya Mejía.
+Tipo de salida: Expediente hidrológico mínimo.
+Tipo auxiliar: expediente_hidrologico_minimo.
+Versión del expediente: OT-0330
+Fecha de generación: OT-0330
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Decisión
+
+La salida real/exportable del bloque `Sello técnico de generación` corregido queda revalidada desde main en el alcance de OT-0330.

--- a/00_ADMIN/bitacora/OT-0330/OT-0330C_cierre_revalidacion-salida-real-sello-tecnico-generacion-corregido-expediente.md
+++ b/00_ADMIN/bitacora/OT-0330/OT-0330C_cierre_revalidacion-salida-real-sello-tecnico-generacion-corregido-expediente.md
@@ -1,0 +1,79 @@
+# OT-0330C — Cierre Revalidación salida real Sello técnico de generación corregido
+
+## Resultado
+
+Se revalidó desde `main` la corrección aplicada en OT-0329 sobre la salida real/exportable del bloque `Sello técnico de generación` del expediente hidrológico mínimo.
+
+La revalidación confirmó que el bloque conserva herramienta, autor técnico, tipo de salida, tipo auxiliar, versión del expediente, fecha de generación y alcance.
+
+## Evidencia principal
+
+Documento de apertura:
+
+00_ADMIN\bitacora\OT-0330\OT-0330A_apertura_revalidacion-salida-real-sello-tecnico-generacion-corregido-expediente.md
+
+Documento de revalidación:
+
+00_ADMIN\bitacora\OT-0330\OT-0330B_revalidacion_salida_real_sello_tecnico_generacion_corregido.md
+
+## Resultado de validación
+
+```json
+{
+  "validacion": "OT-0330",
+  "bloque": "Sello técnico de generación",
+  "totalControles": 13,
+  "controlesAprobados": 13,
+  "controlesFallidos": 0,
+  "controlesFallidosIds": [],
+  "salidaRealSelloTecnicoRevalidada": true,
+  "buildAprobado": true,
+  "recalculaResultados": false,
+  "modificaMotor": false,
+  "modificaUI": false
+}
+```
+
+## Bloque revalidado
+
+```text
+## 11. Sello técnico de generación
+Herramienta: HidroFlow.
+Autor técnico: Luis German Montoya Mejía.
+Tipo de salida: Expediente hidrológico mínimo.
+Tipo auxiliar: expediente_hidrologico_minimo.
+Versión del expediente: OT-0330
+Fecha de generación: OT-0330
+Alcance: helper puro inicial no integrado al botón de copiado.
+```
+
+## Alcance mantenido
+
+No se modificó código funcional.
+
+No se modificó:
+
+- Motor.
+- UI.
+- textoExpediente.
+- ComparadorMultiMetodo.jsx.
+- construirExpedienteHidrologicoMinimo.js.
+- construirBloqueEscenarioQTrActivoExpediente.js.
+- construirBloqueResumenQ5AuditadoExpediente.js.
+- Helpers existentes.
+
+No se creó helper funcional nuevo.
+
+No se creó validador permanente nuevo.
+
+No se recalcularon resultados.
+
+No se emitió dictamen de suficiencia hidrológica.
+
+## Decisión
+
+OT-0330 queda cerrada como revalidación limpia de la corrección del bloque `Sello técnico de generación` aplicada en OT-0329.
+
+## Próximo frente recomendado
+
+OT-0331 — Revalidación salida real Restricciones y advertencias técnicas


### PR DESCRIPTION
## Resumen

Esta OT revalida desde `main` que la corrección aplicada en OT-0329 mantiene la salida real/exportable del bloque `Sello técnico de generación`.

## Resultado

El bloque conserva:

```text
## 11. Sello técnico de generación
Herramienta: HidroFlow.
Autor técnico: Luis German Montoya Mejía.
Tipo de salida: Expediente hidrológico mínimo.
Tipo auxiliar: expediente_hidrologico_minimo.
Versión del expediente: OT-0330
Fecha de generación: OT-0330
Alcance: helper puro inicial no integrado al botón de copiado.