### PR TITLE
OT-0359 — Apertura operativa desde main estabilizado

### DIFF
--- a/00_ADMIN/bitacora/OT-0359/OT-0359A_apertura_nueva-ot-desde-main-limpio.md
+++ b/00_ADMIN/bitacora/OT-0359/OT-0359A_apertura_nueva-ot-desde-main-limpio.md
@@ -1,0 +1,63 @@
+# OT-0359 — Nueva OT desde main limpio
+
+## Estado
+
+EN APERTURA
+
+## Fecha
+
+2026-06-29 12:26:42
+
+## Contexto base
+
+La nueva OT se abre desde main limpio, después del cierre e integración de:
+
+- PR #387 — GID / MCVD-0002 y MCVD-0003
+- PR #388 — OT-0358 / Validación integral del expediente exportable
+
+## Estado de partida
+
+- main local/remoto estabilizado.
+- Build post-merge aprobado.
+- Working tree limpio.
+- GID operativo con MCVD-0002 y MCVD-0003 auditadas y congeladas.
+
+## Objetivo
+
+POR DEFINIR.
+
+## Alcance inicial
+
+POR DEFINIR.
+
+## Fuera de alcance
+
+- No modificar motor hidrológico sin auditoría previa.
+- No modificar entidades críticas sin revisar MCVD.
+- No tocar entidades GID congeladas sin auditoría de impacto.
+
+## Relación GID
+
+Entidades ya congeladas:
+
+- MCVD-0002 — q_tr_activo_estado
+- MCVD-0003 — tc_final / Tc_final
+
+Regla vigente:
+
+NO SE MODIFICA.
+PRIMERO SE AUDITA.
+LUEGO SE CAMBIA.
+
+## Criterio de cierre
+
+POR DEFINIR.
+
+## Validación mínima esperada
+
+- 
+pm run build aprobado.
+- git status --short limpio.
+- PR fusionado a main.
+- Sincronizar-MainPostMerge ejecutado después del merge.
+


### PR DESCRIPTION
## Resumen

Se abre formalmente la OT-0359 desde un estado estabilizado de `main`, posterior al cierre e integración de:

- PR #387 — GID / MCVD-0002 y MCVD-0003
- PR #388 — Validación integral del expediente exportable

Esta OT establece la base documental y operativa para iniciar una nueva línea de trabajo sobre una rama limpia y sincronizada.

---

## Cambios incluidos

Se crea la bitácora inicial:

- `00_ADMIN/bitacora/OT-0359/OT-0359A_apertura_nueva-ot-desde-main-limpio.md`

---

## Estado de partida

Verificado al momento de apertura:

- `main` local y remoto sincronizados.
- Build aprobado mediante `npm run build`.
- Working tree limpio.
- GID operativo.
- MCVD-0002 auditada y congelada.
- MCVD-0003 auditada y congelada.

---

## Relación con GID

Entidades actualmente congeladas:

- MCVD-0002 — `q_tr_activo_estado`
- MCVD-0003 — `tc_final / Tc_final`

Regla vigente:

```text
NO SE MODIFICA.
PRIMERO SE AUDITA.
LUEGO SE CAMBIA.