### PR TITLE
HF-PROD-003B — Constructor mínimo de expediente (caso y cuenca)

### DIFF
--- a/01_APP/HIDROFLOW/scripts/build-expediente.js
+++ b/01_APP/HIDROFLOW/scripts/build-expediente.js
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+
+const otId = process.argv[2];
+if (!otId) process.exit(1);
+
+const ruta = path.join(
+  "D:",
+  "HidroFlow",
+  "02_PROYECTOS",
+  otId,
+  `${otId}.hfproj`
+);
+
+const proyecto = JSON.parse(
+  fs.readFileSync(ruta, "utf8")
+);
+
+const params =
+  proyecto.estado_operativo?.params || {};
+
+proyecto.expediente.caso = {
+  id_proyecto: otId
+};
+
+proyecto.expediente.cuenca = {
+  nombre:
+    params.nombre_cuenca ??
+    "No definido"
+};
+
+fs.writeFileSync(
+  ruta,
+  JSON.stringify(proyecto, null, 2),
+  "utf8"
+);
+
+console.log(
+  `✅ Expediente reconstruido para ${otId}`
+);


### PR DESCRIPTION
## Objetivo

Implementar la primera versión operativa del Constructor de Expediente.

Este cambio permite reconstruir automáticamente las secciones iniciales del expediente (`caso` y `cuenca`) a partir de la memoria persistente del proyecto (`estado_operativo.params`).

---

## Alcance

Se agrega:

- `scripts/build-expediente.js`

Capacidad incorporada:

```text
estado_operativo.params
          ↓
expediente.caso

estado_operativo.params
          ↓
expediente.cuenca