### PR TITLE
OT-0336 — Preparar descarga Markdown expediente

### DIFF
--- a/01_APP/HIDROFLOW/src/services/documentos/prepararDescargaMarkdownExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/prepararDescargaMarkdownExpediente.js
@@ -1,0 +1,21 @@
+const limpiarNombreArchivo = (valor = "expediente_hidrologico") =>
+  String(valor)
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9-_]+/g, "_")
+    .replace(/^_+|_+$/g, "") || "expediente_hidrologico";
+
+export default function prepararDescargaMarkdownExpediente({
+  markdown = "",
+  nombreBase = "expediente_hidrologico_minimo"
+} = {}) {
+  const contenido = typeof markdown === "string" ? markdown : "";
+
+  return {
+    nombreArchivo: `${limpiarNombreArchivo(nombreBase)}.md`,
+    tipoMime: "text/markdown;charset=utf-8",
+    contenido
+  };
+}


### PR DESCRIPTION
## Resumen

Crea función pura para preparar descarga `.md` desde Markdown validado.

## Archivo

- `01_APP/HIDROFLOW/src/services/documentos/prepararDescargaMarkdownExpediente.js`

## Validación

```json
{
  "validacion": "OT-0336",
  "controles": 3,
  "fallidos": [],
  "descargaMarkdownPreparada": true
}