### PR TITLE
HF-PROD-004F — Centralización MCVD de formatos en UI y documentos

### DIFF
--- a/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
+++ b/01_APP/HIDROFLOW/src/components/ComparadorMultiMetodo.jsx
@@ -46,6 +46,15 @@ import {
   obtenerCriterioPendientesAuditoria,
 } from "../data/auditoriaPendientesTc";
 
+import {
+  formatTc,
+  formatQ,
+  formatArea,
+  formatVolumen,
+  formatPendiente,
+  formatCN
+} from "../utils/formatters";
+
 export default function ComparadorMultiMetodo({ contexto = null }) {
   let bloqueoAdopcion = false;
   // ✅ OT-0067E — utilidades de bloqueo (GLOBAL COMPONENTE)
@@ -1159,7 +1168,7 @@ const handleClickSeguro = (accion) => () => {
 
                       return (
                         <span style={estilos.chip}>
-                          {tcValor.toFixed(2)} min
+                          {formatTc(tcValor)} min
                         </span>
                       );
                     })()}
@@ -1208,7 +1217,7 @@ const handleClickSeguro = (accion) => () => {
 
     return (
       <span style={estilos.chip}>
-        {resultadoQ.Qp.toFixed(2)} m³/s
+        {formatQ(resultadoQ.Qp)} m³/s
       </span>
     );
   })()}
@@ -1247,10 +1256,10 @@ const handleClickSeguro = (accion) => () => {
     return (
       <div>
         <span style={estilos.chip}>
-          {resultadoQ.Tp.toFixed(2)} min
+          {formatTc(resultadoQ.Tp)} min
         </span>
         <div style={{ ...estilos.muted, marginTop: "4px" }}>
-          Tp/Tc: {tpRel !== null ? tpRel.toFixed(2) + "x" : "—"} · Dur. eq.: {Number.isFinite(resultadoQ.volumen) && Number.isFinite(resultadoQ.Qp) && resultadoQ.Qp > 0 ? (resultadoQ.volumen / resultadoQ.Qp / 60).toFixed(0) + " min" : "—"}
+          Tp/Tc: {tpRel !== null ? formatTc(tpRel) + "x" : "—"} · Dur. eq.: {Number.isFinite(resultadoQ.volumen) && Number.isFinite(resultadoQ.Qp) && resultadoQ.Qp > 0 ? formatTc(resultadoQ.volumen / resultadoQ.Qp / 60) + " min" : "—"}
         </div>
         <div style={{ ...estilos.muted, marginTop: "4px" }}>
           Estado temporal: {estadoTemporal}
@@ -1317,11 +1326,11 @@ const handleClickSeguro = (accion) => () => {
     return (
       <div>
         <span style={estilos.chip}>
-          {resultadoQ.volumen.toFixed(2)}
+          {formatVolumen(resultadoQ.volumen)}
         </span>
         {estadoEscalaVolumen ? (
           <div style={{ ...estilos.muted, marginTop: "4px" }}>
-            {estadoEscalaVolumen} · {relacionVolumen.toFixed(1)}x
+            {estadoEscalaVolumen} · {formatTc(relacionVolumen)}x
           </div>
         ) : null}
       </div>
@@ -1430,14 +1439,14 @@ const handleClickSeguro = (accion) => () => {
     <div>
       <strong>Área:</strong>{" "}
       {Number.isFinite(contextoBase?.area_km2)
-        ? `${cuencaActiva.area_km2.toFixed(4)} km²`
+        ? `${formatArea(cuencaActiva.area_km2)} km²`
         : "—"}
     </div>
 
     <div>
       <strong>Scp cauce principal:</strong>{" "}
       {Number.isFinite(contextoBase?.pendiente_media_pct)
-        ? `${cuencaActiva.pendiente_media_pct} %`
+        ? `${formatPendiente(cuencaActiva.pendiente_media_pct)} %`
         : "—"}
     </div>
 
@@ -1454,21 +1463,21 @@ const handleClickSeguro = (accion) => () => {
     <div>
       <strong>CN:</strong>{" "}
       {Number.isFinite(hidrologiaActiva.CN)
-        ? hidrologiaActiva.CN
+        ? formatCN(hidrologiaActiva.CN)
         : "—"}
     </div>
 
     <div>
       <strong>CN base:</strong>{" "}
       {Number.isFinite(hidrologiaActiva.CN_base)
-        ? hidrologiaActiva.CN_base
+        ? formatCN(hidrologiaActiva.CN_base)
         : "—"}
     </div>
 
     <div>
       <strong>CN efectivo:</strong>{" "}
       {Number.isFinite(hidrologiaActiva.CN_efectivo)
-        ? hidrologiaActiva.CN_efectivo
+        ? formatCN(hidrologiaActiva.CN_efectivo)
         : "—"}
     </div>
 
@@ -1852,7 +1861,7 @@ const handleClickSeguro = (accion) => () => {
       </button>
       <button
         type="button"
-        onClick={() => {
+        onClick={async () => {
           const areaKm2 = Number(
   contextoBase?.casoActivo?.cuenca?.area_km2 ??
   contextoBase?.area_km2
@@ -2228,7 +2237,7 @@ if (!tieneRacionalPublicado) {
               ? [
                   `Tc racional exportado: ${
                     Number.isFinite(Number(contextoBase?.metodo_racional?.tc_min))
-                      ? Number(contextoBase.metodo_racional.tc_min).toFixed(2) + " min"
+                      ? formatTc(contextoBase.metodo_racional.tc_min) + " min"
                       : "—"
                   }`,
                   "",
@@ -2257,7 +2266,7 @@ if (!tieneRacionalPublicado) {
             `Volumen esperado: ${Number.isFinite(volumenEsperadoM3) ? volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 }) + " m³" : "—"}`,
             `Método Q-5 principal: ${metodoQ5PrincipalConsistencia?.nombre ?? "—"}`,
             `Volumen Q-5 principal: ${Number.isFinite(volumenQ5PrincipalM3) ? volumenQ5PrincipalM3.toLocaleString("es-CO", { maximumFractionDigits: 2 }) + " m³" : "—"}`,
-            `Relación volumen Q-5 / volumen esperado: ${relacionVolumenQ5Esperado !== null ? relacionVolumenQ5Esperado.toFixed(3) + "x" : "—"}`,
+            `Relación volumen Q-5 / volumen esperado: ${relacionVolumenQ5Esperado !== null ? formatTc(relacionVolumenQ5Esperado) + "x" : "—"}`,
             `Resultado de consistencia volumétrica: ${estadoConsistenciaVolumen}`,
             `Q-Tr activo: ${estadoQTrActivoExpediente?.estado ?? "no_publicado"}`,
             "Q-5 auditado: presente como bloque no adoptivo.",
@@ -2858,25 +2867,68 @@ contextoBase?.longitud_cauce_km ??
 
           
           const payloadExpedienteMarkdown = construirPayloadExpedienteDesdeEstado({
-            contextoBase: contextoBasePayload,
-            metodos: metodosQ5Payload,
-            filasMorfologiaQt,
-            filasDictamenFormaQt,
-            filasRiesgoTemporalQt,
-            sintesisRiesgoTemporalQt: sintesisRiesgoTemporalQtPayload,
-            tcState: {
-              Tc_final,
-              metodosTc
-            },
-            fechaGeneracion: new Date().toLocaleString("es-CO"),
-            idSimulacion:
-              contextoBasePayload?.cuenca?.id ??
-              contextoBasePayload?.identificadorCuenca ??
-              "expediente_hidrologico_minimo"
-          });
+  contextoBase: contextoBasePayload,
+  metodos: metodosQ5Payload,
+  filasMorfologiaQt,
+  filasDictamenFormaQt,
+  filasRiesgoTemporalQt,
+  sintesisRiesgoTemporalQt: sintesisRiesgoTemporalQtPayload,
+  tcState: {
+    Tc_final,
+    metodosTc
+  },
+  fechaGeneracion: new Date().toLocaleString("es-CO"),
+  idSimulacion:
+    contextoBasePayload?.cuenca?.id ??
+    contextoBasePayload?.identificadorCuenca ??
+    "expediente_hidrologico_minimo"
+});
 
-          const descargaMarkdownExpediente =
-            construirDescargaMarkdownExpedienteDesdePayload(payloadExpedienteMarkdown);
+try {
+  console.log(
+    "HF-PROD-003C POST EJECUTANDOSE",
+    payloadExpedienteMarkdown
+  );
+
+  const respuestaPersistencia = await fetch(
+    "http://localhost:4000/api/proyecto/activo",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        expediente: payloadExpedienteMarkdown
+      })
+    }
+  );
+
+  console.log(
+    "HF-PROD-003C STATUS",
+    respuestaPersistencia.status
+  );
+
+  const resultadoPersistencia =
+    await respuestaPersistencia.json();
+
+  console.log(
+    "HF-PROD-003C RESPUESTA",
+    resultadoPersistencia
+  );
+
+} catch (error) {
+
+  console.error(
+    "HF-PROD-003C - Error persistiendo expediente:",
+    error
+  );
+
+}
+
+const descargaMarkdownExpediente =
+  construirDescargaMarkdownExpedienteDesdePayload(
+    payloadExpedienteMarkdown
+  );
 
           const resultadoDescargaMarkdown = descargarArchivoMarkdownEnNavegador(
             descargaMarkdownExpediente
@@ -2929,7 +2981,7 @@ contextoBase?.longitud_cauce_km ??
         return volumenEsperadoM3 ? (
           <div style={{ ...estilos.muted, marginBottom: "10px" }}>
             Referencia de escala: Volumen esperado ≈ {volumenEsperadoM3.toLocaleString("es-CO", { maximumFractionDigits: 0 })} m³
-            {" "}({peTotalMm.toFixed(2)} mm × {areaKm2.toFixed(4)} km² × 1000).
+            {" "}({formatVolumen(peTotalMm)} mm × {formatArea(areaKm2)} km² × 1000).
           </div>
         ) : null;
       })()}
@@ -3062,12 +3114,21 @@ contextoBase?.longitud_cauce_km ??
                     gap: 8
                   }}
                 >
-                  <div><strong>Pe total:</strong> {formato(peTotalMm, 4)} mm</div>
-                  <div><strong>Área:</strong> {formato(areaKm2, 4)} km²</div>
-                  <div><strong>Volumen esperado:</strong> {formato(volumenEsperadoM3, 0)} m³</div>
-                  <div><strong>Método Q-5 principal:</strong> {metodoQ5PrincipalPanel?.nombre ?? "—"}</div>
-                  <div><strong>Volumen Q-5 principal:</strong> {formato(volumenQ5PrincipalM3, 2)} m³</div>
-                  <div><strong>Relación Q-5/esperado:</strong> {relacionVolumenQ5Esperado !== null ? relacionVolumenQ5Esperado.toFixed(3) + "x" : "—"}</div>
+                  <div><strong>Pe total:</strong> {formatVolumen(peTotalMm)} mm</div>
+
+<div><strong>Área:</strong> {formatArea(areaKm2)} km²</div>
+
+<div><strong>Volumen esperado:</strong> {formatVolumen(volumenEsperadoM3)} m³</div>
+
+<div><strong>Volumen Q-5 principal:</strong> {formatVolumen(volumenQ5PrincipalM3)} m³</div>
+                  <div>
+<strong>Relación Q-5/esperado:</strong>
+{
+  relacionVolumenQ5Esperado !== null
+    ? formatTc(relacionVolumenQ5Esperado) + "x"
+    : "—"
+}
+</div>
                   <div><strong>Resultado:</strong> {estadoConsistenciaVolumen}</div>
                   <div><strong>Q-Tr activo:</strong> {estadoQTrActivo}</div>
                 </div>

--- a/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
+++ b/01_APP/HIDROFLOW/src/components/IndiceHidrologico.jsx
@@ -1,4 +1,9 @@
 import React, { useState, useEffect } from "react";
+import {
+  formatTc,
+  formatCN,
+  formatPendiente
+} from "../utils/formatters";
 import { getTcState, subscribeTc } from "../agents/tcAgent";
 import { getTrState, setTrState, subscribeTr } from "../agents/trAgent";
 
@@ -194,7 +199,7 @@ const rangoTcAgente =
 
     // Acepta peso en escala 0-1 o 0-100.
     const pct = n <= 1 ? n * 100 : n;
-    return `${Math.round(pct)} %`;
+    return `${formatCN(pct)} %`;
   };
 
   const formatTR = (p) => {
@@ -505,6 +510,27 @@ const rangoTcAgente =
       <p style={estilos.subtitulo}>
         Panel lector · {cuencaNombre} · Motor HidroFlow
       </p>
+
+      {contexto?.expediente && (
+  <section
+    style={{
+      marginBottom: 12,
+      padding: 8,
+      border: "1px solid #00d4ff",
+      borderRadius: 6
+    }}
+  >
+    <div><strong>Contrato:</strong> {contexto.expediente.versionContrato}</div>
+    <div><strong>Cuenca:</strong> {contexto.expediente.cuenca?.nombre}</div>
+    <div>
+  <strong>Tc:</strong>{" "}
+  {formatTc(
+    contexto.expediente.tiempoConcentracion?.tcSugeridoMinutos
+  )}
+</div>
+    <div><strong>CN:</strong> {contexto.expediente.lluviaYAbstraccion?.cnEfectivo}</div>
+  </section>
+)}
 
       {/* 0. Cuenca activa */}
       <section style={estiloTarjeta("params")}>

--- a/01_APP/HIDROFLOW/src/components/TablaTcMetodos.jsx
+++ b/01_APP/HIDROFLOW/src/components/TablaTcMetodos.jsx
@@ -58,7 +58,7 @@ export default function TablaTcMetodos({ tiempoConcentracion }) {
               >
                 <td>{f.metodo}</td>
                 <td style={{ textAlign: "right" }}>
-                  {f.tc.toFixed(1)}
+                  {formatTc(f.tc)}
                 </td>
                 <td>{obs}</td>
               </tr>
@@ -68,7 +68,7 @@ export default function TablaTcMetodos({ tiempoConcentracion }) {
       </table>
 
       <p style={{ fontSize: 12, opacity: 0.7 }}>
-        Tc adoptado = <b>{tc_adoptado_min.toFixed(1)} min</b>
+        Tc adoptado = <b>{formatTc(tc_adoptado_min)} min</b>
       </p>
     </div>
   );

--- a/01_APP/HIDROFLOW/src/services/documentos/construirBloqueTiempoConcentracionRolesTcExpediente.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirBloqueTiempoConcentracionRolesTcExpediente.js
@@ -1,3 +1,5 @@
+import { formatTc } from "../../utils/formatters";
+
 function formatearTcDocumental(valor) {
   if (valor === undefined || valor === null) {
     return "—";
@@ -17,7 +19,7 @@ function formatearTcDocumental(valor) {
     return "—";
   }
 
-  return `${numero.toFixed(1)} min`;
+  return `${formatTc(numero)} min`;
 }
 
 function normalizarTrDocumental(valor) {

--- a/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
+++ b/01_APP/HIDROFLOW/src/services/documentos/construirMarkdownExpedienteDesdePayload.js
@@ -1,6 +1,7 @@
 import derivarTablaResumenTrDesdeQTrMultiEscenario from "./derivarTablaResumenTrDesdeQTrMultiEscenario";
 import derivarQDisenoDesdeEscenarioActivo from "./derivarQDisenoDesdeEscenarioActivo";
 import { generarNarrativasExpediente } from "./narrativas/generarNarrativasExpediente";
+import { formatTc } from "../../utils/formatters";
 
 const texto = (valor, defecto = "NO DETECTADO") =>
   valor === undefined || valor === null || valor === "" ? defecto : String(valor);
@@ -297,7 +298,7 @@ narrativas.q5,
 "",
 `Volumen esperado Pe × Área: ${numero(payload?.controlConsistencia?.volumenEsperadoTeoricoM3, 2)} m³`,
 `Volumen integrado Q-5: ${numero(payload?.controlConsistencia?.volumenIntegradoQ5M3, 2)} m³`,
-`Ratio Vol Q-5 / Vol esperado: ${Number.isFinite(Number(ratio)) ? Number(ratio).toFixed(6) : "NO DETECTADO"}`,
+`Ratio Vol Q-5 / Vol esperado: ${Number.isFinite(Number(ratio)) ? formatTc(ratio) : "NO DETECTADO"}`,
 `Estado: ${texto(payload?.controlConsistencia?.estadoConsistencia)}`,
 
 "",

--- a/01_APP/HIDROFLOW/src/utils/formatters.js
+++ b/01_APP/HIDROFLOW/src/utils/formatters.js
@@ -1,0 +1,11 @@
+const format = (val, dec) =>
+  Number.isFinite(Number(val))
+    ? Number(val).toFixed(dec)
+    : "—";
+
+export const formatTc = (val) => format(val, 4);
+export const formatQ = (val) => format(val, 3);
+export const formatArea = (val) => format(val, 2);
+export const formatCN = (val) => format(val, 0);
+export const formatPendiente = (val) => format(val, 4);
+export const formatVolumen = (val) => format(val, 2);


### PR DESCRIPTION
Objetivo

Completar la normalización institucional de representación visual y documental mediante la centralización de formatos bajo src/utils/formatters.js.

Alcance

- Creación de formatters.js
- Normalización de IndiceHidrologico.jsx
- Normalización de TablaTcMetodos.jsx
- Normalización de ComparadorMultiMetodo.jsx
- Normalización documental de:
  - construirBloqueTiempoConcentracionRolesTcExpediente.js
  - construirMarkdownExpedienteDesdePayload.js

Resultado

- Eliminados formateadores manuales en componentes visuales certificados.
- Eliminados formateadores manuales en servicios documentales.
- Conservada la integridad de los motores hidrológicos.
- Separación explícita entre cálculo, representación documental y visualización.

Clasificación MCVD certificada

Representación:
- src/components/*
- src/layouts/*
- src/services/documentos/*

Motores protegidos:
- src/services/hidroEngine.js
- src/services/hidrogramas/*
- src/services/cn/*
- src/services/qtr/*

Principio institucional consolidado

Expediente Inteligente-Orquestador
    ↓
Memoria Técnica
    ↓
Inventarios
    ↓
MCVD
    ↓
Contratos
    ↓
Código

Los motores calculan.
Los documentos representan.
La UI visualiza.