### PR TITLE
OT-0355 — Barrido final textos heredados

### DIFF
--- a/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
+++ b/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
@@ -947,7 +947,7 @@ const rangoTcAgente =
         </div>
 
         <p style={estilos.muted}>
-          Para La Iguaná PC_80, el Método Racional se conserva como contraste
+          El Método Racional se conserva como contraste
           referencial. El cálculo de C en función del CN queda en radar para el
           motor hidrológico.
         </p>
@@ -1005,6 +1005,8 @@ const rangoTcAgente =
     </aside>
   );
 }
+
+
 
 
 

--- a/01_APP/HIDROFLOW/src/data/metodosComparadorCatalogo.js
+++ b/01_APP/HIDROFLOW/src/data/metodosComparadorCatalogo.js
@@ -287,7 +287,7 @@ export const metodosQCatalogo = [
     requiere: ["coeficiente_c", "intensidad_idf", "area_km2", "tr"],
     variablesSalida: ["Qp"],
     observacion:
-      "Para La Iguaná PC_80 debe mantenerse como contraste referencial, no como método principal.",
+      "Debe mantenerse como contraste referencial, no como método principal.",
   },
 ];
 


### PR DESCRIPTION
Neutraliza referencias visibles heredadas de La Iguaná y PC_80 en la UI. Build aprobado y sin cambios funcionales.