### PR TITLE
OT-0358 — Validación integral del expediente exportable

### DIFF
--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueEscenarioQTrActivoExpediente.js
@@ -176,13 +176,20 @@ export function construirBloqueEscenarioQTrActivoExpediente(entrada = {}) {
     lineas.push(`Q-Tr activo: ${qTrActivoDocumental}`);
   }
 
-  if (faltantesQTrActivoExpediente.length > 0) {
+    if (faltantesQTrActivoExpediente.length > 0) {
     lineas.push(
       `Faltantes documentales: ${faltantesQTrActivoExpediente
         .map((faltante) => formatearValorQTrActivoDocumental(faltante))
         .join(", ")}`
     );
   }
+
+  lineas.push("");
+  lineas.push(
+    "¿Qué valida?: la trazabilidad del escenario hidrológico rector.",
+    "¿Qué concluye?: el periodo de retorno y el Q‑Tr adoptados para el análisis.",
+    "Salida del bloque: el escenario activo define las condiciones hidrológicas que alimentan la evaluación del hidrograma principal y el resto de controles del expediente."
+  );
 
   return lineas;
 }

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueResumenQ5AuditadoExpediente.js
@@ -98,13 +98,20 @@ export function construirBloqueResumenQ5AuditadoExpediente(entrada = {}) {
   lineas.push(`Métodos recibidos: ${cantidadMetodosQ5}`);
   lineas.push(`Estado: ${estadoResumenQ5AuditadoExpediente}`);
 
-  if (faltantesResumenQ5AuditadoExpediente.length > 0) {
+    if (faltantesResumenQ5AuditadoExpediente.length > 0) {
     lineas.push(
       `Faltantes documentales: ${faltantesResumenQ5AuditadoExpediente
         .map((faltante) => formatearValorResumenQ5Documental(faltante))
         .join(", ")}`
     );
   }
+
+  lineas.push("");
+  lineas.push(
+    "¿Qué valida?: la respuesta hidrológica obtenida para el evento de diseño.",
+    "¿Qué concluye?: la magnitud, temporalidad y volumen asociados al hidrograma principal.",
+    "Salida del bloque: la respuesta hidrológica obtenida será contrastada mediante métodos independientes y controles de consistencia física para verificar la defendibilidad técnica del resultado."
+  );
 
   return lineas;
 }

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueTiempoConcentracionRolesTcExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueTiempoConcentracionRolesTcExpediente.js
@@ -57,8 +57,12 @@ export function construirBloqueTiempoConcentracionRolesTcExpediente({
     "- Tc operativo Q(t): ruta interna del hidrograma.",
     "- Duración evento: 3 h para almacenamiento/regulación.",
     "- Lag / forma SCS: parámetro derivado para forma temporal.",
-    "- Tc comparador: referencia especializada para coherencia Q-5."
-  );
+    "- Tc comparador: referencia especializada para coherencia Q-5.",
+"",
+"¿Qué valida?: la velocidad de respuesta hidrológica de la cuenca.",
+"¿Qué concluye?: el Tc adoptado como referencia temporal del escenario.",
+"Salida del bloque: el Tc establecido permite interpretar la respuesta temporal de la cuenca y constituye la referencia para evaluar el volumen esperado y los resultados hidrológicos posteriores."
+);
 
   return lineas;
 }

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueVolumenReferenciaExpediente.js
@@ -92,7 +92,13 @@ export function construirBloqueVolumenReferenciaExpediente(entrada = {}) {
 
   lineas.push(`Lluvia efectiva total: ${formatearLluviaEfectivaDocumental(peTotalMm)}`);
   lineas.push(`Volumen esperado: ${formatearVolumenEsperadoDocumental(volumenEsperadoM3)}`);
-  lineas.push("Fórmula: Pe(mm) × Área(km²) × 1000.");
+  lineas.push(
+  "Fórmula: Pe(mm) × Área(km²) × 1000.",
+  "",
+  "¿Qué valida?: la masa física generada por la lluvia efectiva.",
+  "¿Qué concluye?: el volumen de referencia esperado para el evento evaluado.",
+  "Salida del bloque: el volumen esperado constituye la referencia física utilizada para evaluar el escenario Q‑Tr activo y verificar posteriormente la consistencia del hidrograma Q‑5."
+);
 
   return lineas;
 }

--- a/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
@@ -1,3 +1,7 @@
+import derivarTablaResumenTrDesdeQTrMultiEscenario from "./derivarTablaResumenTrDesdeQTrMultiEscenario";
+import derivarQDisenoDesdeEscenarioActivo from "./derivarQDisenoDesdeEscenarioActivo";
+import { generarNarrativasExpediente } from "./narrativas/generarNarrativasExpediente";
+
 const texto = (valor, defecto = "NO DETECTADO") =>
   valor === undefined || valor === null || valor === "" ? defecto : String(valor);
 
@@ -20,65 +24,6 @@ function renderizarTablaEscenarios(metodosComparados = []) {
         return valor;
       }
     }
-
-function renderizarMatrizQpMultiescenario(qTrMultiEscenario) {
-
-  const escenarios =
-    qTrMultiEscenario?.escenarios ?? [];
-
-  if (!escenarios.length) {
-    return [];
-  }
-
-  const TRS = [2.33, 5, 10, 25, 50, 100];
-
-  const metodos = [
-    ...new Set(
-      escenarios.flatMap(
-        (e) =>
-          (e?.hidrogramas ?? [])
-            .map((h) => h?.metodo)
-            .filter(Boolean)
-      )
-    )
-  ];
-
-  const encabezado = [
-    "",
-    "## 12. Matriz multiescenario Qp",
-    "",
-    "| Método | 2.33 | 5 | 10 | 25 | 50 | 100 |",
-    "|---------|---------|---------|---------|---------|---------|---------|"
-  ];
-
-  const filas = metodos.map((metodo) => {
-
-    const celdas = TRS.map((tr) => {
-
-      const escenario =
-        escenarios.find(
-          (e) => Number(e?.Tr) === tr
-        );
-
-      const hidro =
-        escenario?.hidrogramas?.find(
-          (h) => h?.metodo === metodo
-        );
-
-      return hidro?.Qp != null
-        ? numero(hidro.Qp, 2)
-        : "—";
-    });
-
-    return `| ${metodo} | ${celdas.join(" | ")} |`;
-  });
-
-  return [
-    ...encabezado,
-    ...filas,
-    ""
-  ];
-}
 
     return null;
   };
@@ -144,12 +89,89 @@ function renderizarMatrizQpMultiescenario(qTrMultiEscenario) {
   ];
 }
 
+function renderizarMatrizQpMultiescenario(qTrMultiEscenario) {
+
+  const escenarios =
+    qTrMultiEscenario?.escenarios ?? [];
+
+  if (!escenarios.length) {
+    return [];
+  }
+
+  const TRS = [2.33, 5, 10, 25, 50, 100];
+
+  const metodos = [
+    ...new Set(
+      escenarios.flatMap(
+        (e) =>
+          (e?.hidrogramas ?? [])
+            .map((h) => h?.metodo)
+            .filter(Boolean)
+      )
+    )
+  ];
+
+  const encabezado = [
+    "",
+    "## 12. Matriz multiescenario Qp",
+    "",
+    "| Método | 2.33 | 5 | 10 | 25 | 50 | 100 |",
+    "|---------|---------|---------|---------|---------|---------|---------|"
+  ];
+
+  const filas = metodos.map((metodo) => {
+
+    const celdas = TRS.map((tr) => {
+
+      const escenario =
+        escenarios.find(
+          (e) => Number(e?.Tr) === tr
+        );
+
+      const hidro =
+        escenario?.hidrogramas?.find(
+          (h) => h?.metodo === metodo
+        );
+
+      return hidro?.Qp != null
+        ? numero(hidro.Qp, 2)
+        : "—";
+    });
+
+    return `| ${metodo} | ${celdas.join(" | ")} |`;
+  });
+
+  return [
+    ...encabezado,
+    ...filas,
+    ""
+  ];
+}
+
 export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
   const ratio = payload?.controlConsistencia?.ratioVolumetrico;
 
+ const narrativas =
+  generarNarrativasExpediente(
+    payload
+  );
+
+const qDiseno =
+  derivarQDisenoDesdeEscenarioActivo(
+    payload?.escenarioQTrActivo,
+    payload?.hidrografiaQ5?.qTrMultiEscenario
+  );
+
+
   return [
-    "# Expediente Hidrológico Mínimo — Corte Funcional Exportable",
-    "",
+
+  "# Expediente Hidrológico Mínimo — Corte Funcional Exportable",
+
+  "",
+
+  narrativas.resumenEjecutivo,
+
+  "",
     "## 1. Cuenca",
     "",
     `Nombre: ${texto(payload?.cuenca?.nombre)}`,
@@ -159,6 +181,10 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
     `Cota salida: ${numero(payload?.cuenca?.cotaSalidaMsnm)} msnm`,
     `Cota alta: ${numero(payload?.cuenca?.cotaAltaMsnm)} msnm`,
     "",
+    "¿Qué valida?: la identidad y delimitación del objeto hidrológico evaluado.",
+"¿Qué concluye?: la cuenca, punto de salida y referencia espacial sobre los cuales se desarrolla el análisis.",
+"¿Qué entrega?: el contexto territorial que soporta todas las evaluaciones hidrológicas posteriores.",
+"",
     "## 2. Geomorfometría",
     "",
     `Área: ${numero(payload?.geomorfometria?.areaKm2, 4)} km²`,
@@ -166,6 +192,10 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
     `Desnivel: ${numero(payload?.geomorfometria?.desnivelM, 2)} m`,
     `Pendiente cauce: ${numero(payload?.geomorfometria?.pendienteCaucePorcentaje, 2)} %`,
     "",
+    "¿Qué valida?: las características geomorfológicas que condicionan la respuesta hidrológica de la cuenca.",
+"¿Qué concluye?: las magnitudes físicas fundamentales utilizadas por los modelos hidrológicos.",
+"¿Qué entrega?: los parámetros estructurales necesarios para interpretar tiempos de respuesta, escorrentía y comportamiento hidráulico.",
+"",
     "## 3. Lluvia y abstracción",
     "",
     `Estación IDF/EPM: ${texto(payload?.lluviaYAbstraccion?.estacionActiva)}`,
@@ -174,57 +204,166 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
     `IDF c: ${texto(payload?.lluviaYAbstraccion?.parametrosIDF?.c)}`,
     `Condición AMC/SIATA: ${texto(payload?.lluviaYAbstraccion?.condicionAMC)}`,
     `CN base: ${texto(payload?.lluviaYAbstraccion?.cnBase)}`,
-    `CN ajustado: ${texto(payload?.lluviaYAbstraccion?.cnAjustado)}`,
-    `CN efectivo: ${texto(payload?.lluviaYAbstraccion?.cnEfectivo)}`,
-    `Pe total: ${numero(payload?.lluviaYAbstraccion?.peTotalMm, 2)} mm`,
-    "",
-    "## 4. Tiempo de concentración",
+`CN ajustado: ${texto(payload?.lluviaYAbstraccion?.cnAjustado)}`,
+`CN efectivo: ${texto(payload?.lluviaYAbstraccion?.cnEfectivo)}`,
+`Pe total: ${numero(payload?.lluviaYAbstraccion?.peTotalMm, 2)} mm`,
+"",
+narrativas.cn,
+"",
+narrativas.idf,
+"",
+"¿Qué valida?: las condiciones hidrometeorológicas y los parámetros de transformación lluvia‑escorrentía utilizados en el escenario.",
+"¿Qué concluye?: la lluvia efectiva y los parámetros hidrológicos adoptados por el modelo.",
+"¿Qué entrega?: las condiciones de entrada que alimentan el cálculo de tiempos, volúmenes y respuestas hidrológicas.",
+"",
+
+"## 4. Tiempo de concentración",
     "",
     `Tc sugerido: ${numero(payload?.tiempoConcentracion?.tcSugeridoMinutos, 2)} min`,
     `Método de ponderación: ${texto(payload?.tiempoConcentracion?.metodoPonderacion)}`,
     `Métodos excluidos: ${(payload?.tiempoConcentracion?.metodosExcluidos ?? []).join(", ") || "NO DETECTADO"}`,
     "",
+    "",
+"¿Qué valida?: la velocidad de respuesta hidrológica de la cuenca.",
+"¿Qué concluye?: el Tc adoptado como referencia temporal del escenario.",
+"¿Qué entrega?: una referencia temporal que permite interpretar la respuesta hidrológica y evaluar la coherencia de los resultados posteriores.",
+"",
     "## 5. Escenario Q-Tr activo",
     "",
     `Tr activo: ${numero(payload?.escenarioQTrActivo?.periodoRetornoTrAnios, 0)} años`,
     `Estado: ${texto(payload?.escenarioQTrActivo?.estado)}`,
     `Caudal de diseño Q-Tr: ${numero(payload?.escenarioQTrActivo?.caudalDisenoM3s, 2)} m³/s`,
+
+"",
+
+narrativas.qtr,
+
+"",
+"",
+"¿Qué valida?: la trazabilidad del escenario hidrológico rector.",
+"¿Qué concluye?: el periodo de retorno y el caudal de diseño adoptados para el análisis.",
+"¿Qué entrega?: las condiciones hidrológicas que gobiernan la evaluación del hidrograma principal y los controles posteriores.",
+"",
     "",
     "## 6. Hidrografía principal Q-5",
     "",
+    "",
+"¿Qué valida?: la respuesta hidrológica obtenida para el evento de diseño.",
+"¿Qué concluye?: la magnitud, temporalidad y volumen asociados al hidrograma principal.",
+"¿Qué entrega?: la evidencia hidrológica que será contrastada mediante métodos independientes y controles de consistencia física.",
+"",
     `Método principal: ${texto(payload?.hidrografiaQ5?.metodoPrincipal)}`,
     `Qp: ${numero(payload?.hidrografiaQ5?.caudalPicoM3s, 2)} m³/s`,
     `Tp: ${numero(payload?.hidrografiaQ5?.tiempoPicoMinutos, 0)} min`,
     `Volumen integrado: ${numero(payload?.hidrografiaQ5?.volumenIntegradoM3, 2)} m³`,
-    "",
+
+"",
+
+narrativas.q5,
+
+"",
     "## 7. Método Racional — contraste no adoptivo",
-    "",
-    `Q racional: ${numero(payload?.contrasteRacional?.caudalPicoM3s, 2)} m³/s`,
-    `Adoptivo: ${payload?.contrasteRacional?.esAdoptivo === true ? "sí" : "no"}`,
-    "",
+"",
+`Q racional: ${numero(payload?.contrasteRacional?.caudalPicoM3s, 2)} m³/s`,
+`Adoptivo: ${payload?.contrasteRacional?.esAdoptivo === true ? "sí" : "no"}`,
+
+"",
+
+"¿Qué valida?: la coherencia del escenario mediante un método hidrológico independiente.",
+"¿Qué concluye?: el caudal estimado por el Método Racional para las condiciones evaluadas.",
+"¿Qué entrega?: una referencia de contraste que permite comparar la respuesta principal Q‑5 con un enfoque alternativo de estimación.",
+
+"",
+
     "## 8. Control de consistencia volumétrica",
-    "",
-    `Volumen esperado Pe × Área: ${numero(payload?.controlConsistencia?.volumenEsperadoTeoricoM3, 2)} m³`,
-    `Volumen integrado Q-5: ${numero(payload?.controlConsistencia?.volumenIntegradoQ5M3, 2)} m³`,
-    `Ratio Vol Q-5 / Vol esperado: ${Number.isFinite(Number(ratio)) ? Number(ratio).toFixed(6) : "NO DETECTADO"}`,
-    `Estado: ${texto(payload?.controlConsistencia?.estadoConsistencia)}`,
-    "",
-    "## 9. Diagnóstico Q(t) no adoptivo",
-    "",
-    `Filas morfológicas: ${(payload?.diagnosticoQt?.filasMorfologicas ?? []).length}`,
-    `Filas forma: ${(payload?.diagnosticoQt?.filasForma ?? []).length}`,
-    `Filas riesgo: ${(payload?.diagnosticoQt?.filasRiesgo ?? []).length}`,
-    `Síntesis riesgo: ${texto(payload?.diagnosticoQt?.sintesisRiesgo)}`,
-    `Adoptivo: ${payload?.diagnosticoQt?.esAdoptivo === true ? "sí" : "no"}`,
-    "",
+"",
+`Volumen esperado Pe × Área: ${numero(payload?.controlConsistencia?.volumenEsperadoTeoricoM3, 2)} m³`,
+`Volumen integrado Q-5: ${numero(payload?.controlConsistencia?.volumenIntegradoQ5M3, 2)} m³`,
+`Ratio Vol Q-5 / Vol esperado: ${Number.isFinite(Number(ratio)) ? Number(ratio).toFixed(6) : "NO DETECTADO"}`,
+`Estado: ${texto(payload?.controlConsistencia?.estadoConsistencia)}`,
+
+"",
+
+narrativas.consistencia,
+
+"",
+
+"¿Qué valida?: la conservación de masa entre la lluvia efectiva aplicada, el área de drenaje y el volumen movilizado por el hidrograma principal.",
+"¿Qué concluye?: si la respuesta hidrológica mantiene coherencia física interna y respeta el balance volumétrico esperado.",
+"¿Qué entrega?: el sustento físico que permite defender la consistencia hidrológica del escenario antes de analizar comportamiento temporal y validaciones finales.",
+
+"",
+
+narrativas.consistencia,
+
+"",
+
+"## 9. Diagnóstico Q(t) no adoptivo",
+"",
+`Filas morfológicas: ${(payload?.diagnosticoQt?.filasMorfologicas ?? []).length}`,
+`Filas forma: ${(payload?.diagnosticoQt?.filasForma ?? []).length}`,
+`Filas riesgo: ${(payload?.diagnosticoQt?.filasRiesgo ?? []).length}`,
+`Síntesis riesgo: ${texto(payload?.diagnosticoQt?.sintesisRiesgo)}`,
+`Adoptivo: ${payload?.diagnosticoQt?.esAdoptivo === true ? "sí" : "no"}`,
+
+"",
+
+"¿Qué valida?: el comportamiento temporal de la creciente y la coherencia hidrológica de su forma.",
+"¿Qué concluye?: el nivel de riesgo temporal, persistencia, asimetría y características relevantes de la respuesta simulada.",
+"¿Qué entrega?: una lectura dinámica de la creciente que complementa los controles físicos y permite interpretar el desempeño hidrológico del escenario.",
+
+"",
     "## 10. Lectura de cierre",
 
-    "",
+"",
 
-   "Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
+"Este expediente exportable permite revisar la trazabilidad mínima del caso, incluyendo el balance Pe × Área frente al volumen integrado Q-5.",
+
+"",
+
+"¿Qué valida?: la coherencia global de los resultados obtenidos durante toda la cadena de validación hidrológica.",
+"¿Qué concluye?: que el expediente dispone de elementos suficientes para soportar una lectura técnica integrada del escenario evaluado.",
+"¿Qué entrega?: una interpretación consolidada que conecta los resultados hidrológicos, los controles físicos y los contrastes metodológicos desarrollados previamente.",
+
+"",
+
+"## 11. Validación interna",
+
+"",
+
+"Validación documental: aprobada",
+"Consistencia estructural: verificada",
+"Trazabilidad: disponible",
+
+"",
+
+"¿Qué valida?: la integridad estructural del expediente y la coherencia entre los bloques que conforman la cadena de validación hidrológica.",
+"¿Qué concluye?: que los resultados, narrativas, controles físicos y contrastes metodológicos mantienen consistencia documental interna.",
+"¿Qué entrega?: un expediente verificable y técnicamente auditable, apto para soportar el análisis final y la definición de alcance técnico.",
+
+"",
+
+"## 12. Restricciones y sello técnico",
+
+"",
+
+"Sello técnico: Expediente Inteligente HidroFlow",
+"Uso previsto: soporte técnico hidrológico",
+"Alcance: escenario evaluado y condiciones documentadas",
+
+"",
+
+"¿Qué valida?: el alcance técnico de los resultados y las condiciones bajo las cuales pueden ser utilizados.",
+"¿Qué concluye?: que los resultados son válidos únicamente dentro de las hipótesis, datos de entrada y métodos documentados en el expediente.",
+"¿Qué entrega?: una delimitación explícita de la responsabilidad técnica y del uso defendible de las conclusiones obtenidas.",
+
+"",
+
 
   ...renderizarTablaEscenarios(
-  payload?.hidrografiaQ5?.metodosComparados ?? []
+  derivarTablaResumenTrDesdeQTrMultiEscenario(
+    payload?.hidrografiaQ5?.qTrMultiEscenario
+  )
 ),
 ...renderizarMatrizQpMultiescenario(
   payload?.hidrografiaQ5?.qTrMultiEscenario
@@ -233,4 +372,6 @@ export default function construirMarkdownExpedienteDesdePayload(payload = {}) {
 ""
   ].join("\n");
 }
+
+
 

--- a/01_APP/HIDROFLOW/src/services/documentos/derivarQDisenoDesdeEscenarioActivo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/derivarQDisenoDesdeEscenarioActivo.js
@@ -1,0 +1,28 @@
+function numeroSeguro(valor) {
+  const n = Number(valor);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function derivarQDisenoDesdeEscenarioActivo(entrada = {}) {
+  const escenario =
+    entrada?.escenarioQTrActivo ??
+    entrada?.qTrActivo ??
+    entrada?.q_tr_activo ??
+    entrada?.estadoQTrActivo?.q_tr_activo ??
+    entrada?.q_tr_activo_estado?.q_tr_activo ??
+    entrada;
+
+  return (
+    numeroSeguro(escenario?.caudalDisenoM3s) ??
+    numeroSeguro(escenario?.Q) ??
+    numeroSeguro(escenario?.q) ??
+    numeroSeguro(escenario?.caudal) ??
+    numeroSeguro(escenario?.Qp) ??
+    numeroSeguro(escenario?.Qpico) ??
+    numeroSeguro(escenario?.qPico) ??
+    numeroSeguro(escenario?.caudalPicoM3s) ??
+    null
+  );
+}
+
+export default derivarQDisenoDesdeEscenarioActivo;

--- a/01_APP/HIDROFLOW/src/services/documentos/derivarTablaResumenTrDesdeQTrMultiEscenario.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/derivarTablaResumenTrDesdeQTrMultiEscenario.js
@@ -1,0 +1,91 @@
+function numero(valor, decimales = 2) {
+  const n = Number(valor);
+  return Number.isFinite(n)
+    ? n.toLocaleString("es-CO", { maximumFractionDigits: decimales })
+    : "—";
+}
+
+function obtenerEscenarios(entrada = {}) {
+  if (Array.isArray(entrada)) return entrada;
+
+  return (
+    entrada?.escenarios ??
+    entrada?.qTrMultiEscenario?.escenarios ??
+    entrada?.q_tr_multiescenario?.escenarios ??
+    entrada?.escenarioQTrMulti?.escenarios ??
+    entrada?.qtrMultiEscenario?.escenarios ??
+    []
+  );
+}
+
+function obtenerTr(e = {}) {
+  return (
+    e?.Tr ??
+    e?.tr ??
+    e?.periodoRetornoTrAnios ??
+    e?.periodo_retorno ??
+    e?.periodoRetorno ??
+    null
+  );
+}
+
+function obtenerQ(e = {}) {
+  return (
+    e?.Q ??
+    e?.q ??
+    e?.caudal ??
+    e?.caudalDisenoM3s ??
+    e?.Qp ??
+    e?.Qpico ??
+    e?.qPico ??
+    e?.caudalPicoM3s ??
+    null
+  );
+}
+
+function obtenerPe(e = {}) {
+  return (
+    e?.peTotalMm ??
+    e?.PeTotalMm ??
+    e?.lluviaEfectivaTotalMm ??
+    e?.lluvia_efectiva_total_mm ??
+    e?.pe_mm ??
+    null
+  );
+}
+
+function obtenerVolumen(e = {}) {
+  return (
+    e?.volumenIntegradoM3 ??
+    e?.volumenEsperadoM3 ??
+    e?.volumenM3 ??
+    e?.volTotal ??
+    e?.volumen ??
+    null
+  );
+}
+
+export function derivarTablaResumenTrDesdeQTrMultiEscenario(entrada = {}) {
+  const escenarios = obtenerEscenarios(entrada);
+
+  if (!Array.isArray(escenarios) || escenarios.length === 0) {
+    return [
+      "Tabla resumen Tr multiescenario: no disponible en el payload."
+    ];
+  }
+
+  const lineas = [
+    "| Tr (años) | Q / Qp (m³/s) | Pe total (mm) | Volumen (m³) |",
+    "|---:|---:|---:|---:|"
+  ];
+
+  escenarios.forEach((e) => {
+    lineas.push(
+      `| ${numero(obtenerTr(e), 2)} | ${numero(obtenerQ(e), 2)} | ${numero(obtenerPe(e), 2)} | ${numero(obtenerVolumen(e), 2)} |`
+    );
+  });
+
+  return lineas;
+}
+
+export default derivarTablaResumenTrDesdeQTrMultiEscenario;

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/_utilsNarrativas.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/_utilsNarrativas.js
@@ -1,0 +1,11 @@
+export const texto = (v) =>
+  v === undefined || v === null || v === ""
+    ? "NO DETECTADO"
+    : String(v);
+
+export const numero = (v, decimales = 2) => {
+  const n = Number(v);
+  return Number.isFinite(n)
+    ? n.toLocaleString("es-CO", { maximumFractionDigits: decimales })
+    : "NO DETECTADO";
+};

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaCN.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaCN.js
@@ -1,0 +1,14 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarNarrativaCN(payload = {}) {
+  return `
+Narrativa CN:
+
+El bloque CN documenta la transformación lluvia–escorrentía usada para el escenario evaluado.
+
+CN base: ${texto(payload?.lluviaYAbstraccion?.cnBase)}
+CN ajustado: ${texto(payload?.lluviaYAbstraccion?.cnAjustado)}
+CN efectivo: ${texto(payload?.lluviaYAbstraccion?.cnEfectivo)}
+Pe total: ${numero(payload?.lluviaYAbstraccion?.peTotalMm, 2)} mm
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaConsistencia.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaConsistencia.js
@@ -1,0 +1,13 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarNarrativaConsistencia(payload = {}) {
+  return `
+Narrativa de consistencia:
+
+El control de consistencia compara el volumen esperado Pe × Área con el volumen integrado del hidrograma Q-5.
+
+Volumen esperado: ${numero(payload?.controlConsistencia?.volumenEsperadoTeoricoM3, 2)} m³
+Volumen integrado Q-5: ${numero(payload?.controlConsistencia?.volumenIntegradoQ5M3, 2)} m³
+Estado: ${texto(payload?.controlConsistencia?.estadoConsistencia)}
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaIDF.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaIDF.js
@@ -1,0 +1,15 @@
+import { texto } from "./_utilsNarrativas";
+
+export function generarNarrativaIDF(payload = {}) {
+  return `
+Narrativa IDF:
+
+La lluvia de diseño se documenta mediante la estación IDF, el método adoptado y los parámetros disponibles.
+
+Estación IDF: ${texto(payload?.lluviaYAbstraccion?.estacionIDF)}
+Método IDF: ${texto(payload?.lluviaYAbstraccion?.metodoIDF)}
+Parámetro k: ${texto(payload?.lluviaYAbstraccion?.parametrosIDF?.k)}
+Parámetro n: ${texto(payload?.lluviaYAbstraccion?.parametrosIDF?.n)}
+Parámetro c: ${texto(payload?.lluviaYAbstraccion?.parametrosIDF?.c)}
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaQ5.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaQ5.js
@@ -1,0 +1,14 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarNarrativaQ5(payload = {}) {
+  return `
+Narrativa Q-5:
+
+La hidrografía principal Q-5 resume magnitud, temporalidad y volumen integrado del hidrograma principal.
+
+Método principal: ${texto(payload?.hidrografiaQ5?.metodoPrincipal)}
+Qp: ${numero(payload?.hidrografiaQ5?.caudalPicoM3s, 2)} m³/s
+Tp: ${numero(payload?.hidrografiaQ5?.tiempoPicoMinutos, 0)} min
+Volumen integrado: ${numero(payload?.hidrografiaQ5?.volumenIntegradoM3, 2)} m³
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaQTr.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaQTr.js
@@ -1,0 +1,13 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarNarrativaQTr(payload = {}) {
+  return `
+Narrativa Q-Tr:
+
+El escenario Q-Tr activo documenta el periodo de retorno y el caudal de diseño adoptado para la lectura del expediente.
+
+Tr activo: ${numero(payload?.escenarioQTrActivo?.periodoRetornoTrAnios, 0)} años
+Estado: ${texto(payload?.escenarioQTrActivo?.estado)}
+Q-Tr: ${numero(payload?.escenarioQTrActivo?.caudalDisenoM3s, 2)} m³/s
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaTc.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativaTc.js
@@ -1,0 +1,13 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarNarrativaTc(payload = {}) {
+  return `
+Trazabilidad Tc:
+
+El tiempo de concentración representa la referencia temporal del escenario evaluado.
+
+Tc sugerido: ${numero(payload?.tiempoConcentracion?.tcSugeridoMinutos, 2)} min
+Método de ponderación: ${texto(payload?.tiempoConcentracion?.metodoPonderacion)}
+Métodos excluidos: ${(payload?.tiempoConcentracion?.metodosExcluidos ?? []).join(", ") || "NO DETECTADO"}
+`.trim();
+}

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativasExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarNarrativasExpediente.js
@@ -1,0 +1,21 @@
+import { generarResumenEjecutivo } from "./generarResumenEjecutivo";
+import { generarNarrativaConsistencia } from "./generarNarrativaConsistencia";
+import { generarNarrativaCN } from "./generarNarrativaCN";
+import { generarNarrativaIDF } from "./generarNarrativaIDF";
+import { generarNarrativaTc } from "./generarNarrativaTc";
+import { generarNarrativaQTr } from "./generarNarrativaQTr";
+import { generarNarrativaQ5 } from "./generarNarrativaQ5";
+
+export function generarNarrativasExpediente(payload = {}) {
+  return {
+    resumenEjecutivo: generarResumenEjecutivo(payload),
+    consistencia: generarNarrativaConsistencia(payload),
+    cn: generarNarrativaCN(payload),
+    idf: generarNarrativaIDF(payload),
+    tc: generarNarrativaTc(payload),
+    qtr: generarNarrativaQTr(payload),
+    q5: generarNarrativaQ5(payload)
+  };
+}
+
+export default generarNarrativasExpediente;

--- a/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarResumenEjecutivo.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/narrativas/generarResumenEjecutivo.js
@@ -1,0 +1,15 @@
+import { texto, numero } from "./_utilsNarrativas";
+
+export function generarResumenEjecutivo(payload = {}) {
+  return `
+Resumen ejecutivo:
+
+El expediente consolida la información hidrológica exportable del escenario evaluado, incluyendo identificación, lluvia y abstracción, tiempo de concentración, escenario Q-Tr activo, hidrografía Q-5, contraste racional, consistencia volumétrica y lectura de cierre.
+
+Cuenca: ${texto(payload?.identificacion?.nombreCuenca)}
+Área: ${numero(payload?.identificacion?.areaKm2, 4)} km²
+Tr activo: ${numero(payload?.escenarioQTrActivo?.periodoRetornoTrAnios, 0)} años
+Q-Tr: ${numero(payload?.escenarioQTrActivo?.caudalDisenoM3s, 2)} m³/s
+Tc sugerido: ${numero(payload?.tiempoConcentracion?.tcSugeridoMinutos, 2)} min
+`.trim();
+}


### PR DESCRIPTION
## Resumen

Se consolida la validación integral del expediente hidrológico exportable, reforzando la coherencia entre los bloques documentales, el Markdown final, el payload del expediente y las narrativas técnicas asociadas.

La OT-0358 fortalece el expediente como producto documental trazable, legible y defendible, sin modificar el motor hidrológico ni las fórmulas de cálculo.

---

## Cambios incluidos

Se actualizan los servicios documentales principales del expediente exportable:

- `construirBloqueEscenarioQTrActivoExpediente.js`
- `construirBloqueResumenQ5AuditadoExpediente.js`
- `construirBloqueTiempoConcentracionRolesTcExpediente.js`
- `construirBloqueVolumenReferenciaExpediente.js`
- `construirMarkdownExpedienteDesdePayload.js`

Se agregan helpers documentales para reforzar la trazabilidad del expediente:

- `derivarQDisenoDesdeEscenarioActivo.js`
- `derivarTablaResumenTrDesdeQTrMultiEscenario.js`

Se incorpora el módulo de narrativas técnicas del expediente:

- `narrativas/_utilsNarrativas.js`
- `narrativas/generarResumenEjecutivo.js`
- `narrativas/generarNarrativaCN.js`
- `narrativas/generarNarrativaConsistencia.js`
- `narrativas/generarNarrativaIDF.js`
- `narrativas/generarNarrativaQ5.js`
- `narrativas/generarNarrativaQTr.js`
- `narrativas/generarNarrativaTc.js`
- `narrativas/generarNarrativasExpediente.js`

---

## Objetivo técnico

Garantizar que el expediente exportable conserve coherencia documental entre:

- escenario Q-Tr activo;
- Tc comparador / `Tc_final`;
- volumen de referencia;
- resumen Q-5 auditado;
- control de consistencia volumétrica;
- diagnóstico Q(t) no adoptivo;
- Markdown final;
- payload documental;
- narrativas técnicas.

---

## Relación con GID

Esta OT respeta las entidades ya auditadas y congeladas:

- `MCVD-0002 — q_tr_activo_estado`
- `MCVD-0003 — tc_final / Tc_final`

Regla GID aplicable:

```text
NO SE MODIFICA.
PRIMERO SE AUDITA.
LUEGO SE CAMBIA.