### PR TITLE
OT-0357 — Auditoría expediente exportable

### DIFF
--- a/01_APP/HIDROFLOW/src/services/hidrogramas/prepararGraficaQpTPicoMatrizPatron.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/prepararGraficaQpTPicoMatrizPatron.js
@@ -50,7 +50,7 @@ export default function prepararGraficaQpTPicoMatrizPatron(matriz = {}) {
 
   return {
     ok: puntos.length > 0,
-    titulo: "Qp vs tPico — Matriz patrón La Iguaná PC_80",
+    titulo: "Qp vs tPico — Matriz patrón de referencia",
     ejes: {
       x: "tPico (min)",
       y: "Qp (m³/s)"

--- a/01_APP/HIDROFLOW/src/services/hidrogramas/prepararGraficaVelocidadEfectivaMatrizPatron.js
+++ b/01_APP/HIDROFLOW/src/services/hidrogramas/prepararGraficaVelocidadEfectivaMatrizPatron.js
@@ -65,7 +65,7 @@ export default function prepararGraficaVelocidadEfectivaMatrizPatron(matriz = {}
 
   return {
     ok: barras.length > 0,
-    titulo: "Velocidad efectiva — Matriz patrón La Iguaná PC_80",
+    titulo: "Velocidad efectiva — Matriz patrón de referencia",
     ejes: {
       x: "Velocidad efectiva (km/h)",
       y: "Método"


### PR DESCRIPTION
Neutraliza referencias heredadas de La Iguaná y PC_80 en servicios y componentes asociados al expediente exportable. Build aprobado y sin cambios funcionales.