### PR TITLE
OT-0338 — Adaptador descarga Markdown navegador

### DIFF
--- a/01_APP/HIDROFLOW/src/services/documentos/descargarArchivoMarkdownEnNavegador.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/descargarArchivoMarkdownEnNavegador.js
@@ -1,0 +1,32 @@
+export default function descargarArchivoMarkdownEnNavegador({
+  nombreArchivo = "expediente_hidrologico.md",
+  tipoMime = "text/markdown;charset=utf-8",
+  contenido = ""
+} = {}) {
+  if (typeof document === "undefined") {
+    return {
+      ejecutado: false,
+      motivo: "document_no_disponible"
+    };
+  }
+
+  const blob = new Blob([contenido], { type: tipoMime });
+  const url = URL.createObjectURL(blob);
+
+  const enlace = document.createElement("a");
+  enlace.href = url;
+  enlace.download = nombreArchivo;
+  enlace.style.display = "none";
+
+  document.body.appendChild(enlace);
+  enlace.click();
+  document.body.removeChild(enlace);
+
+  URL.revokeObjectURL(url);
+
+  return {
+    ejecutado: true,
+    nombreArchivo,
+    tipoMime
+  };
+}


### PR DESCRIPTION
## Resumen

Agrega adaptador seguro para ejecutar la descarga real de un archivo Markdown en navegador.

## Archivo

- `01_APP/HIDROFLOW/src/services/documentos/descargarArchivoMarkdownEnNavegador.js`

## Validación

```json
{
  "validacion": "OT-0338",
  "controles": 2,
  "fallidos": [],
  "adaptadorSeguroSinNavegador": true
}