### PR TITLE
OT-0331 — Contrato payload expediente exportable

### DIFF
--- a/01_APP/HIDROFLOW/src/types/expediente.js
+++ b/01_APP/HIDROFLOW/src/types/expediente.js
@@ -1,0 +1,70 @@
+export const VERSION_CONTRATO_EXPEDIENTE_HIDROLOGICO = "HF_EXPEDIENTE_PAYLOAD_V1";
+
+export const crearPayloadExpedienteVacio = () => ({
+  versionContrato: VERSION_CONTRATO_EXPEDIENTE_HIDROLOGICO,
+
+  cuenca: {
+    nombre: "",
+    puntoSalida: { id: "", lat: null, lon: null },
+    cotaSalidaMsnm: null,
+    cotaAltaMsnm: null
+  },
+
+  geomorfometria: {
+    areaKm2: null,
+    longitudCauceKm: null,
+    desnivelM: null,
+    pendienteCaucePorcentaje: null
+  },
+
+  lluviaYAbstraccion: {
+    estacionActiva: "",
+    parametrosIDF: { k: null, n: null, c: null },
+    condicionAMC: "",
+    cnBase: null,
+    cnAjustado: null,
+    cnEfectivo: null,
+    peTotalMm: null
+  },
+
+  tiempoConcentracion: {
+    tcSugeridoMinutos: null,
+    metodoPonderacion: "",
+    metodosValidos: [],
+    metodosExcluidos: []
+  },
+
+  escenarioQTrActivo: {
+    periodoRetornoTrAnios: null,
+    estado: "",
+    caudalDisenoM3s: null
+  },
+
+  hidrografiaQ5: {
+    metodoPrincipal: "SCS Unit Hydrograph",
+    caudalPicoM3s: null,
+    tiempoPicoMinutos: null,
+    volumenIntegradoM3: null,
+    metodosComparados: []
+  },
+
+  contrasteRacional: {
+    caudalPicoM3s: null,
+    esAdoptivo: false
+  },
+
+  controlConsistencia: {
+    volumenEsperadoTeoricoM3: null,
+    volumenIntegradoQ5M3: null,
+    ratioVolumetrico: null,
+    estadoConsistencia: ""
+  },
+
+  diagnosticoQt: {
+    filasMorfologicas: [],
+    filasForma: [],
+    filasRiesgo: [],
+    sintesisRiesgo: "",
+    esAdoptivo: false
+  }
+});


### PR DESCRIPTION
## Resumen

Define el contrato base del payload exportable del Expediente Hidrológico Mínimo.

## Archivo creado

- `01_APP/HIDROFLOW/src/types/expediente.js`

## Alcance

No modifica motor.
No modifica UI.
No modifica exportador.
No modifica constructor del expediente.
No toca sellos, restricciones, logs ni estilos.

## Pipeline cubierto

```text
Geomorfometría
IDF/EPM
SIATA/AMC
CN/Pe
Tc
Q-Tr activo
Q-5 SCS
Método Racional no adoptivo
Control volumétrico
Diagnóstico Q(t) no adoptivo
``