### PR TITLE
OT-0337 — Conectar descarga Markdown al flujo exportable

### DIFF
--- a/01_APP/HIDROFLOW/src/services/documentos/construirDescargaMarkdownExpedienteDesdePayload.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirDescargaMarkdownExpedienteDesdePayload.js
@@ -1,0 +1,16 @@
+import construirMarkdownExpedienteDesdePayload from "./construirMarkdownExpedienteDesdePayload.js";
+import prepararDescargaMarkdownExpediente from "./prepararDescargaMarkdownExpediente.js";
+
+export default function construirDescargaMarkdownExpedienteDesdePayload(payload = {}) {
+  const markdown = construirMarkdownExpedienteDesdePayload(payload);
+
+  const nombreCuenca =
+    payload?.cuenca?.nombre ||
+    payload?.cuenca?.puntoSalida?.id ||
+    "expediente_hidrologico_minimo";
+
+  return prepararDescargaMarkdownExpediente({
+    markdown,
+    nombreBase: nombreCuenca
+  });
+}


### PR DESCRIPTION
## Resumen

Conecta el flujo puro:

payload → Markdown → descriptor de descarga `.md`

## Archivo

- `01_APP/HIDROFLOW/src/services/documentos/construirDescargaMarkdownExpedienteDesdePayload.js`

## Validación

```json
{
  "validacion": "OT-0337",
  "controles": 5,
  "fallidos": [],
  "descargaDesdePayloadValida": true,
  "nombreArchivo": "la_iguana_pc_80.md",
  "tipoMime": "text/markdown;charset=utf-8"
}