### PR TITLE
OT‑PEND‑TOOLS — Recuperación pendientes master y HF‑Tools

### DIFF
--- a/01_APP/HIDROFLOW/src/services/master/resolverCuencaDesdeCoordenadas.js
+++ b/01_APP/HIDROFLOW/src/services/master/resolverCuencaDesdeCoordenadas.js
@@ -1,16 +1,19 @@
 import { CUENCAS_CATALOGO } from "../../data/cuencasCatalogo";
 
 function distancia2(lat1, lon1, lat2, lon2) {
+
   return (
     Math.pow(Number(lat1) - Number(lat2), 2) +
     Math.pow(Number(lon1) - Number(lon2), 2)
   );
+
 }
 
 export default function resolverCuencaDesdeCoordenadas(
   latitud,
   longitud
 ) {
+
   if (
     !Number.isFinite(Number(latitud)) ||
     !Number.isFinite(Number(longitud))
@@ -21,17 +24,17 @@ export default function resolverCuencaDesdeCoordenadas(
   let mejor = null;
   let mejorDistancia = Number.POSITIVE_INFINITY;
 
-  for (const cuenca of CUENCAS_CATALOGO) {
+  for (const cuenca of Object.values(CUENCAS_CATALOGO)) {
 
     const lat =
+      cuenca?.lat_salida ??
       cuenca?.lat ??
-      cuenca?.latitud ??
-      cuenca?.coordenadas?.lat;
+      cuenca?.latitud;
 
     const lon =
+      cuenca?.lon_salida ??
       cuenca?.lon ??
-      cuenca?.longitud ??
-      cuenca?.coordenadas?.lon;
+      cuenca?.longitud;
 
     if (
       !Number.isFinite(Number(lat)) ||
@@ -40,16 +43,18 @@ export default function resolverCuencaDesdeCoordenadas(
       continue;
     }
 
-    const distancia = distancia2(
+    const d = distancia2(
       latitud,
       longitud,
       lat,
       lon
     );
 
-    if (distancia < mejorDistancia) {
-      mejorDistancia = distancia;
+    if (d < mejorDistancia) {
+
+      mejorDistancia = d;
       mejor = cuenca;
+
     }
   }
 

--- a/07_TOOLBOX/powershell/HF-Tools.ps1
+++ b/07_TOOLBOX/powershell/HF-Tools.ps1
@@ -1,0 +1,23 @@
+function HF-Trace {
+    param([string]$Simbolo)
+
+    powershell -ExecutionPolicy Bypass `
+    -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-Trace.ps1" `
+    -Simbolo $Simbolo
+}
+
+function HF-Impact {
+    param([string]$Simbolo)
+
+    powershell -ExecutionPolicy Bypass `
+    -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-Impact.ps1" `
+    -Simbolo $Simbolo
+}
+
+function HF-Patch {
+    param([string]$Problema)
+
+    powershell -ExecutionPolicy Bypass `
+    -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-PATCH.ps1" `
+    -Problema $Problema
+}

--- a/07_TOOLBOX/powershell/Run-HidroFlowMaster.ps1
+++ b/07_TOOLBOX/powershell/Run-HidroFlowMaster.ps1
@@ -208,3 +208,32 @@ foreach($token in $tokensEntrada){
         Write-Host "[OK] $token"
     }
 }
+
+Write-Host ""
+Write-Host "AUTOMATIZACION FINAL"
+Write-Host "--------------------"
+
+$adaptador =
+"01_APP\HIDROFLOW\src\services\master\resolverCuencaDesdeCoordenadas.js"
+
+if(Test-Path $adaptador){
+
+    Write-Host "[OK] resolverCuencaDesdeCoordenadas"
+
+    Write-Host ""
+    Write-Host "CADENA OBJETIVO"
+
+    Write-Host "Coordenadas"
+    Write-Host " -> resolverCuencaDesdeCoordenadas"
+    Write-Host " -> params"
+    Write-Host " -> casoActivo"
+    Write-Host " -> contextoBase"
+    Write-Host " -> Expediente"
+
+}
+else{
+
+    Write-Host "[PENDIENTE] resolverCuencaDesdeCoordenadas"
+
+}
+


### PR DESCRIPTION
## Objetivo

Recuperar cambios pendientes separados del cierre de OT‑EXP‑CONS‑004.

## Cambios

- Ajuste en resolverCuencaDesdeCoordenadas.js para recorrer CUENCAS_CATALOGO mediante Object.values.
- Actualización de Run-HidroFlowMaster.ps1.
- Incorporación de HF-Tools.ps1 como lanzador unificado de herramientas HF.

## Validación

- Build Vite aprobado.
- Rama subida correctamente a origin.

## Estado

Lista para revisión.