### PR TITLE
OT‑AUTO‑003 — Batería multi‑Tr para HF‑TestExpediente

### DIFF
--- a/00_ADMIN/bitacora/OT-AUTO-003_hf_test_expediente_multitr.md
+++ b/00_ADMIN/bitacora/OT-AUTO-003_hf_test_expediente_multitr.md
@@ -1,0 +1,15 @@
+# OT-AUTO-003
+
+## Objetivo
+
+Ampliar HF-TestExpediente para soportar validación multi-Tr del expediente hidrológico mínimo.
+
+## Casos objetivo
+
+- Tr=25: Q-Tr 17,13 m³/s y Qp Q-5 17,13 m³/s.
+- Tr=50: Q-Tr 18,87 m³/s y Qp Q-5 18,87 m³/s.
+- Tr=100: Q-Tr 20,62 m³/s y Qp Q-5 20,62 m³/s.
+
+## Estado
+
+Abierta.

--- a/07_TOOLBOX/powershell/HF-TestExpediente.ps1
+++ b/07_TOOLBOX/powershell/HF-TestExpediente.ps1
@@ -1,27 +1,17 @@
 param(
-    [string]$Caso = "TrActivoVsQp"
+    [string]$Caso = "TrActivoVsQp",
+    [string]$Tr = "",
+    [string]$Carpeta = "D:\HidroFlow\10_LOGS\hf-test-expediente"
 )
-
-try {
-    $texto = Get-Clipboard -Raw
-}
-catch {
-    Write-Host "ERROR: No fue posible leer el portapapeles." -ForegroundColor Red
-    exit 1
-}
-
-if ([string]::IsNullOrWhiteSpace($texto)) {
-    Write-Host "ERROR: Portapapeles vacio. Copia primero el expediente." -ForegroundColor Red
-    exit 1
-}
 
 function Obtener-Primera-Linea {
     param(
+        [string]$Texto,
         [string]$Patron
     )
 
     return (
-        ($texto -split "`r?`n") |
+        ($Texto -split "`r?`n") |
         Where-Object { $_ -match $Patron } |
         Select-Object -First 1
     )
@@ -47,6 +37,92 @@ function Extraer-Numero {
     return $null
 }
 
+function Evaluar-Expediente {
+    param(
+        [string]$Texto,
+        [string]$Etiqueta = "clipboard"
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Texto)) {
+        Write-Host "FAIL: Texto vacio para $Etiqueta." -ForegroundColor Red
+        return $false
+    }
+
+    $lineaTr = Obtener-Primera-Linea -Texto $Texto -Patron "Tr activo:"
+    $lineaQTr = Obtener-Primera-Linea -Texto $Texto -Patron "Caudal de diseño Q-Tr:"
+    $lineaQp = Obtener-Primera-Linea -Texto $Texto -Patron "^\s*Qp:"
+    $lineaRatio = Obtener-Primera-Linea -Texto $Texto -Patron "Ratio Vol Q-5 / Vol esperado:"
+    $lineaEstado = Obtener-Primera-Linea -Texto $Texto -Patron "^\s*Estado:\s*consistente"
+
+    $tr = Extraer-Numero $lineaTr
+    $qtr = Extraer-Numero $lineaQTr
+    $qp = Extraer-Numero $lineaQp
+    $ratio = Extraer-Numero $lineaRatio
+
+    $esperado = @{
+        "25"  = "17,13"
+        "50"  = "18,87"
+        "100" = "20,62"
+    }
+
+    Write-Host ""
+    Write-Host "-----------------------------------" -ForegroundColor Cyan
+    Write-Host "CASO: $Etiqueta" -ForegroundColor Yellow
+    Write-Host "-----------------------------------" -ForegroundColor Cyan
+    Write-Host "Tr activo : $tr"
+    Write-Host "Q-Tr      : $qtr"
+    Write-Host "Qp Q-5    : $qp"
+    Write-Host "Ratio     : $ratio"
+    Write-Host "Estado    : $lineaEstado"
+    Write-Host ""
+
+    if ([string]::IsNullOrWhiteSpace($tr)) {
+        Write-Host "FAIL: No se detecto Tr activo." -ForegroundColor Red
+        return $false
+    }
+
+    if (-not $esperado.ContainsKey($tr)) {
+        Write-Host "FAIL: Tr activo no catalogado: $tr" -ForegroundColor Red
+        return $false
+    }
+
+    $qEsperado = $esperado[$tr]
+
+    $okQTr = $qtr -eq $qEsperado
+    $okQp = $qp -eq $qEsperado
+    $okRatio = $ratio -eq "1.000000" -or $ratio -eq "1,000000"
+    $okEstado = -not [string]::IsNullOrWhiteSpace($lineaEstado)
+
+    Write-Host "Validacion esperada:"
+    Write-Host "Tr=$tr -> Q esperado=$qEsperado"
+    Write-Host ""
+
+    if ($okQTr -and $okQp -and $okRatio -and $okEstado) {
+        Write-Host "PASS: Expediente sincronizado Tr activo <-> Q-Tr <-> Q-5." -ForegroundColor Green
+        return $true
+    }
+
+    Write-Host "FAIL: Expediente no sincronizado." -ForegroundColor Red
+
+    if (-not $okQTr) {
+        Write-Host "- Q-Tr esperado: $qEsperado ; detectado: $qtr" -ForegroundColor Red
+    }
+
+    if (-not $okQp) {
+        Write-Host "- Qp esperado: $qEsperado ; detectado: $qp" -ForegroundColor Red
+    }
+
+    if (-not $okRatio) {
+        Write-Host "- Ratio esperado: 1.000000 ; detectado: $ratio" -ForegroundColor Red
+    }
+
+    if (-not $okEstado) {
+        Write-Host "- Estado consistente no detectado." -ForegroundColor Red
+    }
+
+    return $false
+}
+
 Write-Host ""
 Write-Host "===================================" -ForegroundColor Cyan
 Write-Host "HF-TEST EXPEDIENTE" -ForegroundColor Yellow
@@ -54,79 +130,135 @@ Write-Host "Caso: $Caso"
 Write-Host "===================================" -ForegroundColor Cyan
 Write-Host ""
 
-$lineaTr = Obtener-Primera-Linea "Tr activo:"
-$lineaQTr = Obtener-Primera-Linea "Caudal de diseño Q-Tr:"
-$lineaQp = Obtener-Primera-Linea "^\s*Qp:"
-$lineaRatio = Obtener-Primera-Linea "Ratio Vol Q-5 / Vol esperado:"
-$lineaEstado = Obtener-Primera-Linea "^\s*Estado:\s*consistente"
+if ($Caso -eq "TrActivoVsQp") {
 
-$tr = Extraer-Numero $lineaTr
-$qtr = Extraer-Numero $lineaQTr
-$qp = Extraer-Numero $lineaQp
-$ratio = Extraer-Numero $lineaRatio
+    $texto = Get-Clipboard -Raw
 
-Write-Host "Lectura detectada:"
-Write-Host "Tr activo : $tr"
-Write-Host "Q-Tr      : $qtr"
-Write-Host "Qp Q-5    : $qp"
-Write-Host "Ratio     : $ratio"
-Write-Host "Estado    : $lineaEstado"
-Write-Host ""
+    $ok = Evaluar-Expediente `
+        -Texto $texto `
+        -Etiqueta "Clipboard"
 
-if ($Caso -ne "TrActivoVsQp") {
-    Write-Host "FAIL: Caso no catalogado: $Caso" -ForegroundColor Red
+    if ($ok) {
+        exit 0
+    }
+
     exit 1
 }
 
-$esperado = @{
-    "25"  = "17,13"
-    "50"  = "18,87"
-    "100" = "20,62"
-}
+if ($Caso -eq "RegistrarTr") {
 
-if ([string]::IsNullOrWhiteSpace($tr)) {
-    Write-Host "FAIL: No se detecto Tr activo." -ForegroundColor Red
-    exit 1
-}
+    if ([string]::IsNullOrWhiteSpace($Tr)) {
+        Write-Host "FAIL: Debes indicar -Tr 25, 50 o 100." -ForegroundColor Red
+        exit 1
+    }
 
-if (-not $esperado.ContainsKey($tr)) {
-    Write-Host "FAIL: Tr activo no catalogado: $tr" -ForegroundColor Red
-    exit 1
-}
+    if ($Tr -notin @("25", "50", "100")) {
+        Write-Host "FAIL: Tr no permitido para esta bateria: $Tr" -ForegroundColor Red
+        exit 1
+    }
 
-$qEsperado = $esperado[$tr]
+    $texto = Get-Clipboard -Raw
 
-$okQTr = $qtr -eq $qEsperado
-$okQp = $qp -eq $qEsperado
-$okRatio = $ratio -eq "1.000000" -or $ratio -eq "1,000000"
-$okEstado = -not [string]::IsNullOrWhiteSpace($lineaEstado)
+    if ([string]::IsNullOrWhiteSpace($texto)) {
+        Write-Host "FAIL: Portapapeles vacio. Copia primero el expediente." -ForegroundColor Red
+        exit 1
+    }
 
-Write-Host "Validacion esperada:"
-Write-Host "Tr=$tr -> Q esperado=$qEsperado"
-Write-Host ""
+    $lineaTrRegistro =
+        Obtener-Primera-Linea `
+            -Texto $texto `
+            -Patron "Tr activo:"
 
-if ($okQTr -and $okQp -and $okRatio -and $okEstado) {
-    Write-Host "PASS: Expediente sincronizado Tr activo <-> Q-Tr <-> Q-5." -ForegroundColor Green
+    $trDetectado =
+        Extraer-Numero `
+            -Linea $lineaTrRegistro
+
+    if ($trDetectado -ne $Tr) {
+        Write-Host "FAIL: El expediente copiado no corresponde al Tr solicitado." -ForegroundColor Red
+        Write-Host "Tr solicitado : $Tr"
+        Write-Host "Tr detectado  : $trDetectado"
+        exit 1
+    }
+
+    $ok =
+        Evaluar-Expediente `
+            -Texto $texto `
+            -Etiqueta "Pre-registro Tr=$Tr"
+
+    if (-not $ok) {
+        Write-Host "FAIL: No se registra Tr=$Tr porque el expediente no pasa validacion." -ForegroundColor Red
+        exit 1
+    }
+
+    New-Item `
+        -ItemType Directory `
+        -Path $Carpeta `
+        -Force | Out-Null
+
+    $ruta =
+        Join-Path `
+            $Carpeta `
+            "Tr$Tr.txt"
+
+    Set-Content `
+        -Path $ruta `
+        -Value $texto `
+        -Encoding UTF8
+
+    Write-Host "PASS: Expediente registrado para Tr=$Tr en:" -ForegroundColor Green
+    Write-Host $ruta
+
     exit 0
 }
 
-Write-Host "FAIL: Expediente no sincronizado." -ForegroundColor Red
-Write-Host ""
+if ($Caso -eq "MultiTr") {
 
-if (-not $okQTr) {
-    Write-Host "- Q-Tr esperado: $qEsperado ; detectado: $qtr" -ForegroundColor Red
+    $casos = @("25", "50", "100")
+    $fallos = 0
+
+    foreach ($t in $casos) {
+
+        $ruta =
+            Join-Path `
+                $Carpeta `
+                "Tr$t.txt"
+
+        if (-not (Test-Path $ruta)) {
+            Write-Host "FAIL: No existe archivo de prueba para Tr=$t" -ForegroundColor Red
+            Write-Host $ruta
+            $fallos++
+            continue
+        }
+
+        $texto =
+            Get-Content `
+                -Path $ruta `
+                -Raw
+
+        $ok =
+            Evaluar-Expediente `
+                -Texto $texto `
+                -Etiqueta "Tr=$t"
+
+        if (-not $ok) {
+            $fallos++
+        }
+    }
+
+    Write-Host ""
+    Write-Host "===================================" -ForegroundColor Cyan
+    Write-Host "RESUMEN MULTI-TR" -ForegroundColor Yellow
+    Write-Host "===================================" -ForegroundColor Cyan
+
+    if ($fallos -eq 0) {
+        Write-Host "PASS: Bateria multi-Tr aprobada." -ForegroundColor Green
+        exit 0
+    }
+
+    Write-Host "FAIL: Bateria multi-Tr con $fallos fallo(s)." -ForegroundColor Red
+    exit 1
 }
 
-if (-not $okQp) {
-    Write-Host "- Qp esperado: $qEsperado ; detectado: $qp" -ForegroundColor Red
-}
-
-if (-not $okRatio) {
-    Write-Host "- Ratio esperado: 1.000000 ; detectado: $ratio" -ForegroundColor Red
-}
-
-if (-not $okEstado) {
-    Write-Host "- Estado consistente no detectado." -ForegroundColor Red
-}
-
+Write-Host "FAIL: Caso no catalogado: $Caso" -ForegroundColor Red
 exit 1
+

--- a/07_TOOLBOX/powershell/HF-Tools.ps1
+++ b/07_TOOLBOX/powershell/HF-Tools.ps1
@@ -1,5 +1,7 @@
 function HF-Trace {
-    param([string]$Simbolo)
+    param(
+        [string]$Simbolo
+    )
 
     powershell -ExecutionPolicy Bypass `
     -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-Trace.ps1" `
@@ -7,7 +9,9 @@ function HF-Trace {
 }
 
 function HF-Impact {
-    param([string]$Simbolo)
+    param(
+        [string]$Simbolo
+    )
 
     powershell -ExecutionPolicy Bypass `
     -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-Impact.ps1" `
@@ -15,16 +19,30 @@ function HF-Impact {
 }
 
 function HF-Patch {
-    param([string]$Problema)
+    param(
+        [string]$Problema
+    )
 
     powershell -ExecutionPolicy Bypass `
     -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-PATCH.ps1" `
     -Problema $Problema
 }
-function HF-TestExpediente {
-    param([string]$Caso = "TrActivoVsQp")
 
-    powershell -ExecutionPolicy Bypass `
-    -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-TestExpediente.ps1" `
-    -Caso $Caso
+function HF-TestExpediente {
+    param(
+        [string]$Caso = "TrActivoVsQp",
+        [string]$Tr = ""
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Tr)) {
+        powershell -ExecutionPolicy Bypass `
+        -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-TestExpediente.ps1" `
+        -Caso $Caso
+    }
+    else {
+        powershell -ExecutionPolicy Bypass `
+        -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-TestExpediente.ps1" `
+        -Caso $Caso `
+        -Tr $Tr
+    }
 }


### PR DESCRIPTION
## Objetivo

Ampliar HF-TestExpediente para validar automáticamente la sincronización Tr activo ↔ Q-Tr ↔ Q-5 en batería multi-Tr.

## Cambios

- Se agrega modo `RegistrarTr`.
- Se agrega modo `MultiTr`.
- Se valida que el Tr registrado coincida con el Tr detectado en el expediente.
- Se integra el uso de `HF-TestExpediente` desde `HF-Tools.ps1`.

## Validación

- Prueba negativa: intento de registrar Tr=25 con expediente Tr=100 → FAIL correcto.
- Registro Tr=25 → PASS.
- Registro Tr=50 → PASS.
- Registro Tr=100 → PASS.
- Batería MultiTr → PASS.

## Estado

Listo para revisión.