### PR TITLE
OT-0353B — Desacople documental del mini-mapa respecto a PC_80

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,33 @@
+# HidroFlow — Reglas para el agente de IA
+
+## Contexto del proyecto
+Proyecto de ingeniería hidrológica y análisis geoespacial. Todo el código debe ejecutarse de forma local y privada.
+
+## Librerías prioritarias (orden de preferencia)
+1. **rasterio** — Lectura/escritura de ráster por ventanas (chunks), análisis multitemporal, índices de cambio. Usar siempre procesamiento por bloques en archivos grandes para no saturar RAM.
+2. **arcpy** — Operaciones en entorno ArcGIS (geodatabases, toolboxes, spatial analyst). Usar solo cuando el flujo requiera el ecosistema Esri; documentar dependencia de licencia local.
+3. Complementos permitidos: **numpy**, **pandas**, **geopandas**, **pathlib**, **multiprocessing** (para CPU/GDAL), **asyncio** solo si el cuello de botella es I/O concurrente no bloqueante.
+
+No sustituir rasterio/arcpy por SDKs en la nube (AWS, GCP, Azure) salvo orden explícita del usuario.
+
+## Rutas y archivos
+- **Prohibido** usar rutas absolutas hardcodeadas (`C:\...`, `/home/...`, `D:\...`).
+- Usar rutas **relativas al directorio raíz del proyecto** o `pathlib.Path(__file__).resolve().parent`.
+- Centralizar rutas en constantes o variables de entorno (`HIDROFLOW_ROOT`, `DATOS_DIR`, etc.).
+- Estructura esperada:
+  - `scripts/` — pipelines y análisis ejecutables
+  - `datos/raw/` — insumos sin modificar
+  - `datos/processed/` — intermedios
+  - `outputs/` — resultados finales (ráster, tablas, mapas)
+  - `tools/` — utilidades reutilizables
+  - `docs/` — documentación y metadatos
+
+## Estilo de código
+- Código modular con `try/except` en operaciones de I/O y GDAL.
+- Evitar bucles fila a fila (`iterrows`, bucles Python sobre píxeles); preferir operaciones vectorizadas o por ventanas.
+- No commitear datos pesados ni credenciales; usar `.gitignore` para `datos/` y `outputs/` si contienen archivos grandes.
+
+## Respuestas del agente
+- Entregar código listo para ejecutar en local.
+- Indicar dependencias (`requirements.txt` o entorno ArcGIS Pro) cuando se use arcpy.
+- Explicar brevemente el índice o método hidrológico aplicado cuando se proponga un script nuevo.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -643,12 +643,12 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
 
   // ------------------------------------------------------------
   // 3. Dominio del mini-mapa
-  // Incluye PC_80, estaciones cercanas y estación IDF adoptada.
+  // Incluye el punto de salida, estaciones cercanas y estación IDF adoptada.
   // Esto evita que todo quede apeñuscado.
   // ------------------------------------------------------------
   const puntosMapa = [
     {
-      n: "PC_80",
+      n: "SALIDA",
       lat,
       lon,
       alt,
@@ -694,7 +694,7 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
   const yMap = (la) =>
     `${100 - ((la - lat0) / (lat1 - lat0)) * 100}%`;
 
-  // Línea conceptual PC_80 ↔ IDF adoptada
+  // Línea conceptual salida ↔ IDF adoptada
   const lineaIDF = puntoIDF
     ? {
         x1: xMap(lon),
@@ -752,7 +752,7 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
                 border: "1px solid rgba(120,160,210,0.18)"
               }}
             >
-              Distancia IDF–PC_80: {puntoIDF.dist.toFixed(1)} km
+              Distancia IDF–Salida: {puntoIDF.dist.toFixed(1)} km
             </span>
           )}
         </div>
@@ -845,7 +845,7 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
         ))}
 
         {/* Río Medellín — referencia oriental del valle.
-    La subcuenca La Iguaná PC_80 se representa al occidente del río.
+    La cuenca activa se representa en el contexto occidental del valle.
     Este trazo es conceptual: no representa conectividad hidráulica ni cruce del cauce. */}
 <div
   style={{
@@ -882,8 +882,8 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
   Río Medellín
 </div>
 
-{/* Banda occidental conceptual de la subcuenca La Iguaná PC_80.
-    Ayuda a leer que PC_80 y la subcuenca quedan al occidente del Río Medellín. */}
+{/* Banda occidental conceptual de la cuenca activa.
+    Ayuda a interpretar la ubicación relativa de la cuenca activa respecto al Río Medellín. */}
 <div
   style={{
     position: "absolute",
@@ -915,10 +915,10 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
     whiteSpace: "nowrap"
   }}
 >
-  Occidente del Río Medellín · Subcuenca La Iguaná PC_80
+  Occidente del Río Medellín · Cuenca activa
 </div>
 
-        {/* Línea IDF–PC_80 desactivada.
+        {/* Línea IDF–Salida desactivada.
     La relación IDF es pluviométrica, no una conexión hidráulica.
     Se evita sugerir cruce físico del Río Medellín. */}
 
@@ -995,10 +995,10 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
           </>
         )}
 
-        {/* Punto de control / salida PC_80 */}
+        {/* Punto de salida activo */}
         <>
           <div
-            title={`PC_80 · salida · ${lat.toFixed(6)}, ${lon.toFixed(6)}`}
+            title={`Salida activa · ${lat.toFixed(6)}, ${lon.toFixed(6)}`}
             style={{
               position: "absolute",
               left: "58%",
@@ -1029,7 +1029,7 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
               fontFamily: "monospace"
             }}
           >
-            PC_80 · SALIDA
+            SALIDA ACTIVA
           </div>
         </>
 
@@ -1090,7 +1090,7 @@ function OutletMiniMap({ lat, lon, alt, idf }) {
       >
         <span>
           <span style={{ color: "#00e6b8", fontWeight: 900 }}>●</span>{" "}
-          PC_80 / salida
+          Salida activa
         </span>
 
         <span>
@@ -3981,6 +3981,11 @@ useEffect(() => {
     </div>
   </div>);
 }
+
+
+
+
+
 
 
 

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3639,6 +3639,21 @@ useEffect(() => {
       : [];
   onContextoComparador((previo) => ({
     ...(previo ?? {}),
+	
+	casoActivo:{
+  idCaso: previo?.casoActivo?.idCaso ?? "CASO-0001",
+  tipo:"CASO_HIDROLOGICO",
+  version:"1.0",
+
+  cuenca:{
+    nombre:
+      params?.nombreCuenca ??
+      params?.cuencaNombre ??
+      params?.nombre ??
+      null
+  }
+}, 
+
     fuente: "motor HidroFlow",
     estacion_idf: stn,
     metodoIDF: "EPM",

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -26,6 +26,7 @@ import {
 import HidrogramaResultado from "./components/HidrogramaResultado";
 import { getTcState, setTcState } from "./agents/tcAgent";
 import { derivarEstadoQTrActivo } from "./services/qtr/derivarEstadoQTrActivo";
+import { construirQTrMultiEscenario } from "./services/qtr/construirQTrMultiEscenario";
 
 import {
   calcCNdinamico,
@@ -1972,6 +1973,51 @@ function ModHidrogramas({ params, est, name, onContextoComparador }) {
     [hu_scs, hu_scsMod, hu_snyder, hu_wh, hu_clark].map(hu => calcHidroCompleto(lluvEfect, hu, dtMin))
   ), [lluvEfect, hu_scs, hu_scsMod, hu_snyder, hu_wh, hu_clark, dtMin]);
 
+
+const qTrMultiEscenario = useMemo(() => {
+
+  return construirQTrMultiEscenario({
+
+    TR_LIST,
+
+    est,
+
+    CNact,
+
+    dtMin,
+
+    tcSugeridoMinutos: tc_min,
+
+    unidadesHidrologicas: [
+      hu_scs,
+      hu_scsMod,
+      hu_snyder,
+      hu_wh,
+      hu_clark
+    ],
+
+    calcHietograma,
+    calcLluviaEfectiva,
+    calcHidroCompleto
+
+  });
+
+}, [
+
+  est,
+  CNact,
+  dtMin,
+
+  tc_min,
+
+  hu_scs,
+  hu_scsMod,
+  hu_snyder,
+  hu_wh,
+  hu_clark
+
+]);
+
   // Hidrograma activo (SCS por defecto)
   const h0 = hidros?.[0] ?? null;
 
@@ -2198,6 +2244,7 @@ const leerT = (punto, indice) => {
           lluvia_efectiva_total_mm: lluviaEfectivaTotalMm,
           hidrogramas_resumen: hidrogramasResumen,
           hidrograma_principal: h0 ?? null,
+	  q_tr_multiescenario: qTrMultiEscenario,
         };
 
         // OT-0056C4 refresca Q-Tr activo con Pe total sin recalcular caudales.

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3668,6 +3668,57 @@ useEffect(() => {
       params?.longitudCauce ??
       params?.longitud_cauce ??
       null
+  },
+  hidrologia:{
+    CN: cnBase,
+
+    CN_base:
+      params?.cnBase ??
+      params?.CN ??
+      cnBase,
+
+    CN_efectivo:
+      params?.CN_efectivo ??
+      params?.cnEfectivo ??
+      cnBase,
+
+    AMC:
+      params?.AMC ??
+      params?.amcActual ??
+      params?.amc ??
+      "II",
+
+    S_mm:
+      Number(
+        (
+          25400 /
+            Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) -
+          254
+        ).toFixed(2)
+      ),
+
+    Ia_mm:
+      Number(
+        (
+          0.2 *
+          (
+            25400 /
+              Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) -
+            254
+          )
+        ).toFixed(2)
+      ),
+
+    porcentaje_impermeable:
+      Number.isFinite(Number(params?.porcentajeImpermeable))
+        ? Number(params.porcentajeImpermeable)
+        : 60,
+
+    tc_min:
+      getTcState()?.Tc_final ?? null,
+
+    tc_metodos:
+      calcTc(params)
   }
 }, 
 
@@ -3930,6 +3981,7 @@ useEffect(() => {
     </div>
   </div>);
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3647,10 +3647,11 @@ useEffect(() => {
 
   cuenca:{
     nombre:
-      params?.nombreCuenca ??
-      params?.cuencaNombre ??
-      params?.nombre ??
-      null,
+  params?.nombreCuenca ??
+  params?.cuencaNombre ??
+  params?.nombre_cuenca ??
+  params?.nombre ??
+  null,
 
     area_km2:
       params?.area_km2 ??
@@ -3688,10 +3689,11 @@ useEffect(() => {
     },
 
     cuencaNombre:
-      params?.nombreCuenca ??
-      params?.cuencaNombre ??
-      params?.nombre ??
-      "Quebrada La Iguaná - PC_80",
+  params?.nombreCuenca ??
+  params?.cuencaNombre ??
+  params?.nombre_cuenca ??
+  params?.nombre ??
+  "Sin caso activo",
 
     area_km2:
       params?.area_km2 ??

--- a/01_APP/HIDROFLOW/src/HidroFlow.jsx
+++ b/01_APP/HIDROFLOW/src/HidroFlow.jsx
@@ -3650,6 +3650,22 @@ useEffect(() => {
       params?.nombreCuenca ??
       params?.cuencaNombre ??
       params?.nombre ??
+      null,
+
+    area_km2:
+      params?.area_km2 ??
+      params?.areaKm2 ??
+      params?.area ??
+      params?.A ??
+      null,
+
+    longitud_cauce_km:
+      params?.longitud_cauce_km ??
+      params?.longitudCauceKm ??
+      params?.longitud_km ??
+      params?.L ??
+      params?.longitudCauce ??
+      params?.longitud_cauce ??
       null
   }
 }, 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -65,12 +65,29 @@ const contextoBase = contexto || {
 };
 
 const fuenteContexto = contexto ? "motor HidroFlow" : "contexto base";
+const cuencaActiva = {
+  nombre:
+    contextoBase?.casoActivo?.cuenca?.nombre ??
+    contextoBase?.cuencaNombre,
+
+  area_km2:
+    contextoBase?.casoActivo?.cuenca?.area_km2 ??
+    contextoBase?.area_km2,
+
+  longitud_cauce_km:
+    contextoBase?.casoActivo?.cuenca?.longitud_cauce_km ??
+    contextoBase?.longitud_cauce_km,
+
+  pendiente_media_pct:
+    contextoBase?.casoActivo?.cuenca?.pendiente_media_pct ??
+    contextoBase?.pendiente_media_pct
+};
 
 // ✅ DEFINICIÓN REAL DE p
 const p = {
   longitud_cauce: 15.524,
-  area: contextoBase.area_km2,
-  pendiente_cuenca: contextoBase.pendiente_media_pct,
+  area: cuencaActiva.area_km2,
+  pendiente_cuenca: cuencaActiva.pendiente_media_pct,
   cota_mayor_cauce: 2819.27,
   cota_menor_cauce: 1511.36,
   cota_max: 2819.27,
@@ -86,8 +103,8 @@ const metodosTc = mapTcResultados(tcArray);
 
 // ✅ CONTEXTO HIDROLÓGICO
 const contextoTc = {
-  pendiente: contextoBase.pendiente_media_pct,
-  area: contextoBase.area_km2,
+  pendiente: cuencaActiva.pendiente_media_pct,
+  area: cuencaActiva.area_km2,
   CN: contextoBase.CN,
   urbanizacion: 0.5
 };
@@ -394,7 +411,7 @@ const sintesisRiesgoTemporalQt = useMemo(() => {
 
 // OT-0092B — Lectura visual controlada de matriz patrón La Iguaná PC_80.
 // Solo lectura: no recalcula, no adopta método y no modifica Q(t).
-const matrizPatronVisual = matrizPatronLaIguanaPC80;
+const matrizPatronVisual = null;
 const diagnosticoMatrizPatronQt = Array.isArray(matrizPatronVisual?.diagnosticoQt)
   ? matrizPatronVisual.diagnosticoQt
   : [];
@@ -1226,7 +1243,10 @@ const handleClickSeguro = (accion) => () => {
       return <span style={estilos.chip}>—</span>;
     }
 
-    const areaKm2 = Number(contextoBase?.area_km2);
+    const areaKm2 = Number(
+  contextoBase?.casoActivo?.cuenca?.area_km2 ??
+  contextoBase?.area_km2
+);
     const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
     const volumenEsperadoM3 =
       Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
@@ -1363,21 +1383,24 @@ const handleClickSeguro = (accion) => () => {
     <div>
       <strong>Área:</strong>{" "}
       {Number.isFinite(contextoBase?.area_km2)
-        ? `${contextoBase.area_km2.toFixed(4)} km²`
+        ? `${cuencaActiva.area_km2.toFixed(4)} km²`
         : "—"}
     </div>
 
     <div>
       <strong>Scp cauce principal:</strong>{" "}
       {Number.isFinite(contextoBase?.pendiente_media_pct)
-        ? `${contextoBase.pendiente_media_pct} %`
+        ? `${cuencaActiva.pendiente_media_pct} %`
         : "—"}
     </div>
 
     <div>
       <strong>Longitud cauce:</strong>{" "}
-      {Number.isFinite(contextoBase?.longitud_cauce_km)
-        ? `${contextoBase.longitud_cauce_km} km`
+      {Number.isFinite(
+  contextoBase?.casoActivo?.cuenca?.longitud_cauce_km ??
+  contextoBase?.longitud_cauce_km
+)
+        ? `${cuencaActiva.longitud_cauce_km} km`
         : "—"}
     </div>
 
@@ -1783,7 +1806,10 @@ const handleClickSeguro = (accion) => () => {
       <button
         type="button"
         onClick={() => {
-          const areaKm2 = Number(contextoBase?.area_km2);
+          const areaKm2 = Number(
+  contextoBase?.casoActivo?.cuenca?.area_km2 ??
+  contextoBase?.area_km2
+);
           const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
           const volumenEsperadoM3 =
             Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
@@ -2738,7 +2764,8 @@ contextoBase?.cuencaNombre ??
                 cuencaCatalogoPayload?.cota_max
             },
             longitud_cauce_km:
-              contextoBase?.longitud_cauce_km ??
+              contextoBase?.casoActivo?.cuenca?.longitud_cauce_km ??
+contextoBase?.longitud_cauce_km ??
               contextoBase?.longitud_cauce ??
               geometriaCatalogoPayload?.longitud_cauce_km ??
               cuencaCatalogoPayload?.longitud_cauce,
@@ -2816,7 +2843,10 @@ contextoBase?.cuencaNombre ??
         Copiar expediente hidrológico mínimo
       </button>
       {(() => {
-        const areaKm2 = Number(contextoBase?.area_km2);
+        const areaKm2 = Number(
+  contextoBase?.casoActivo?.cuenca?.area_km2 ??
+  contextoBase?.area_km2
+);
         const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
         const volumenEsperadoM3 =
           Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
@@ -2874,7 +2904,10 @@ contextoBase?.cuencaNombre ??
 
       <div style={{ ...estilos.muted, marginBottom: "10px" }}>
           {(() => {
-            const areaKm2 = Number(contextoBase?.area_km2);
+            const areaKm2 = Number(
+  contextoBase?.casoActivo?.cuenca?.area_km2 ??
+  contextoBase?.area_km2
+);
             const peTotalMm = Number(contextoBase?.lluvia_efectiva_total_mm);
             const volumenEsperadoM3 =
               Number.isFinite(areaKm2) && Number.isFinite(peTotalMm)
@@ -3967,6 +4000,7 @@ contextoBase?.cuencaNombre ??
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -82,6 +82,53 @@ const cuencaActiva = {
     contextoBase?.casoActivo?.cuenca?.pendiente_media_pct ??
     contextoBase?.pendiente_media_pct
 };
+const hidrologiaActiva = {
+  CN:
+    contextoBase?.casoActivo?.hidrologia?.CN ??
+    contextoBase?.CN,
+
+  CN_base:
+    contextoBase?.casoActivo?.hidrologia?.CN_base ??
+    contextoBase?.CN_base ??
+    contextoBase?.CN,
+
+  CN_efectivo:
+    contextoBase?.casoActivo?.hidrologia?.CN_efectivo ??
+    contextoBase?.CN_efectivo ??
+    contextoBase?.cn_efectivo ??
+    contextoBase?.CN,
+
+  AMC:
+    contextoBase?.casoActivo?.hidrologia?.AMC ??
+    contextoBase?.AMC ??
+    contextoBase?.amcActual ??
+    contextoBase?.amc,
+
+  S_mm:
+    contextoBase?.casoActivo?.hidrologia?.S_mm ??
+    contextoBase?.S_mm ??
+    contextoBase?.s_mm,
+
+  Ia_mm:
+    contextoBase?.casoActivo?.hidrologia?.Ia_mm ??
+    contextoBase?.Ia_mm ??
+    contextoBase?.ia_mm,
+
+  porcentaje_impermeable:
+    contextoBase?.casoActivo?.hidrologia?.porcentaje_impermeable ??
+    contextoBase?.porcentaje_impermeable,
+
+  tc_min:
+    contextoBase?.casoActivo?.hidrologia?.tc_min ??
+    contextoBase?.q_tr_activo_estado?.q_tr_activo?.tc_min ??
+    contextoBase?.q_tr_activo_estado?.tc_min ??
+    contextoBase?.tc_min,
+
+  tc_metodos:
+    contextoBase?.casoActivo?.hidrologia?.tc_metodos ??
+    contextoBase?.tc_metodos ??
+    []
+};
 
 // ✅ DEFINICIÓN REAL DE p
 const p = {
@@ -4000,6 +4047,7 @@ contextoBase?.longitud_cauce_km ??
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -57,11 +57,11 @@ export default function ComparadorMultiMetodo({ contexto = null }) {
 
   // ✅ CONTEXTO BASE
 const contextoBase = contexto || {
-  cuencaNombre: "Quebrada La Iguaná - PC_80",
-  area_km2: 46.8516,
-  pendiente_media_pct: 8.43,
-  CN: 88,
-  lluvia_efectiva: true
+  cuencaNombre: "Sin caso activo",
+  area_km2: null,
+  pendiente_media_pct: null,
+  CN: null,
+  lluvia_efectiva: false
 };
 
 const fuenteContexto = contexto ? "motor HidroFlow" : "contexto base";
@@ -1353,7 +1353,11 @@ const handleClickSeguro = (accion) => () => {
   >
     <div>
       <strong>Cuenca:</strong>{" "}
-      {contextoBase?.cuencaNombre ?? "—"}
+      {
+  contextoBase?.casoActivo?.cuenca?.nombre ??
+  contextoBase?.cuencaNombre ??
+  "—"
+}
     </div>
 
     <div>
@@ -1733,7 +1737,11 @@ const handleClickSeguro = (accion) => () => {
             "## 9. Sello técnico de generación",
             "Herramienta: HidroFlow.",
             "Tipo de salida: Expediente hidrológico mínimo.",
-            `Cuenca activa: ${contextoBase?.cuencaNombre ?? "Cuenca activa"}.`,
+            `Cuenca activa: ${
+  contextoBase?.casoActivo?.cuenca?.nombre ??
+  contextoBase?.cuencaNombre ??
+  "Cuenca activa"
+}.`,
             `Fecha de generación: ${new Date().toLocaleString("es-CO")}.`,
             "Estado técnico: completo, limpio, numéricamente útil y con plausibilidad hidrológica interna preliminar.",
             "Validaciones superadas: estructura, coherencia entre salidas, completitud numérica y plausibilidad hidrológica preliminar.",
@@ -2558,7 +2566,9 @@ const handleClickSeguro = (accion) => () => {
             const diagnosticoDocumentalExpediente = adaptarExpedienteDocumental(textoExpediente, {
               fuenteExpediente: "ComparadorMultiMetodo.textoExpediente",
               origenPlantilla: "OT-0064",
-              cuencaActiva: contextoBase?.cuencaNombre ?? "Cuenca activa"
+              cuencaActiva: contextoBase?.casoActivo?.cuenca?.nombre ??
+contextoBase?.cuencaNombre ??
+"Cuenca activa"
             });
 
             if (!diagnosticoDocumentalExpediente.ok) {

--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -139,7 +139,7 @@ const p = {
   cota_menor_cauce: 1511.36,
   cota_max: 2819.27,
   cota_min: 1511.36,
-  CN: contextoBase.CN
+  CN: hidrologiaActiva.CN
 };
 
 // ✅ EJECUTAR MOTOR
@@ -152,7 +152,7 @@ const metodosTc = mapTcResultados(tcArray);
 const contextoTc = {
   pendiente: cuencaActiva.pendiente_media_pct,
   area: cuencaActiva.area_km2,
-  CN: contextoBase.CN,
+  CN: hidrologiaActiva.CN,
   urbanizacion: 0.5
 };
 
@@ -833,7 +833,7 @@ const lecturaComparativaMatrizPatron = sintetizarLecturaComparativaMatrizPatron(
     return null;
   };
 
-  const bruto = contextoBase?.tc_metodos;
+  const bruto = hidrologiaActiva.tc_metodos;
 
   if (!bruto) return null;
 
@@ -1453,28 +1453,28 @@ const handleClickSeguro = (accion) => () => {
 
     <div>
       <strong>CN:</strong>{" "}
-      {Number.isFinite(contextoBase?.CN)
-        ? contextoBase.CN
+      {Number.isFinite(hidrologiaActiva.CN)
+        ? hidrologiaActiva.CN
         : "—"}
     </div>
 
     <div>
       <strong>CN base:</strong>{" "}
-      {Number.isFinite(contextoBase?.CN_base)
-        ? contextoBase.CN_base
+      {Number.isFinite(hidrologiaActiva.CN_base)
+        ? hidrologiaActiva.CN_base
         : "—"}
     </div>
 
     <div>
       <strong>CN efectivo:</strong>{" "}
-      {Number.isFinite(contextoBase?.CN_efectivo)
-        ? contextoBase.CN_efectivo
+      {Number.isFinite(hidrologiaActiva.CN_efectivo)
+        ? hidrologiaActiva.CN_efectivo
         : "—"}
     </div>
 
     <div>
       <strong>AMC:</strong>{" "}
-      {contextoBase?.AMC ?? "—"}
+      {hidrologiaActiva.AMC ?? "—"}
     </div>
 
     <div>
@@ -2824,9 +2824,9 @@ contextoBase?.longitud_cauce_km ??
                 ? Number(contextoBase.cota_mayor_cauce) -
                   Number(contextoBase.cota_menor_cauce)
                 : undefined),
-            cnBase: contextoBase?.cnBase ?? contextoBase?.CN_base ?? contextoBase?.CN,
-            cnEfectivo: contextoBase?.cnEfectivo ?? contextoBase?.CN_efectivo,
-            amcActual: contextoBase?.amcActual ?? contextoBase?.AMC,
+            cnBase: contextoBase?.cnBase ?? hidrologiaActiva.CN_base ?? hidrologiaActiva.CN,
+            cnEfectivo: contextoBase?.cnEfectivo ?? hidrologiaActiva.CN_efectivo,
+            amcActual: hidrologiaActiva.AMC ?? hidrologiaActiva.AMC,
             tr_diseno_activo: trDisenoActivoExpediente,
             q_tr_activo_estado: estadoQTrActivoExpediente
           };
@@ -4047,6 +4047,7 @@ contextoBase?.longitud_cauce_km ??
     </main>
   );
 }
+
 
 
 

--- a/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
+++ b/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
@@ -54,7 +54,10 @@ const rangoTcAgente =
     racional = null,
 
     // Cuenca
-    cuencaNombre = "Cuenca activa",
+    cuencaNombre =
+  contexto?.casoActivo?.cuenca?.nombre ??
+  contexto?.cuencaNombre ??
+  "Cuenca activa",
     puntoControl = "PC",
     pendiente_media_pct = null,
     estadoTecnico = "En validación",
@@ -500,7 +503,7 @@ const rangoTcAgente =
       <h2 style={estilos.titulo}>Índice Hidrológico de la Cuenca</h2>
 
       <p style={estilos.subtitulo}>
-        Panel lector · La Iguaná PC_80 · Motor HidroFlow
+        Panel lector · {cuencaNombre} · Motor HidroFlow
       </p>
 
       {/* 0. Cuenca activa */}

--- a/01_APP/HIDROFLOW/src/data/cuencasCatalogo.js
+++ b/01_APP/HIDROFLOW/src/data/cuencasCatalogo.js
@@ -402,7 +402,7 @@ export const CUENCAS_CATALOGO = {
   }
 };
 
-export const CUENCA_DEFAULT_ID = "iguana_pc80";
+export const CUENCA_DEFAULT_ID = "san_antonio_prado";
 
 export function getCuencaById(id) {
   return CUENCAS_CATALOGO[id] || CUENCAS_CATALOGO[CUENCA_DEFAULT_ID];

--- a/01_APP/HIDROFLOW/src/data/cuencasCatalogo.js
+++ b/01_APP/HIDROFLOW/src/data/cuencasCatalogo.js
@@ -38,6 +38,7 @@ export const CUENCAS_CATALOGO = {
     alt_salida: 1702,
 
     CN: 88,
+    dt: 5,
     dt_min: 5,
 
     fuente: "Parametros originales app HidroFlow",

--- a/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
@@ -21,6 +21,65 @@ function renderizarTablaEscenarios(metodosComparados = []) {
       }
     }
 
+function renderizarMatrizQpMultiescenario(qTrMultiEscenario) {
+
+  const escenarios =
+    qTrMultiEscenario?.escenarios ?? [];
+
+  if (!escenarios.length) {
+    return [];
+  }
+
+  const TRS = [2.33, 5, 10, 25, 50, 100];
+
+  const metodos = [
+    ...new Set(
+      escenarios.flatMap(
+        (e) =>
+          (e?.hidrogramas ?? [])
+            .map((h) => h?.metodo)
+            .filter(Boolean)
+      )
+    )
+  ];
+
+  const encabezado = [
+    "",
+    "## 12. Matriz multiescenario Qp",
+    "",
+    "| Método | 2.33 | 5 | 10 | 25 | 50 | 100 |",
+    "|---------|---------|---------|---------|---------|---------|---------|"
+  ];
+
+  const filas = metodos.map((metodo) => {
+
+    const celdas = TRS.map((tr) => {
+
+      const escenario =
+        escenarios.find(
+          (e) => Number(e?.Tr) === tr
+        );
+
+      const hidro =
+        escenario?.hidrogramas?.find(
+          (h) => h?.metodo === metodo
+        );
+
+      return hidro?.Qp != null
+        ? numero(hidro.Qp, 2)
+        : "—";
+    });
+
+    return `| ${metodo} | ${celdas.join(" | ")} |`;
+  });
+
+  return [
+    ...encabezado,
+    ...filas,
+    ""
+  ];
+}
+
     return null;
   };
 
@@ -158,14 +217,17 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
     `Síntesis riesgo: ${texto(payload?.diagnosticoQt?.sintesisRiesgo)}`,
     `Adoptivo: ${payload?.diagnosticoQt?.esAdoptivo === true ? "sí" : "no"}`,
     "",
-   "## 10. Lectura de cierre",
+    "## 10. Lectura de cierre",
 
-"",
+    "",
 
-"Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
+   "Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
 
-...renderizarTablaEscenarios(
+  ...renderizarTablaEscenarios(
   payload?.hidrografiaQ5?.metodosComparados ?? []
+),
+...renderizarMatrizQpMultiescenario(
+  payload?.hidrografiaQ5?.qTrMultiEscenario
 ),
 
 ""

--- a/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
@@ -8,6 +8,83 @@ const numero = (valor, decimales = 2) => {
     : "NO DETECTADO";
 };
 
+function renderizarTablaEscenarios(metodosComparados = []) {
+  const TR_OBJETIVO = [2.33, 5, 10, 25, 50, 100];
+  const TOLERANCIA = 0.01;
+
+  const obtenerNumero = (objeto, claves = []) => {
+    for (const clave of claves) {
+      const valor = Number(objeto?.[clave]);
+
+      if (Number.isFinite(valor)) {
+        return valor;
+      }
+    }
+
+    return null;
+  };
+
+  const filas = TR_OBJETIVO.map((tr) => {
+    const escenario =
+      metodosComparados.find(
+        (m) => Number(m?.Tr ?? m?.TR ?? m?.tr) === tr
+      ) ?? null;
+
+    if (!escenario) {
+      return {
+        tr,
+        estado: "No calculado",
+        qDiseno: "—",
+        ratio: "Pendiente"
+      };
+    }
+
+    const qDiseno = obtenerNumero(escenario, [
+      "Q",
+      "q",
+      "Qp",
+      "qp",
+      "Qpico",
+      "caudalPico"
+    ]);
+
+    const ratio = obtenerNumero(escenario, [
+      "ratioVolumen",
+      "ratio",
+      "ratioVolumetrico"
+    ]);
+
+    const estadoRatio =
+      ratio !== null &&
+      Math.abs(ratio - 1) <= TOLERANCIA
+        ? "Consistente"
+        : "Pendiente";
+
+    return {
+      tr,
+      estado: escenario?.estado ?? "disponible",
+      qDiseno:
+        qDiseno !== null
+          ? `${numero(qDiseno, 2)} m³/s`
+          : "—",
+      ratio: estadoRatio
+    };
+  });
+
+  return [
+    "",
+    "## 11. Tabla resumen multi-escenario Tr",
+    "",
+    "| Tr | Estado | Q diseño | Ratio volumen |",
+    "|----|--------|----------|---------------|",
+    ...filas.map(
+      (fila) =>
+        `| ${fila.tr} | ${fila.estado} | ${fila.qDiseno} | ${fila.ratio} |`
+    ),
+    ""
+  ];
+}
+
 export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
   const ratio = payload?.controlConsistencia?.ratioVolumetrico;
 
@@ -81,10 +158,17 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
     `Síntesis riesgo: ${texto(payload?.diagnosticoQt?.sintesisRiesgo)}`,
     `Adoptivo: ${payload?.diagnosticoQt?.esAdoptivo === true ? "sí" : "no"}`,
     "",
-    "## 10. Lectura de cierre",
-    "",
-    "Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
-    ""
+   "## 10. Lectura de cierre",
+
+"",
+
+"Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
+
+...renderizarTablaEscenarios(
+  payload?.hidrografiaQ5?.metodosComparados ?? []
+),
+
+""
   ].join("\n");
 }
 

--- a/01_APP/HIDROFLOW/src/services/documentos/construirPayloadExpedienteDesdeEstado.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirPayloadExpedienteDesdeEstado.js
@@ -161,7 +161,11 @@ export default function construirPayloadExpedienteDesdeEstado({
       ? extraerNumeroMetodo(q5, ["Tp", "tp", "tPico", "TPico", "tiempoPico"])
       : null,
     volumenIntegradoM3: volumenQ5,
-    metodosComparados: Array.isArray(metodos) ? metodos : []
+    metodosComparados: Array.isArray(metodos) ? metodos : [],
+   
+    qTrMultiEscenario:
+      contextoBase?.q_tr_multiescenario ?? null
+
   };
 
   payload.contrasteRacional = {

--- a/01_APP/HIDROFLOW/src/services/documentos/construirPayloadExpedienteDesdeEstado.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirPayloadExpedienteDesdeEstado.js
@@ -150,6 +150,8 @@ export default function construirPayloadExpedienteDesdeEstado({
     )
   };
 
+
+
   payload.hidrografiaQ5 = {
     metodoPrincipal: textoSeguro(q5?.metodo ?? q5?.nombre) || "SCS Unit Hydrograph",
     caudalPicoM3s: q5

--- a/01_APP/HIDROFLOW/src/services/qtr/construirQTrMultiEscenario.js
+++ b/01_APP/HIDROFLOW/src/services/qtr/construirQTrMultiEscenario.js
@@ -1,0 +1,65 @@
+export function construirQTrMultiEscenario({
+  TR_LIST,
+  est,
+  CNact,
+  dtMin,
+  tcSugeridoMinutos,
+  unidadesHidrologicas,
+  calcHietograma,
+  calcLluviaEfectiva,
+  calcHidroCompleto
+}) {
+
+  const escenarios = TR_LIST.map((Tr) => {
+
+    const hiet = calcHietograma(
+      est,
+      Tr,
+      3,
+      dtMin,
+      "EPM_Q1"
+    );
+
+    const lluviaEfectiva = calcLluviaEfectiva(
+      hiet,
+      CNact
+    );
+
+    const lluviaEfectivaTotalMm =
+      lluviaEfectiva.reduce(
+        (s, r) => s + (r.PeIncrem || 0),
+        0
+      );
+
+    const hidrogramas =
+      unidadesHidrologicas.map((HU) => {
+
+        const H = calcHidroCompleto(
+          lluviaEfectiva,
+          HU,
+          dtMin
+        );
+
+        return {
+          metodo: H.metodo,
+          Qp: H.Qpico,
+          Tp: H.tPico,
+          volumen: H.volTotal
+        };
+      });
+
+    return {
+      Tr,
+      Ptotal: hiet?.Ptotal ?? null,
+      lluviaEfectivaTotalMm:
+        +lluviaEfectivaTotalMm.toFixed(4),
+      hidrogramas
+    };
+  });
+
+  return {
+    version: "OT-0344",
+    tcSugeridoMinutos,
+    escenarios
+  };
+}

--- a/07_TOOLBOX/powershell/HF_Migrar_CuencaActiva.ps1
+++ b/07_TOOLBOX/powershell/HF_Migrar_CuencaActiva.ps1
@@ -1,0 +1,22 @@
+$archivo = "D:\HidroFlow\01_APP\HIDROFLOW\src\components\ComparadorMultiMetodo.jsx"
+
+$texto = Get-Content $archivo -Raw
+
+$texto = $texto.Replace(
+    "contextoBase.area_km2",
+    "cuencaActiva.area_km2"
+)
+
+$texto = $texto.Replace(
+    "contextoBase.longitud_cauce_km",
+    "cuencaActiva.longitud_cauce_km"
+)
+
+$texto = $texto.Replace(
+    "contextoBase.pendiente_media_pct",
+    "cuencaActiva.pendiente_media_pct"
+)
+
+Set-Content $archivo $texto -Encoding UTF8
+
+Write-Host "Parche aplicado correctamente."

--- a/07_TOOLBOX/powershell/HF_OT0351A_Publicar_HidrologiaActiva.ps1
+++ b/07_TOOLBOX/powershell/HF_OT0351A_Publicar_HidrologiaActiva.ps1
@@ -1,0 +1,106 @@
+$ErrorActionPreference = "Stop"
+
+$archivo = "D:\HidroFlow\01_APP\HIDROFLOW\src\HidroFlow.jsx"
+$backup = "$archivo.bak_OT0351A_hidrologia"
+
+Write-Host "OT-0351A - Publicar casoActivo.hidrologia" -ForegroundColor Cyan
+
+if (!(Test-Path $archivo)) {
+  throw "No existe el archivo: $archivo"
+}
+
+Copy-Item $archivo $backup -Force
+Write-Host "Backup creado: $backup" -ForegroundColor DarkGray
+
+$texto = Get-Content $archivo -Raw
+
+if ($texto -match "casoActivo:\s*\{[\s\S]*?hidrologia\s*:") {
+  Write-Host "casoActivo.hidrologia ya existe. No se aplica parche duplicado." -ForegroundColor Yellow
+}
+else {
+  $regex = [regex]'(?s)(casoActivo:\s*\{.*?cuenca:\s*\{.*?longitud_cauce_km:\s*.*?null\s*\r?\n\s*\})(\s*\r?\n\s*\},)'
+
+  if (-not $regex.IsMatch($texto)) {
+    throw "No se encontró el bloque casoActivo.cuenca para insertar hidrologia. No se modificó el archivo."
+  }
+
+  $bloqueHidrologia = @"
+
+  hidrologia:{
+    CN: cnBase,
+
+    CN_base:
+      params?.cnBase ??
+      params?.CN ??
+      cnBase,
+
+    CN_efectivo:
+      params?.CN_efectivo ??
+      params?.cnEfectivo ??
+      cnBase,
+
+    AMC:
+      params?.AMC ??
+      params?.amcActual ??
+      params?.amc ??
+      "II",
+
+    S_mm:
+      Number(
+        (
+          25400 /
+            Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) -
+          254
+        ).toFixed(2)
+      ),
+
+    Ia_mm:
+      Number(
+        (
+          0.2 *
+          (
+            25400 /
+              Number(params?.CN_efectivo ?? params?.cnEfectivo ?? cnBase) -
+            254
+          )
+        ).toFixed(2)
+      ),
+
+    porcentaje_impermeable:
+      Number.isFinite(Number(params?.porcentajeImpermeable))
+        ? Number(params.porcentajeImpermeable)
+        : 60,
+
+    tc_min:
+      getTcState()?.Tc_final ?? null,
+
+    tc_metodos:
+      calcTc(params)
+  }
+"@
+
+  $texto = $regex.Replace(
+    $texto,
+    {
+      param($m)
+
+      $m.Groups[1].Value + "," + $bloqueHidrologia + $m.Groups[2].Value
+    },
+    1
+  )
+
+  Set-Content $archivo $texto -Encoding UTF8
+
+  Write-Host "Parche OT-0351A aplicado: casoActivo.hidrologia publicado." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Compilando HidroFlow..." -ForegroundColor Cyan
+
+Push-Location "D:\HidroFlow\01_APP\HIDROFLOW"
+npm run build
+Pop-Location
+
+Write-Host ""
+Write-Host "Resumen git:" -ForegroundColor Cyan
+git diff --stat

--- a/07_TOOLBOX/powershell/HF_OT0351B_Crear_HidrologiaActiva.ps1
+++ b/07_TOOLBOX/powershell/HF_OT0351B_Crear_HidrologiaActiva.ps1
@@ -1,0 +1,101 @@
+$ErrorActionPreference = "Stop"
+
+$archivo = "D:\HidroFlow\01_APP\HIDROFLOW\src\components\ComparadorMultiMetodo.jsx"
+$backup = "$archivo.bak_OT0351B_hidrologiaActiva"
+
+Write-Host "OT-0351B - Crear adaptador hidrologiaActiva" -ForegroundColor Cyan
+
+if (!(Test-Path $archivo)) {
+  throw "No existe el archivo: $archivo"
+}
+
+Copy-Item $archivo $backup -Force
+Write-Host "Backup creado: $backup" -ForegroundColor DarkGray
+
+$texto = Get-Content $archivo -Raw
+
+if ($texto -match "const\s+hidrologiaActiva\s*=") {
+  Write-Host "hidrologiaActiva ya existe. No se aplica parche duplicado." -ForegroundColor Yellow
+}
+else {
+  $regex = [regex]'(?s)(const\s+cuencaActiva\s*=\s*\{.*?\};)'
+
+  if (-not $regex.IsMatch($texto)) {
+    throw "No se encontró el bloque const cuencaActiva = { ... }; No se modificó el archivo."
+  }
+
+  $bloque = @"
+
+const hidrologiaActiva = {
+  CN:
+    contextoBase?.casoActivo?.hidrologia?.CN ??
+    contextoBase?.CN,
+
+  CN_base:
+    contextoBase?.casoActivo?.hidrologia?.CN_base ??
+    contextoBase?.CN_base ??
+    contextoBase?.CN,
+
+  CN_efectivo:
+    contextoBase?.casoActivo?.hidrologia?.CN_efectivo ??
+    contextoBase?.CN_efectivo ??
+    contextoBase?.cn_efectivo ??
+    contextoBase?.CN,
+
+  AMC:
+    contextoBase?.casoActivo?.hidrologia?.AMC ??
+    contextoBase?.AMC ??
+    contextoBase?.amcActual ??
+    contextoBase?.amc,
+
+  S_mm:
+    contextoBase?.casoActivo?.hidrologia?.S_mm ??
+    contextoBase?.S_mm ??
+    contextoBase?.s_mm,
+
+  Ia_mm:
+    contextoBase?.casoActivo?.hidrologia?.Ia_mm ??
+    contextoBase?.Ia_mm ??
+    contextoBase?.ia_mm,
+
+  porcentaje_impermeable:
+    contextoBase?.casoActivo?.hidrologia?.porcentaje_impermeable ??
+    contextoBase?.porcentaje_impermeable,
+
+  tc_min:
+    contextoBase?.casoActivo?.hidrologia?.tc_min ??
+    contextoBase?.q_tr_activo_estado?.q_tr_activo?.tc_min ??
+    contextoBase?.q_tr_activo_estado?.tc_min ??
+    contextoBase?.tc_min,
+
+  tc_metodos:
+    contextoBase?.casoActivo?.hidrologia?.tc_metodos ??
+    contextoBase?.tc_metodos ??
+    []
+};
+"@
+
+  $texto = $regex.Replace(
+    $texto,
+    {
+      param($m)
+      $m.Groups[1].Value + $bloque
+    },
+    1
+  )
+
+  Set-Content $archivo $texto -Encoding UTF8
+
+  Write-Host "Parche OT-0351B aplicado: hidrologiaActiva creado." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Compilando HidroFlow..." -ForegroundColor Cyan
+
+Push-Location "D:\HidroFlow\01_APP\HIDROFLOW"
+npm run build
+Pop-Location
+
+Write-Host ""
+Write-Host "Resumen git:" -ForegroundColor Cyan
+git diff --stat

--- a/07_TOOLBOX/powershell/HF_OT0351C_Migrar_Consumidores_HidrologiaActiva.ps1
+++ b/07_TOOLBOX/powershell/HF_OT0351C_Migrar_Consumidores_HidrologiaActiva.ps1
@@ -1,0 +1,109 @@
+$ErrorActionPreference = "Stop"
+
+$archivo = "D:\HidroFlow\01_APP\HIDROFLOW\src\components\ComparadorMultiMetodo.jsx"
+$backup = "$archivo.bak_OT0351C_migrar_consumidores_hidrologiaActiva"
+
+Write-Host "OT-0351C - Migrar consumidores hacia hidrologiaActiva" -ForegroundColor Cyan
+
+if (!(Test-Path $archivo)) {
+  throw "No existe el archivo: $archivo"
+}
+
+Copy-Item $archivo $backup -Force
+Write-Host "Backup creado: $backup" -ForegroundColor DarkGray
+
+$texto = Get-Content $archivo -Raw
+
+if ($texto -notmatch "const\s+hidrologiaActiva\s*=") {
+  throw "No existe hidrologiaActiva. Ejecuta primero OT-0351B."
+}
+
+# Proteger el bloque del adaptador para evitar autorreemplazos dentro de hidrologiaActiva.
+$inicio = $texto.IndexOf("const hidrologiaActiva =")
+if ($inicio -lt 0) {
+  throw "No se encontró el inicio literal de hidrologiaActiva."
+}
+
+$fin = $texto.IndexOf("};", $inicio)
+if ($fin -lt 0) {
+  throw "No se encontró el cierre de hidrologiaActiva."
+}
+
+$fin = $fin + 2
+
+$antes = $texto.Substring(0, $fin)
+$despues = $texto.Substring($fin)
+
+# Lista ordenada de reemplazos. No usar hashtable: PowerShell trata claves como case-insensitive.
+$reemplazos = @(
+  @{ buscar = "contextoBase?.CN_efectivo"; reemplazar = "hidrologiaActiva.CN_efectivo" }
+  @{ buscar = "contextoBase.CN_efectivo";  reemplazar = "hidrologiaActiva.CN_efectivo" }
+  @{ buscar = "contextoBase?.cn_efectivo"; reemplazar = "hidrologiaActiva.CN_efectivo" }
+  @{ buscar = "contextoBase.cn_efectivo";  reemplazar = "hidrologiaActiva.CN_efectivo" }
+
+  @{ buscar = "contextoBase?.CN_base"; reemplazar = "hidrologiaActiva.CN_base" }
+  @{ buscar = "contextoBase.CN_base";  reemplazar = "hidrologiaActiva.CN_base" }
+
+  @{ buscar = "contextoBase?.AMC";       reemplazar = "hidrologiaActiva.AMC" }
+  @{ buscar = "contextoBase.AMC";        reemplazar = "hidrologiaActiva.AMC" }
+  @{ buscar = "contextoBase?.amcActual"; reemplazar = "hidrologiaActiva.AMC" }
+  @{ buscar = "contextoBase.amcActual";  reemplazar = "hidrologiaActiva.AMC" }
+  @{ buscar = "contextoBase?.amc";       reemplazar = "hidrologiaActiva.AMC" }
+  @{ buscar = "contextoBase.amc";        reemplazar = "hidrologiaActiva.AMC" }
+
+  @{ buscar = "contextoBase?.S_mm"; reemplazar = "hidrologiaActiva.S_mm" }
+  @{ buscar = "contextoBase.S_mm";  reemplazar = "hidrologiaActiva.S_mm" }
+  @{ buscar = "contextoBase?.s_mm"; reemplazar = "hidrologiaActiva.S_mm" }
+  @{ buscar = "contextoBase.s_mm";  reemplazar = "hidrologiaActiva.S_mm" }
+
+  @{ buscar = "contextoBase?.Ia_mm"; reemplazar = "hidrologiaActiva.Ia_mm" }
+  @{ buscar = "contextoBase.Ia_mm";  reemplazar = "hidrologiaActiva.Ia_mm" }
+  @{ buscar = "contextoBase?.ia_mm"; reemplazar = "hidrologiaActiva.Ia_mm" }
+  @{ buscar = "contextoBase.ia_mm";  reemplazar = "hidrologiaActiva.Ia_mm" }
+
+  @{ buscar = "contextoBase?.porcentaje_impermeable"; reemplazar = "hidrologiaActiva.porcentaje_impermeable" }
+  @{ buscar = "contextoBase.porcentaje_impermeable";  reemplazar = "hidrologiaActiva.porcentaje_impermeable" }
+
+  @{ buscar = "contextoBase?.tc_metodos"; reemplazar = "hidrologiaActiva.tc_metodos" }
+  @{ buscar = "contextoBase.tc_metodos";  reemplazar = "hidrologiaActiva.tc_metodos" }
+
+  @{ buscar = "contextoBase?.tc_min"; reemplazar = "hidrologiaActiva.tc_min" }
+  @{ buscar = "contextoBase.tc_min";  reemplazar = "hidrologiaActiva.tc_min" }
+
+  # CN simple se deja al final para no tocar CN_base ni CN_efectivo antes de tiempo.
+  @{ buscar = "contextoBase?.CN"; reemplazar = "hidrologiaActiva.CN" }
+  @{ buscar = "contextoBase.CN";  reemplazar = "hidrologiaActiva.CN" }
+)
+
+$total = 0
+
+foreach ($par in $reemplazos) {
+  $buscar = $par.buscar
+  $reemplazar = $par.reemplazar
+
+  $conteo = ([regex]::Matches($despues, [regex]::Escape($buscar))).Count
+
+  if ($conteo -gt 0) {
+    Write-Host ("Reemplazos {0}: {1}" -f $buscar, $conteo) -ForegroundColor Yellow
+    $despues = $despues.Replace($buscar, $reemplazar)
+    $total += $conteo
+  }
+}
+
+$textoFinal = $antes + $despues
+
+Set-Content $archivo $textoFinal -Encoding UTF8
+
+Write-Host ""
+Write-Host ("Total reemplazos aplicados: {0}" -f $total) -ForegroundColor Green
+
+Write-Host ""
+Write-Host "Compilando HidroFlow..." -ForegroundColor Cyan
+
+Push-Location "D:\HidroFlow\01_APP\HIDROFLOW"
+npm run build
+Pop-Location
+
+Write-Host ""
+Write-Host "Resumen git:" -ForegroundColor Cyan
+git diff --stat

--- a/07_TOOLBOX/powershell/HF_OT0352_Validar_CASO_ACTIVO_SanAntonio.ps1
+++ b/07_TOOLBOX/powershell/HF_OT0352_Validar_CASO_ACTIVO_SanAntonio.ps1
@@ -1,0 +1,91 @@
+$ErrorActionPreference = "Stop"
+
+Write-Host "OT-0352 - Validacion CASO_ACTIVO San Antonio" -ForegroundColor Cyan
+
+$raiz = "D:\HidroFlow"
+$hidroFlow = "$raiz\01_APP\HIDROFLOW\src\HidroFlow.jsx"
+$comparador = "$raiz\01_APP\HIDROFLOW\src\components\ComparadorMultiMetodo.jsx"
+$indice = "$raiz\01_APP\HIDROFLOW\src\components\IndiceHidrologico.jsx"
+$catalogo = "$raiz\01_APP\HIDROFLOW\src\data\cuencasCatalogo.js"
+
+$errores = @()
+
+function CheckFile($ruta, $nombre) {
+  if (!(Test-Path $ruta)) {
+    $script:errores += "No existe: $nombre"
+  } else {
+    Write-Host "OK archivo: $nombre" -ForegroundColor Green
+  }
+}
+
+function CheckContains($ruta, $texto, $descripcion) {
+  $contenido = Get-Content $ruta -Raw
+  if ($contenido.Contains($texto)) {
+    Write-Host "OK: $descripcion" -ForegroundColor Green
+  } else {
+    $script:errores += "Falta: $descripcion"
+  }
+}
+
+Write-Host ""
+Write-Host "1. Archivos base" -ForegroundColor Cyan
+CheckFile $hidroFlow "HidroFlow.jsx"
+CheckFile $comparador "ComparadorMultiMetodo.jsx"
+CheckFile $indice "IndiceHidrologico.jsx"
+CheckFile $catalogo "cuencasCatalogo.js"
+
+Write-Host ""
+Write-Host "2. Catalogo San Antonio" -ForegroundColor Cyan
+CheckContains $catalogo 'export const CUENCA_DEFAULT_ID = "san_antonio_prado";' 'CUENCA_DEFAULT_ID = san_antonio_prado'
+CheckContains $catalogo 'nombre_cuenca: "Cuenca San Antonio"' 'nombre_cuenca San Antonio'
+
+Write-Host ""
+Write-Host "3. CASO_ACTIVO en HidroFlow.jsx" -ForegroundColor Cyan
+CheckContains $hidroFlow 'casoActivo:{' 'casoActivo publicado'
+CheckContains $hidroFlow 'tipo:"CASO_HIDROLOGICO"' 'tipo CASO_HIDROLOGICO'
+CheckContains $hidroFlow 'cuenca:{' 'casoActivo.cuenca publicado'
+CheckContains $hidroFlow 'params?.nombre_cuenca ??' 'nombre_cuenca usado por publicador'
+CheckContains $hidroFlow 'hidrologia:{' 'casoActivo.hidrologia publicado'
+CheckContains $hidroFlow 'CN_efectivo:' 'hidrologia.CN_efectivo publicado'
+CheckContains $hidroFlow 'tc_metodos:' 'hidrologia.tc_metodos publicado'
+
+Write-Host ""
+Write-Host "4. Adaptadores en Comparador" -ForegroundColor Cyan
+CheckContains $comparador 'const cuencaActiva = {' 'cuencaActiva existe'
+CheckContains $comparador 'const hidrologiaActiva = {' 'hidrologiaActiva existe'
+CheckContains $comparador 'cuencaActiva.area_km2' 'consume cuencaActiva.area_km2'
+CheckContains $comparador 'cuencaActiva.pendiente_media_pct' 'consume cuencaActiva.pendiente_media_pct'
+CheckContains $comparador 'hidrologiaActiva.CN' 'consume hidrologiaActiva.CN'
+CheckContains $comparador 'hidrologiaActiva.CN_efectivo' 'consume hidrologiaActiva.CN_efectivo'
+CheckContains $comparador 'hidrologiaActiva.AMC' 'consume hidrologiaActiva.AMC'
+
+Write-Host ""
+Write-Host "5. Indice Hidrologico" -ForegroundColor Cyan
+CheckContains $indice 'contexto?.casoActivo?.cuenca?.nombre ??' 'Indice lee casoActivo.cuenca.nombre'
+
+Write-Host ""
+Write-Host "6. Resultado validacion estatica" -ForegroundColor Cyan
+if ($errores.Count -gt 0) {
+  Write-Host "VALIDACION FALLIDA" -ForegroundColor Red
+  $errores | ForEach-Object { Write-Host "- $_" -ForegroundColor Red }
+  throw "OT-0352 fallo."
+}
+
+Write-Host "VALIDACION ESTATICA OK" -ForegroundColor Green
+
+Write-Host ""
+Write-Host "7. Build HidroFlow" -ForegroundColor Cyan
+Push-Location "$raiz\01_APP\HIDROFLOW"
+npm run build
+Pop-Location
+
+Write-Host ""
+Write-Host "8. Git status" -ForegroundColor Cyan
+git status --short
+
+Write-Host ""
+Write-Host "9. Git diff stat" -ForegroundColor Cyan
+git diff --stat
+
+Write-Host ""
+Write-Host "OT-0352 validacion terminada correctamente." -ForegroundColor Green


### PR DESCRIPTION
## Objetivo
Eliminar referencias documentales heredadas de PC_80 y La Iguaná cuando la cuenca activa es San Antonio.

## Cambios
- Distancia IDF–PC_80 → Distancia IDF–Salida
- PC_80 · SALIDA → SALIDA ACTIVA
- PC_80 / salida → Salida activa
- Cuenca activa en lugar de referencias específicas a La Iguaná en el mini-mapa
- Etiquetas documentales del punto de salida desacopladas

## Validación
- npm run build aprobado
- Sin cambios en cálculos
- Sin cambios en motor hidrológico
- Sin cambios en IDF
- Sin cambios en Tc
- Sin cambios en Q(t)