### PR TITLE
OT-AUTO-005 — HF-ValidarExpediente como validador integral

### DIFF
--- a/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
+++ b/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
@@ -39,3 +39,38 @@ Frente futuro recomendado:
 OT-EXP-FORM-001 — Fórmulas matemáticas trazables del expediente hidrológico.
 
 Este frente deberá incorporar explícitamente al expediente las expresiones matemáticas que dan lugar a resultados como CN, S, Ia, Pe, IDF, Tc, Q-Tr, Qp, volumen, ratio de consistencia y Método Racional.
+
+## Radar complementario no negociable
+
+Además de las fórmulas matemáticas trazables, el expediente HidroFlow deberá evolucionar hacia un producto técnico-científico autoportable con soporte explícito para:
+
+- gráficas exportables,
+- mapas exportables,
+- esquemas de conectividad hidrológica,
+- trazabilidad espacial,
+- rutas de flujo,
+- red hídrica validada,
+- localización de punto de control,
+- evidencia visual asociada a resultados numéricos.
+
+Estos elementos no deben tratarse como adornos visuales, sino como evidencia técnica exportable que complemente las fórmulas, variables, unidades, resultados y trazabilidad computacional.
+
+Frentes futuros recomendados:
+
+- OT-EXP-FORM-001 — Fórmulas matemáticas trazables del expediente hidrológico.
+- OT-EXP-VIS-001 — Gráficas exportables del expediente hidrológico.
+- OT-EXP-MAP-001 — Mapas y conectividad hidrológica exportable.
+- OT-EXP-PORT-001 — Expediente autoportable con evidencias numéricas, gráficas, mapas y trazabilidad completa.
+
+Criterio arquitectónico:
+
+Todo resultado técnico relevante deberá poder responder:
+
+1. ¿De qué fórmula proviene?
+2. ¿Con qué variables se calculó?
+3. ¿Con qué unidades?
+4. ¿Qué valor se aplicó?
+5. ¿Qué resultado generó?
+6. ¿Dónde se calculó en HidroFlow?
+7. ¿Qué gráfica, mapa o evidencia visual lo respalda?
+8. ¿Cómo se exporta en el expediente?

--- a/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
+++ b/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
@@ -20,3 +20,22 @@ Reducir la validación post-cambio del expediente a una sola instrucción operat
 ## Estado
 
 Abierta.
+## Radar arquitectónico no negociable
+
+HidroFlow no debe evolucionar como una calculadora aislada, sino como un expediente técnico-científico automatizable, portable y defendible.
+
+Toda variable o resultado técnico relevante del expediente deberá poder acompañarse de:
+
+- fórmula matemática utilizada,
+- definición de variables,
+- unidades,
+- valores aplicados,
+- resultado obtenido,
+- fuente computacional,
+- trazabilidad dentro del flujo HidroFlow.
+
+Frente futuro recomendado:
+
+OT-EXP-FORM-001 — Fórmulas matemáticas trazables del expediente hidrológico.
+
+Este frente deberá incorporar explícitamente al expediente las expresiones matemáticas que dan lugar a resultados como CN, S, Ia, Pe, IDF, Tc, Q-Tr, Qp, volumen, ratio de consistencia y Método Racional.

--- a/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
+++ b/00_ADMIN/bitacora/OT-AUTO-005_hf_validar_expediente.md
@@ -1,0 +1,22 @@
+# OT-AUTO-005
+
+## Objetivo
+
+Crear un comando único de validación del expediente hidrológico mínimo.
+
+## Alcance
+
+El comando debe ejecutar:
+
+- HF-TestExpediente MultiTr.
+- HF-TestExpedienteReporte.
+- npm run build.
+- Resumen final PASS/FAIL.
+
+## Resultado esperado
+
+Reducir la validación post-cambio del expediente a una sola instrucción operativa.
+
+## Estado
+
+Abierta.

--- a/07_TOOLBOX/powershell/HF-Tools.ps1
+++ b/07_TOOLBOX/powershell/HF-Tools.ps1
@@ -51,3 +51,8 @@ function HF-TestExpedienteReporte {
     powershell -ExecutionPolicy Bypass `
     -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-TestExpedienteReporte.ps1"
 }
+
+function HF-ValidarExpediente {
+    powershell -ExecutionPolicy Bypass `
+    -File "D:\HidroFlow\07_TOOLBOX\powershell\HF-ValidarExpediente.ps1"
+}

--- a/07_TOOLBOX/powershell/HF-ValidarExpediente.ps1
+++ b/07_TOOLBOX/powershell/HF-ValidarExpediente.ps1
@@ -1,0 +1,72 @@
+param(
+    [string]$Raiz = "D:\HidroFlow",
+    [string]$App = "D:\HidroFlow\01_APP\HIDROFLOW"
+)
+
+$fallos = 0
+
+Write-Host ""
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host "HF-VALIDAR EXPEDIENTE" -ForegroundColor Yellow
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host ""
+
+Write-Host "Paso 1/3 — Validando bateria multi-Tr..." -ForegroundColor Yellow
+
+powershell -ExecutionPolicy Bypass `
+-File "$Raiz\07_TOOLBOX\powershell\HF-TestExpediente.ps1" `
+-Caso "MultiTr"
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "FAIL: HF-TestExpediente MultiTr fallo." -ForegroundColor Red
+    $fallos++
+}
+else {
+    Write-Host "PASS: HF-TestExpediente MultiTr aprobado." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Paso 2/3 — Generando reporte Markdown..." -ForegroundColor Yellow
+
+powershell -ExecutionPolicy Bypass `
+-File "$Raiz\07_TOOLBOX\powershell\HF-TestExpedienteReporte.ps1"
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "FAIL: HF-TestExpedienteReporte fallo." -ForegroundColor Red
+    $fallos++
+}
+else {
+    Write-Host "PASS: Reporte Markdown generado." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "Paso 3/3 — Ejecutando build Vite..." -ForegroundColor Yellow
+
+Push-Location $App
+
+npm run build
+
+$codigoBuild = $LASTEXITCODE
+
+Pop-Location
+
+if ($codigoBuild -ne 0) {
+    Write-Host "FAIL: npm run build fallo." -ForegroundColor Red
+    $fallos++
+}
+else {
+    Write-Host "PASS: npm run build aprobado." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "===================================" -ForegroundColor Cyan
+Write-Host "RESUMEN HF-VALIDAR EXPEDIENTE" -ForegroundColor Yellow
+Write-Host "===================================" -ForegroundColor Cyan
+
+if ($fallos -eq 0) {
+    Write-Host "PASS: Expediente validado integralmente." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host "FAIL: Validacion integral con $fallos fallo(s)." -ForegroundColor Red
+exit 1


### PR DESCRIPTION
## Objetivo

Crear un comando único para validar integralmente el expediente hidrológico mínimo.

## Cambios

- Se agrega `HF-ValidarExpediente.ps1`.
- Se integra `HF-ValidarExpediente` en `HF-Tools.ps1`.
- El comando ejecuta:
  - `HF-TestExpediente MultiTr`.
  - `HF-TestExpedienteReporte`.
  - `npm run build`.
  - Resumen final PASS/FAIL.

## Validación

Resultado ejecutado:

- Batería multi-Tr: PASS.
- Reporte Markdown: PASS.
- Build Vite: PASS.
- Validación integral: PASS.

## Radar arquitectónico registrado

Se deja documentado como no negociable que HidroFlow debe evolucionar como expediente técnico-científico automatizable, autoportable y defendible, incorporando:

- fórmulas matemáticas trazables,
- variables,
- unidades,
- valores aplicados,
- resultados,
- fuente computacional,
- gráficas exportables,
- mapas exportables,
- conectividad hidrológica,
- evidencia visual y espacial.

## Estado

Listo para revisión.